### PR TITLE
[Refactor] httpMethod에 따라 접근 패턴 분리

### DIFF
--- a/src/main/java/matchuri/backend/global/config/MatchuriProperties.java
+++ b/src/main/java/matchuri/backend/global/config/MatchuriProperties.java
@@ -19,11 +19,18 @@ public class MatchuriProperties {
     @Setter
     public static class Auth {
         private List<String> publicApiPatterns = List.of(
-                "/api/v1/members/exists/**",
-                "/api/v1/members",
-                "/api/v1/auth/**",
-                "/docs/**",
                 "/error"
+        );
+        private List<String> publicGetApiPatterns = List.of(
+                "/api/v1/members/exists/**",
+                "/docs/**"
+        );
+        private List<String> publicPostApiPatterns = List.of(
+                "/api/v1/members",
+                "/api/v1/auth/login"
+        );
+        private List<String> publicOptionsApiPatterns = List.of(
+                "/**"
         );
         private Jwt jwt = new Jwt();
     }

--- a/src/main/java/matchuri/backend/global/config/SecurityConfig.java
+++ b/src/main/java/matchuri/backend/global/config/SecurityConfig.java
@@ -1,12 +1,13 @@
 package matchuri.backend.global.config;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import matchuri.backend.global.config.MatchuriProperties.Auth;
 import matchuri.backend.global.security.JwtAuthenticationFilter;
 import matchuri.backend.global.security.MatchuriAccessDeniedHandler;
 import matchuri.backend.global.security.MatchuriAuthenticationEntryPoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -27,7 +28,7 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        List<String> publicApiPatterns = matchuriProperties.getAuth().getPublicApiPatterns();
+        Auth authProps = matchuriProperties.getAuth();
 
         http
                 .csrf(AbstractHttpConfigurer::disable)
@@ -40,8 +41,12 @@ public class SecurityConfig {
                         .authenticationEntryPoint(authenticationEntryPoint)
                         .accessDeniedHandler(accessDeniedHandler))
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers(publicApiPatterns.toArray(String[]::new)).permitAll()
-                        .anyRequest().authenticated())
+                        .requestMatchers(authProps.getPublicApiPatterns().toArray(String[]::new)).permitAll()
+                        .requestMatchers(HttpMethod.GET, authProps.getPublicGetApiPatterns().toArray(String[]::new)).permitAll()
+                        .requestMatchers(HttpMethod.POST, authProps.getPublicPostApiPatterns().toArray(String[]::new)).permitAll()
+                        .requestMatchers(HttpMethod.OPTIONS, authProps.getPublicOptionsApiPatterns().toArray(String[]::new)).permitAll()
+                        .anyRequest().authenticated()
+                )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,11 +22,15 @@ spring:
 matchuri:
   auth:
     public-api-patterns:
-      - /api/v1/members/exists/**
-      - /api/v1/members
-      - /api/v1/auth/**
-      - /docs/**
       - /error
+    public-get-api-patterns:
+      - /api/v1/members/exists/**
+      - /docs/**
+    public-post-api-patterns:
+      - /api/v1/members
+      - /api/v1/auth/login
+    public-options-api-patterns:
+      - /**
     jwt:
       secret: ${MATCHURI_JWT_SECRET:matchuri-local-jwt-secret-key-matchuri-local-jwt-secret-key}
       issuer: ${MATCHURI_JWT_ISSUER:matchuri-backend}

--- a/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
@@ -178,6 +178,14 @@ class MemberAuthIntegrationTest {
                 .andExpect(jsonPath("$.error.code").value("AUTH_TOKEN_MISSING"));
     }
 
+    @Test
+    @DisplayName("로그아웃 API는 토큰 없이 접근하면 AUTH_TOKEN_MISSING을 반환한다")
+    void logoutRequiresAuthentication() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/logout"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("AUTH_TOKEN_MISSING"));
+    }
+
     private void createMemberThroughApi(String loginId, String password) throws Exception {
         mockMvc.perform(post("/api/v1/members")
                         .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## 관련 이슈
Closes #19 

## 📝 작업 내용
- 기존 방식은 HttpMethod에 상관 없이 특정 URI에 대한 접근을 허용함
- Method 별로 변수값을 세분화하여 주입

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
