### PR TITLE
[Refactor] servlet을 의존하지 않는 구조로 변경

### DIFF
--- a/src/main/java/matchuri/backend/api/auth/AuthController.java
+++ b/src/main/java/matchuri/backend/api/auth/AuthController.java
@@ -10,6 +10,8 @@ import matchuri.backend.api.auth.dto.LoginResponse;
 import matchuri.backend.api.auth.dto.LogoutResponse;
 import matchuri.backend.api.auth.dto.OAuth2ExchangeRequest;
 import matchuri.backend.domain.auth.service.AuthService;
+import matchuri.backend.domain.auth.service.LoginResult;
+import matchuri.backend.domain.auth.service.RefreshTokenCookieService;
 import matchuri.backend.global.api.ApiResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController implements AuthApi {
 
     private final AuthService authService;
+    private final RefreshTokenCookieService refreshTokenCookieService;
 
     @Override
     @PostMapping("/login")
@@ -31,13 +34,19 @@ public class AuthController implements AuthApi {
             HttpServletRequest httpRequest,
             HttpServletResponse httpResponse
     ) {
-        return ApiResponse.success(authService.login(request, httpRequest, httpResponse));
+        LoginResult loginResult = authService.login(request, resolveClientIp(httpRequest));
+        refreshTokenCookieService.addRefreshToken(httpResponse, loginResult.refreshToken());
+        return ApiResponse.success(loginResult.response());
     }
 
     @Override
     @PostMapping("/logout")
     public ApiResponse<LogoutResponse> logout(HttpServletRequest httpRequest, HttpServletResponse httpResponse) {
-        return ApiResponse.success(authService.logout(httpRequest, httpResponse));
+        String refreshToken = refreshTokenCookieService.resolveRefreshToken(httpRequest)
+                .orElseThrow(() -> new matchuri.backend.global.exception.AuthenticationException(matchuri.backend.domain.auth.AuthErrorCode.LOGOUT_FAILED));
+        LogoutResponse response = authService.logout(refreshToken, resolveClientIp(httpRequest));
+        refreshTokenCookieService.clearRefreshToken(httpResponse);
+        return ApiResponse.success(response);
     }
 
     @Override
@@ -53,6 +62,10 @@ public class AuthController implements AuthApi {
             HttpServletRequest httpRequest,
             HttpServletResponse httpResponse
     ) {
-        return ApiResponse.success(authService.exchangeOAuth2Code(request, httpRequest, httpResponse));
+        return ApiResponse.success(authService.exchangeOAuth2Code(request, resolveClientIp(httpRequest)));
+    }
+
+    private String resolveClientIp(HttpServletRequest httpRequest) {
+        return httpRequest.getRemoteAddr();
     }
 }

--- a/src/main/java/matchuri/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/AuthService.java
@@ -1,7 +1,5 @@
 package matchuri.backend.domain.auth.service;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import matchuri.backend.api.auth.dto.LoginRequest;
 import matchuri.backend.api.auth.dto.LoginResponse;
 import matchuri.backend.api.auth.dto.LogoutResponse;
@@ -9,13 +7,9 @@ import matchuri.backend.api.auth.dto.OAuth2ExchangeRequest;
 
 public interface AuthService {
 
-    LoginResponse login(LoginRequest request, HttpServletRequest httpRequest, HttpServletResponse httpResponse);
+    LoginResult login(LoginRequest request, String clientIp);
 
-    LogoutResponse logout(HttpServletRequest httpRequest, HttpServletResponse httpResponse);
+    LogoutResponse logout(String refreshToken, String clientIp);
 
-    LoginResponse exchangeOAuth2Code(
-            OAuth2ExchangeRequest request,
-            HttpServletRequest httpRequest,
-            HttpServletResponse httpResponse
-    );
+    LoginResponse exchangeOAuth2Code(OAuth2ExchangeRequest request, String clientIp);
 }

--- a/src/main/java/matchuri/backend/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/AuthServiceImpl.java
@@ -1,7 +1,5 @@
 package matchuri.backend.domain.auth.service;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import matchuri.backend.api.auth.dto.LoginRequest;
@@ -34,12 +32,11 @@ public class AuthServiceImpl implements AuthService {
     private final MemberMapper memberMapper;
     private final SessionTokenService sessionTokenService;
     private final JwtTokenProvider jwtTokenProvider;
-    private final RefreshTokenCookieService refreshTokenCookieService;
     private final AuthenticationFacade authenticationFacade;
 
     @Override
     @Transactional
-    public LoginResponse login(LoginRequest request, HttpServletRequest httpRequest, HttpServletResponse httpResponse) {
+    public LoginResult login(LoginRequest request, String clientIp) {
         Member member = memberRepository.findByLoginId(request.loginId())
                 .orElseThrow(() -> new AuthenticationException(AuthErrorCode.LOGIN_FAILED));
 
@@ -50,33 +47,27 @@ public class AuthServiceImpl implements AuthService {
         }
 
         TokenPair tokenPair = sessionTokenService.issueLoginTokenPair(member);
-        refreshTokenCookieService.addRefreshToken(httpResponse, tokenPair.refreshToken());
-        log.info("auth event=login_success provider=local memberId={} ip={}", member.getId(), httpRequest.getRemoteAddr());
+        log.info("auth event=login_success provider=local memberId={} ip={}", member.getId(), clientIp);
 
-        return memberMapper.toLoginResponse(member, tokenPair.accessToken(), tokenPair.accessTokenExpiresIn(), null);
+        return new LoginResult(
+                memberMapper.toLoginResponse(member, tokenPair.accessToken(), tokenPair.accessTokenExpiresIn(), null),
+                tokenPair.refreshToken()
+        );
     }
 
     @Override
     @Transactional
-    public LogoutResponse logout(HttpServletRequest httpRequest, HttpServletResponse httpResponse) {
+    public LogoutResponse logout(String refreshToken, String clientIp) {
         AuthenticatedMember authenticatedMember = authenticationFacade.getCurrentMember();
-        String refreshToken = refreshTokenCookieService.resolveRefreshToken(httpRequest)
-                .orElseThrow(() -> new AuthenticationException(AuthErrorCode.LOGOUT_FAILED));
-
         sessionTokenService.revokeRefreshToken(refreshToken);
-        refreshTokenCookieService.clearRefreshToken(httpResponse);
-        log.info("auth event=logout provider=local memberId={} ip={}", authenticatedMember.memberId(), httpRequest.getRemoteAddr());
+        log.info("auth event=logout provider=local memberId={} ip={}", authenticatedMember.memberId(), clientIp);
 
         return new LogoutResponse(true);
     }
 
     @Override
     @Transactional
-    public LoginResponse exchangeOAuth2Code(
-            OAuth2ExchangeRequest request,
-            HttpServletRequest httpRequest,
-            HttpServletResponse httpResponse
-    ) {
+    public LoginResponse exchangeOAuth2Code(OAuth2ExchangeRequest request, String clientIp) {
         if (request.provider() != SocialProviderType.GOOGLE) {
             throw new AuthenticationException(AuthErrorCode.OAUTH2_PROVIDER_NOT_SUPPORTED);
         }
@@ -89,7 +80,7 @@ public class AuthServiceImpl implements AuthService {
                 "auth event=oauth2_exchange_success provider={} memberId={} ip={}",
                 request.provider().name().toLowerCase(),
                 member.getId(),
-                httpRequest.getRemoteAddr()
+                clientIp
         );
 
         return memberMapper.toLoginResponse(member, issuedAccessToken.accessToken(), issuedAccessToken.expiresIn(), null);

--- a/src/main/java/matchuri/backend/domain/auth/service/LoginResult.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/LoginResult.java
@@ -1,0 +1,9 @@
+package matchuri.backend.domain.auth.service;
+
+import matchuri.backend.api.auth.dto.LoginResponse;
+
+public record LoginResult(
+        LoginResponse response,
+        String refreshToken
+) {
+}


### PR DESCRIPTION
## 관련 이슈
Closes #37 

## 📝 작업 내용
- 기존 auth 기능에 `HttpServlet`을 의존하는 대신 내부 결과 모델인 `LoginResult.java`를 발급하도록 리팩토링함

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
