### PR TITLE
[Refactor] 쿠키 정책을 명시하여 관리

### DIFF
--- a/src/main/java/matchuri/backend/domain/auth/service/RefreshTokenCookieService.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/RefreshTokenCookieService.java
@@ -23,6 +23,8 @@ public class RefreshTokenCookieService {
                 .httpOnly(true)
                 .secure(cookie.isSecure())
                 .path(cookie.getPath())
+                .sameSite(cookie.getSameSite())
+                .domain(cookie.getDomain())
                 .maxAge(cookie.getMaxAgeSeconds())
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
@@ -34,6 +36,8 @@ public class RefreshTokenCookieService {
                 .httpOnly(true)
                 .secure(cookie.isSecure())
                 .path(cookie.getPath())
+                .sameSite(cookie.getSameSite())
+                .domain(cookie.getDomain())
                 .maxAge(0)
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());

--- a/src/main/java/matchuri/backend/global/config/MatchuriProperties.java
+++ b/src/main/java/matchuri/backend/global/config/MatchuriProperties.java
@@ -101,13 +101,24 @@ public class MatchuriProperties {
         @NotBlank
         private String refreshTokenCookieName;
 
+        @NotBlank
+        private String oauth2AuthorizationRequestCookieName;
+
         private boolean secure;
 
         @NotBlank
         private String path;
 
+        private String domain;
+
+        @NotBlank
+        private String sameSite;
+
         @Positive
         private int maxAgeSeconds;
+
+        @Positive
+        private int oauth2AuthorizationRequestCookieMaxAgeSeconds;
     }
 
     @Getter

--- a/src/main/java/matchuri/backend/global/security/CookieUtils.java
+++ b/src/main/java/matchuri/backend/global/security/CookieUtils.java
@@ -6,6 +6,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Optional;
+import matchuri.backend.global.config.MatchuriProperties;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.util.SerializationUtils;
 
 public final class CookieUtils {
@@ -24,28 +27,38 @@ public final class CookieUtils {
                 .findFirst();
     }
 
-    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
-        Cookie cookie = new Cookie(name, value);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-        cookie.setMaxAge(maxAge);
-        response.addCookie(cookie);
+    public static void addCookie(
+            HttpServletResponse response,
+            String name,
+            String value,
+            int maxAge,
+            MatchuriProperties.Cookie cookieConfig
+    ) {
+        ResponseCookie responseCookie = ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .secure(cookieConfig.isSecure())
+                .path(cookieConfig.getPath())
+                .domain(cookieConfig.getDomain())
+                .sameSite(cookieConfig.getSameSite())
+                .maxAge(maxAge)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
     }
 
-    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies == null) {
-            return;
-        }
-
-        Arrays.stream(cookies)
-                .filter(cookie -> name.equals(cookie.getName()))
-                .forEach(cookie -> {
-                    cookie.setValue("");
-                    cookie.setPath("/");
-                    cookie.setMaxAge(0);
-                    response.addCookie(cookie);
-                });
+    public static void deleteCookie(
+            HttpServletResponse response,
+            String name,
+            MatchuriProperties.Cookie cookieConfig
+    ) {
+        ResponseCookie responseCookie = ResponseCookie.from(name, "")
+                .httpOnly(true)
+                .secure(cookieConfig.isSecure())
+                .path(cookieConfig.getPath())
+                .domain(cookieConfig.getDomain())
+                .sameSite(cookieConfig.getSameSite())
+                .maxAge(0)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
     }
 
     public static String serialize(Object value) {

--- a/src/main/java/matchuri/backend/global/security/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/matchuri/backend/global/security/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -2,20 +2,22 @@ package matchuri.backend.global.security;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import matchuri.backend.global.config.MatchuriProperties;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class HttpCookieOAuth2AuthorizationRequestRepository
         implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
 
-    private static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "matchuri_oauth2_auth_request";
-    private static final int COOKIE_EXPIRE_SECONDS = 180;
+    private final MatchuriProperties matchuriProperties;
 
     @Override
     public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
-        return CookieUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+        return CookieUtils.getCookie(request, cookieName())
                 .map(cookie -> CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class))
                 .orElse(null);
     }
@@ -33,9 +35,10 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
 
         CookieUtils.addCookie(
                 response,
-                OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+                cookieName(),
                 CookieUtils.serialize(authorizationRequest),
-                COOKIE_EXPIRE_SECONDS
+                matchuriProperties.getAuth().getCookie().getOauth2AuthorizationRequestCookieMaxAgeSeconds(),
+                matchuriProperties.getAuth().getCookie()
         );
     }
 
@@ -54,6 +57,10 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
     }
 
     public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
-        CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        CookieUtils.deleteCookie(response, cookieName(), matchuriProperties.getAuth().getCookie());
+    }
+
+    private String cookieName() {
+        return matchuriProperties.getAuth().getCookie().getOauth2AuthorizationRequestCookieName();
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -69,9 +69,13 @@ matchuri:
       exchange-code-expiration-seconds: 300
     cookie:
       refresh-token-cookie-name: matchuri_refresh_token
+      oauth2-authorization-request-cookie-name: matchuri_oauth2_auth_request
       secure: ${MATCHURI_COOKIE_SECURE:false}
       path: /
+      domain: ${MATCHURI_COOKIE_DOMAIN:}
+      same-site: ${MATCHURI_COOKIE_SAME_SITE:Lax}
       max-age-seconds: 1209600
+      oauth2-authorization-request-cookie-max-age-seconds: 180
     jwt:
       secret: ${MATCHURI_JWT_SECRET:matchuri-local-jwt-secret-key-matchuri-local-jwt-secret-key}
       issuer: ${MATCHURI_JWT_ISSUER:matchuri-backend}

--- a/src/test/java/matchuri/backend/domain/auth/service/RefreshTokenCookieServiceTest.java
+++ b/src/test/java/matchuri/backend/domain/auth/service/RefreshTokenCookieServiceTest.java
@@ -1,0 +1,42 @@
+package matchuri.backend.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import matchuri.backend.global.config.MatchuriProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class RefreshTokenCookieServiceTest {
+
+    @Test
+    @DisplayName("리프레시 토큰 쿠키는 설정된 보안 속성을 포함한다")
+    void addRefreshTokenUsesConfiguredCookiePolicy() {
+        MatchuriProperties properties = new MatchuriProperties();
+        MatchuriProperties.Auth auth = new MatchuriProperties.Auth();
+        MatchuriProperties.Cookie cookie = new MatchuriProperties.Cookie();
+        cookie.setRefreshTokenCookieName("matchuri_refresh_token");
+        cookie.setOauth2AuthorizationRequestCookieName("matchuri_oauth2_auth_request");
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setDomain("localhost");
+        cookie.setSameSite("None");
+        cookie.setMaxAgeSeconds(1209600);
+        cookie.setOauth2AuthorizationRequestCookieMaxAgeSeconds(180);
+        auth.setCookie(cookie);
+        properties.setAuth(auth);
+
+        RefreshTokenCookieService service = new RefreshTokenCookieService(properties);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        service.addRefreshToken(response, "refresh-token");
+
+        String setCookie = response.getHeader("Set-Cookie");
+        assertThat(setCookie).contains("matchuri_refresh_token=refresh-token");
+        assertThat(setCookie).contains("HttpOnly");
+        assertThat(setCookie).contains("Secure");
+        assertThat(setCookie).contains("SameSite=None");
+        assertThat(setCookie).contains("Domain=localhost");
+        assertThat(setCookie).contains("Path=/");
+    }
+}

--- a/src/test/java/matchuri/backend/global/security/HttpCookieOAuth2AuthorizationRequestRepositoryTest.java
+++ b/src/test/java/matchuri/backend/global/security/HttpCookieOAuth2AuthorizationRequestRepositoryTest.java
@@ -1,0 +1,53 @@
+package matchuri.backend.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import matchuri.backend.global.config.MatchuriProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
+
+    @Test
+    @DisplayName("OAuth2 authorization request 쿠키는 설정된 정책으로 저장된다")
+    void saveAuthorizationRequestUsesConfiguredCookiePolicy() {
+        MatchuriProperties properties = new MatchuriProperties();
+        MatchuriProperties.Auth auth = new MatchuriProperties.Auth();
+        MatchuriProperties.Cookie cookie = new MatchuriProperties.Cookie();
+        cookie.setRefreshTokenCookieName("matchuri_refresh_token");
+        cookie.setOauth2AuthorizationRequestCookieName("matchuri_oauth2_auth_request");
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setDomain("localhost");
+        cookie.setSameSite("None");
+        cookie.setMaxAgeSeconds(1209600);
+        cookie.setOauth2AuthorizationRequestCookieMaxAgeSeconds(180);
+        auth.setCookie(cookie);
+        properties.setAuth(auth);
+
+        HttpCookieOAuth2AuthorizationRequestRepository repository =
+                new HttpCookieOAuth2AuthorizationRequestRepository(properties);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        OAuth2AuthorizationRequest authorizationRequest = OAuth2AuthorizationRequest.authorizationCode()
+                .authorizationUri("https://accounts.google.com/o/oauth2/v2/auth")
+                .clientId("client-id")
+                .redirectUri("http://localhost:8080/login/oauth2/code/google")
+                .state("state-value")
+                .authorizationRequestUri("https://accounts.google.com/o/oauth2/v2/auth?state=state-value")
+                .build();
+
+        repository.saveAuthorizationRequest(authorizationRequest, new MockHttpServletRequest(), response);
+
+        String setCookie = response.getHeader("Set-Cookie");
+        assertThat(setCookie).contains("matchuri_oauth2_auth_request=");
+        assertThat(setCookie).contains("HttpOnly");
+        assertThat(setCookie).contains("Secure");
+        assertThat(setCookie).contains("SameSite=None");
+        assertThat(setCookie).contains("Domain=localhost");
+        assertThat(setCookie).contains("Max-Age=180");
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -70,9 +70,13 @@ matchuri:
       exchange-code-expiration-seconds: 300
     cookie:
       refresh-token-cookie-name: matchuri_refresh_token
+      oauth2-authorization-request-cookie-name: matchuri_oauth2_auth_request
       secure: false
       path: /
+      domain:
+      same-site: Lax
       max-age-seconds: 1209600
+      oauth2-authorization-request-cookie-max-age-seconds: 180
     jwt:
       secret: test-jwt-secret-key-test-jwt-secret-key-test-jwt-secret-key
       issuer: matchuri-test


### PR DESCRIPTION
## 관련 이슈
Closes #39 

## 📝 작업 내용
- 환경변수를 통해 쿠키 정책을 명시화
- 쿠키의 `same-site`를 `Lax`로 설정

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
