### PR TITLE
[Refactor] oauth2 handlers 책임 분리

### DIFF
--- a/src/main/java/matchuri/backend/domain/auth/service/GoogleOAuth2LoginResult.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/GoogleOAuth2LoginResult.java
@@ -1,0 +1,8 @@
+package matchuri.backend.domain.auth.service;
+
+public record GoogleOAuth2LoginResult(
+        Long memberId,
+        String refreshToken,
+        String exchangeCode
+) {
+}

--- a/src/main/java/matchuri/backend/domain/auth/service/GoogleOAuth2LoginService.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/GoogleOAuth2LoginService.java
@@ -1,0 +1,31 @@
+package matchuri.backend.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GoogleOAuth2LoginService {
+
+    private final GoogleOAuth2Service googleOAuth2Service;
+    private final SessionTokenService sessionTokenService;
+
+    @Transactional
+    public GoogleOAuth2LoginResult login(String providerUserId, String email, String nickname, String clientIp) {
+        var member = googleOAuth2Service.findOrCreateMember(providerUserId, email, nickname);
+        TokenPair tokenPair = sessionTokenService.issueLoginTokenPair(member);
+        String exchangeCode = sessionTokenService.createExchangeCode(member, member.getSocialProviderType());
+
+        log.info("auth event=oauth2_login_success provider=google memberId={} ip={}", member.getId(), clientIp);
+
+        return new GoogleOAuth2LoginResult(
+                member.getId(),
+                tokenPair.refreshToken(),
+                exchangeCode
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/global/security/GoogleOAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/matchuri/backend/global/security/GoogleOAuth2AuthenticationFailureHandler.java
@@ -8,12 +8,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import matchuri.backend.domain.auth.AuthErrorCode;
 import matchuri.backend.domain.auth.service.RefreshTokenCookieService;
-import matchuri.backend.global.config.MatchuriProperties;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 @Component
@@ -22,7 +20,7 @@ public class GoogleOAuth2AuthenticationFailureHandler implements AuthenticationF
 
     private final HttpCookieOAuth2AuthorizationRequestRepository authorizationRequestRepository;
     private final RefreshTokenCookieService refreshTokenCookieService;
-    private final MatchuriProperties matchuriProperties;
+    private final GoogleOAuth2RedirectService redirectService;
 
     @Override
     public void onAuthenticationFailure(
@@ -36,15 +34,7 @@ public class GoogleOAuth2AuthenticationFailureHandler implements AuthenticationF
         AuthErrorCode errorCode = resolveErrorCode(exception);
         log.warn("auth event=oauth2_provider_failed provider=google ip={} code={}", request.getRemoteAddr(), errorCode.getCode());
 
-        response.sendRedirect(
-                UriComponentsBuilder.fromUriString(matchuriProperties.getAuth().getOauth2().getFrontendBaseUrl())
-                        .path(matchuriProperties.getAuth().getOauth2().getFailurePath())
-                        .queryParam("loginResult", "failed")
-                        .queryParam("provider", "google")
-                        .queryParam("errorCode", errorCode.getCode())
-                        .build()
-                        .toUriString()
-        );
+        response.sendRedirect(redirectService.buildFailureRedirectUrl(errorCode));
     }
 
     private AuthErrorCode resolveErrorCode(AuthenticationException exception) {

--- a/src/main/java/matchuri/backend/global/security/GoogleOAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/matchuri/backend/global/security/GoogleOAuth2AuthenticationSuccessHandler.java
@@ -7,29 +7,23 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import matchuri.backend.domain.auth.AuthErrorCode;
-import matchuri.backend.domain.auth.service.GoogleOAuth2Service;
+import matchuri.backend.domain.auth.service.GoogleOAuth2LoginResult;
+import matchuri.backend.domain.auth.service.GoogleOAuth2LoginService;
 import matchuri.backend.domain.auth.service.RefreshTokenCookieService;
-import matchuri.backend.domain.auth.service.SessionTokenService;
-import matchuri.backend.domain.auth.service.TokenPair;
-import matchuri.backend.domain.member.entity.Member;
-import matchuri.backend.domain.member.entity.SocialProviderType;
-import matchuri.backend.global.config.MatchuriProperties;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class GoogleOAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
 
-    private final GoogleOAuth2Service googleOAuth2Service;
-    private final SessionTokenService sessionTokenService;
+    private final GoogleOAuth2LoginService googleOAuth2LoginService;
     private final RefreshTokenCookieService refreshTokenCookieService;
     private final HttpCookieOAuth2AuthorizationRequestRepository authorizationRequestRepository;
-    private final MatchuriProperties matchuriProperties;
+    private final GoogleOAuth2RedirectService redirectService;
 
     @Override
     public void onAuthenticationSuccess(
@@ -39,45 +33,22 @@ public class GoogleOAuth2AuthenticationSuccessHandler implements AuthenticationS
     ) throws IOException, ServletException {
         try {
             OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
-            String providerUserId = oauth2User.getAttribute("sub");
-            String email = oauth2User.getAttribute("email");
-            String nickname = oauth2User.getAttribute("name");
-
-            Member member = googleOAuth2Service.findOrCreateMember(providerUserId, email, nickname);
-            TokenPair tokenPair = sessionTokenService.issueLoginTokenPair(member);
-            refreshTokenCookieService.addRefreshToken(response, tokenPair.refreshToken());
-            String exchangeCode = sessionTokenService.createExchangeCode(member, SocialProviderType.GOOGLE);
+            GoogleOAuth2LoginResult loginResult = googleOAuth2LoginService.login(
+                    oauth2User.getAttribute("sub"),
+                    oauth2User.getAttribute("email"),
+                    oauth2User.getAttribute("name"),
+                    request.getRemoteAddr()
+            );
 
             authorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
-            log.info("auth event=oauth2_login_success provider=google memberId={} ip={}", member.getId(), request.getRemoteAddr());
+            refreshTokenCookieService.addRefreshToken(response, loginResult.refreshToken());
 
-            response.sendRedirect(buildSuccessRedirectUrl(exchangeCode));
+            response.sendRedirect(redirectService.buildSuccessRedirectUrl(loginResult.exchangeCode()));
         } catch (Exception exception) {
             log.warn("auth event=oauth2_login_failed provider=google ip={} reason={}", request.getRemoteAddr(), exception.getMessage());
             authorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
             refreshTokenCookieService.clearRefreshToken(response);
-            response.sendRedirect(buildFailureRedirectUrl(AuthErrorCode.OAUTH2_PROCESSING_FAILED));
+            response.sendRedirect(redirectService.buildFailureRedirectUrl(AuthErrorCode.OAUTH2_PROCESSING_FAILED));
         }
-    }
-
-    private String buildSuccessRedirectUrl(String exchangeCode) {
-        MatchuriProperties.OAuth2 oauth2 = matchuriProperties.getAuth().getOauth2();
-        return UriComponentsBuilder.fromUriString(oauth2.getFrontendBaseUrl())
-                .path(oauth2.getSuccessPath())
-                .queryParam("loginResult", "success")
-                .queryParam("code", exchangeCode)
-                .build()
-                .toUriString();
-    }
-
-    private String buildFailureRedirectUrl(AuthErrorCode errorCode) {
-        MatchuriProperties.OAuth2 oauth2 = matchuriProperties.getAuth().getOauth2();
-        return UriComponentsBuilder.fromUriString(oauth2.getFrontendBaseUrl())
-                .path(oauth2.getFailurePath())
-                .queryParam("loginResult", "failed")
-                .queryParam("provider", "google")
-                .queryParam("errorCode", errorCode.getCode())
-                .build()
-                .toUriString();
     }
 }

--- a/src/main/java/matchuri/backend/global/security/GoogleOAuth2RedirectService.java
+++ b/src/main/java/matchuri/backend/global/security/GoogleOAuth2RedirectService.java
@@ -1,0 +1,35 @@
+package matchuri.backend.global.security;
+
+import lombok.RequiredArgsConstructor;
+import matchuri.backend.domain.auth.AuthErrorCode;
+import matchuri.backend.global.config.MatchuriProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+@RequiredArgsConstructor
+public class GoogleOAuth2RedirectService {
+
+    private final MatchuriProperties matchuriProperties;
+
+    public String buildSuccessRedirectUrl(String exchangeCode) {
+        MatchuriProperties.OAuth2 oauth2 = matchuriProperties.getAuth().getOauth2();
+        return UriComponentsBuilder.fromUriString(oauth2.getFrontendBaseUrl())
+                .path(oauth2.getSuccessPath())
+                .queryParam("loginResult", "success")
+                .queryParam("code", exchangeCode)
+                .build()
+                .toUriString();
+    }
+
+    public String buildFailureRedirectUrl(AuthErrorCode errorCode) {
+        MatchuriProperties.OAuth2 oauth2 = matchuriProperties.getAuth().getOauth2();
+        return UriComponentsBuilder.fromUriString(oauth2.getFrontendBaseUrl())
+                .path(oauth2.getFailurePath())
+                .queryParam("loginResult", "failed")
+                .queryParam("provider", "google")
+                .queryParam("errorCode", errorCode.getCode())
+                .build()
+                .toUriString();
+    }
+}

--- a/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
@@ -116,7 +116,7 @@ class MemberAuthIntegrationTest {
     }
 
     @Test
-    @DisplayName("로그인 후 내 정보 조회, 수정, 로그아웃, 탈퇴 흐름이 동작한다")
+    @DisplayName("로그아웃은 refresh token만 폐기하고 access token은 만료 전까지 유지된다")
     void memberAuthLifecycle() throws Exception {
         createMemberThroughApi("tester01", "P@ssw0rd!");
         AuthSession authSession = login("tester01", "P@ssw0rd!");
@@ -178,6 +178,12 @@ class MemberAuthIntegrationTest {
 
         assertThat(authRefreshTokenRepository.findByMemberId(memberRepository.findByLoginId("tester01").orElseThrow().getId()))
                 .isEmpty();
+
+        mockMvc.perform(get("/api/v1/members/me")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").isNumber())
+                .andExpect(jsonPath("$.data.nickname").value("점심탐험가"));
 
         mockMvc.perform(delete("/api/v1/members/me")
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken)))

--- a/src/test/java/matchuri/backend/global/security/GoogleOAuth2RedirectServiceTest.java
+++ b/src/test/java/matchuri/backend/global/security/GoogleOAuth2RedirectServiceTest.java
@@ -1,0 +1,46 @@
+package matchuri.backend.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import matchuri.backend.domain.auth.AuthErrorCode;
+import matchuri.backend.global.config.MatchuriProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GoogleOAuth2RedirectServiceTest {
+
+    @Test
+    @DisplayName("OAuth2 성공 리다이렉트 URL을 일관되게 생성한다")
+    void buildsSuccessRedirectUrl() {
+        GoogleOAuth2RedirectService service = new GoogleOAuth2RedirectService(createProperties());
+
+        String redirectUrl = service.buildSuccessRedirectUrl("exchange-code");
+
+        assertThat(redirectUrl).isEqualTo("http://localhost:3000/auth/callback/google?loginResult=success&code=exchange-code");
+    }
+
+    @Test
+    @DisplayName("OAuth2 실패 리다이렉트 URL을 일관되게 생성한다")
+    void buildsFailureRedirectUrl() {
+        GoogleOAuth2RedirectService service = new GoogleOAuth2RedirectService(createProperties());
+
+        String redirectUrl = service.buildFailureRedirectUrl(AuthErrorCode.OAUTH2_PROVIDER_REJECTED);
+
+        assertThat(redirectUrl).isEqualTo(
+                "http://localhost:3000/login?loginResult=failed&provider=google&errorCode=AUTH_OAUTH2_PROVIDER_REJECTED"
+        );
+    }
+
+    private MatchuriProperties createProperties() {
+        MatchuriProperties properties = new MatchuriProperties();
+        MatchuriProperties.Auth auth = new MatchuriProperties.Auth();
+        MatchuriProperties.OAuth2 oauth2 = new MatchuriProperties.OAuth2();
+        oauth2.setFrontendBaseUrl("http://localhost:3000");
+        oauth2.setSuccessPath("/auth/callback/google");
+        oauth2.setFailurePath("/login");
+        oauth2.setExchangeCodeExpirationSeconds(300);
+        auth.setOauth2(oauth2);
+        properties.setAuth(auth);
+        return properties;
+    }
+}


### PR DESCRIPTION
## 관련 이슈
Closes #41 

## 📝 작업 내용
- 토큰 및 회원 식별에 대한 기능을 분리
- 핸들러는 redirect 주소를 제어하는 역할에만 집중

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
