### PR TITLE
[Fix] 회원 생성 쿼리를 트랜잭션 이전에 발생시켜 경쟁 조건 발생 가능성 해소

### DIFF
--- a/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
@@ -18,6 +18,7 @@ import matchuri.backend.domain.member.repository.MemberTasteProfileRepository;
 import matchuri.backend.global.exception.BusinessException;
 import matchuri.backend.global.security.AuthenticatedMember;
 import matchuri.backend.global.security.AuthenticationFacade;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,8 +50,7 @@ public class MemberServiceImpl implements MemberService {
         }
 
         String passwordHash = passwordEncoder.encode(request.password());
-        Member member = Member.createWithEncodedPassword(request.loginId(), passwordHash);
-        memberRepository.save(member);
+        Member member = createLocalMember(request.loginId(), passwordHash);
 
         return memberMapper.toCreateMemberResponse(member);
     }
@@ -110,6 +110,18 @@ public class MemberServiceImpl implements MemberService {
             throw new BusinessException(
                     MemberErrorCode.INACTIVE_MEMBER,
                     MemberErrorCode.INACTIVE_MEMBER.format(member.getId())
+            );
+        }
+    }
+
+    private Member createLocalMember(String loginId, String passwordHash) {
+        try {
+            Member newMember = Member.createWithEncodedPassword(loginId, passwordHash);
+            return memberRepository.saveAndFlush(newMember);
+        } catch (DataIntegrityViolationException exception) {
+            throw new BusinessException(
+                    MemberErrorCode.DUPLICATE_LOGIN_ID,
+                    MemberErrorCode.DUPLICATE_LOGIN_ID.format(loginId)
             );
         }
     }

--- a/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
+++ b/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
@@ -1,0 +1,60 @@
+package matchuri.backend.domain.member.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import matchuri.backend.api.member.dto.CreateMemberRequest;
+import matchuri.backend.api.member.mapper.MemberMapper;
+import matchuri.backend.domain.member.MemberErrorCode;
+import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.repository.MemberRepository;
+import matchuri.backend.domain.member.repository.MemberTasteProfileRepository;
+import matchuri.backend.global.exception.BusinessException;
+import matchuri.backend.global.security.AuthenticationFacade;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceImplTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private MemberTasteProfileRepository memberTasteProfileRepository;
+
+    @Mock
+    private MemberMapper memberMapper;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private AuthenticationFacade authenticationFacade;
+
+    @InjectMocks
+    private MemberServiceImpl memberService;
+
+    @Test
+    @DisplayName("회원 가입 저장 충돌은 MEMBER_DUPLICATE_LOGIN_ID로 번역한다")
+    void createMemberTranslatesIntegrityViolationToDuplicateLoginId() {
+        CreateMemberRequest request = new CreateMemberRequest("tester01", "P@ssw0rd!");
+
+        when(memberRepository.existsByLoginId("tester01")).thenReturn(false);
+        when(passwordEncoder.encode("P@ssw0rd!")).thenReturn("encoded-password");
+        when(memberRepository.saveAndFlush(any(Member.class)))
+                .thenThrow(new DataIntegrityViolationException("duplicate login id"));
+
+        assertThatThrownBy(() -> memberService.createMember(request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(MemberErrorCode.DUPLICATE_LOGIN_ID);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
Closes #44 

## 📝 작업 내용
- `saveAndFlush()`를 사용하여 계정 생성을 조기 발생
- 트랜잭션 커밋 시점 사이에 경쟁 조건 발생을 방지하기 위해

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
