### PR TITLE
[Refactor] Domain - API 계층 간 데이터 전송 객체를 분리

### DIFF
--- a/src/main/java/matchuri/backend/api/auth/AuthController.java
+++ b/src/main/java/matchuri/backend/api/auth/AuthController.java
@@ -9,6 +9,7 @@ import matchuri.backend.api.auth.dto.LoginRequest;
 import matchuri.backend.api.auth.dto.LoginResponse;
 import matchuri.backend.api.auth.dto.LogoutResponse;
 import matchuri.backend.api.auth.dto.OAuth2ExchangeRequest;
+import matchuri.backend.api.member.mapper.MemberMapper;
 import matchuri.backend.domain.auth.service.AuthService;
 import matchuri.backend.domain.auth.service.LoginResult;
 import matchuri.backend.domain.auth.service.RefreshTokenCookieService;
@@ -26,6 +27,7 @@ public class AuthController implements AuthApi {
 
     private final AuthService authService;
     private final RefreshTokenCookieService refreshTokenCookieService;
+    private final MemberMapper memberMapper;
 
     @Override
     @PostMapping("/login")
@@ -34,9 +36,12 @@ public class AuthController implements AuthApi {
             HttpServletRequest httpRequest,
             HttpServletResponse httpResponse
     ) {
-        LoginResult loginResult = authService.login(request, resolveClientIp(httpRequest));
+        LoginResult loginResult = authService.login(
+                memberMapper.toLoginCommand(request.loginId(), request.password()),
+                resolveClientIp(httpRequest)
+        );
         refreshTokenCookieService.addRefreshToken(httpResponse, loginResult.refreshToken());
-        return ApiResponse.success(loginResult.response());
+        return ApiResponse.success(memberMapper.toLoginResponse(loginResult.payload()));
     }
 
     @Override
@@ -44,7 +49,7 @@ public class AuthController implements AuthApi {
     public ApiResponse<LogoutResponse> logout(HttpServletRequest httpRequest, HttpServletResponse httpResponse) {
         String refreshToken = refreshTokenCookieService.resolveRefreshToken(httpRequest)
                 .orElseThrow(() -> new matchuri.backend.global.exception.AuthenticationException(matchuri.backend.domain.auth.AuthErrorCode.LOGOUT_FAILED));
-        LogoutResponse response = authService.logout(refreshToken, resolveClientIp(httpRequest));
+        LogoutResponse response = memberMapper.toLogoutResponse(authService.logout(refreshToken, resolveClientIp(httpRequest)));
         refreshTokenCookieService.clearRefreshToken(httpResponse);
         return ApiResponse.success(response);
     }
@@ -62,7 +67,14 @@ public class AuthController implements AuthApi {
             HttpServletRequest httpRequest,
             HttpServletResponse httpResponse
     ) {
-        return ApiResponse.success(authService.exchangeOAuth2Code(request, resolveClientIp(httpRequest)));
+        return ApiResponse.success(
+                memberMapper.toLoginResponse(
+                        authService.exchangeOAuth2Code(
+                                memberMapper.toOAuth2ExchangeCommand(request.provider(), request.code()),
+                                resolveClientIp(httpRequest)
+                        )
+                )
+        );
     }
 
     private String resolveClientIp(HttpServletRequest httpRequest) {

--- a/src/main/java/matchuri/backend/api/auth/AuthController.java
+++ b/src/main/java/matchuri/backend/api/auth/AuthController.java
@@ -36,12 +36,12 @@ public class AuthController implements AuthApi {
             HttpServletRequest httpRequest,
             HttpServletResponse httpResponse
     ) {
-        LoginResult loginResult = authService.login(
-                memberMapper.toLoginCommand(request.loginId(), request.password()),
-                resolveClientIp(httpRequest)
-        );
+        var command = memberMapper.toLoginCommand(request.loginId(), request.password());
+        LoginResult loginResult = authService.login(command, resolveClientIp(httpRequest));
+        LoginResponse response = memberMapper.toLoginResponse(loginResult.payload());
+
         refreshTokenCookieService.addRefreshToken(httpResponse, loginResult.refreshToken());
-        return ApiResponse.success(memberMapper.toLoginResponse(loginResult.payload()));
+        return ApiResponse.success(response);
     }
 
     @Override
@@ -49,7 +49,10 @@ public class AuthController implements AuthApi {
     public ApiResponse<LogoutResponse> logout(HttpServletRequest httpRequest, HttpServletResponse httpResponse) {
         String refreshToken = refreshTokenCookieService.resolveRefreshToken(httpRequest)
                 .orElseThrow(() -> new matchuri.backend.global.exception.AuthenticationException(matchuri.backend.domain.auth.AuthErrorCode.LOGOUT_FAILED));
-        LogoutResponse response = memberMapper.toLogoutResponse(authService.logout(refreshToken, resolveClientIp(httpRequest)));
+
+        var result = authService.logout(refreshToken, resolveClientIp(httpRequest));
+        LogoutResponse response = memberMapper.toLogoutResponse(result);
+
         refreshTokenCookieService.clearRefreshToken(httpResponse);
         return ApiResponse.success(response);
     }
@@ -67,14 +70,11 @@ public class AuthController implements AuthApi {
             HttpServletRequest httpRequest,
             HttpServletResponse httpResponse
     ) {
-        return ApiResponse.success(
-                memberMapper.toLoginResponse(
-                        authService.exchangeOAuth2Code(
-                                memberMapper.toOAuth2ExchangeCommand(request.provider(), request.code()),
-                                resolveClientIp(httpRequest)
-                        )
-                )
-        );
+        var command = memberMapper.toOAuth2ExchangeCommand(request.provider(), request.code());
+        var payload = authService.exchangeOAuth2Code(command, resolveClientIp(httpRequest));
+        LoginResponse response = memberMapper.toLoginResponse(payload);
+
+        return ApiResponse.success(response);
     }
 
     private String resolveClientIp(HttpServletRequest httpRequest) {

--- a/src/main/java/matchuri/backend/api/member/MemberController.java
+++ b/src/main/java/matchuri/backend/api/member/MemberController.java
@@ -35,11 +35,11 @@ public class MemberController implements MemberApi {
     @Override
     @PostMapping
     public ApiResponse<CreateMemberResponse> createMember(@Valid @RequestBody CreateMemberRequest request) {
-        return ApiResponse.success(
-                memberMapper.toCreateMemberResponse(
-                        memberService.createMember(memberMapper.toCreateMemberCommand(request.loginId(), request.password()))
-                )
-        );
+        var command = memberMapper.toCreateMemberCommand(request.loginId(), request.password());
+        var result = memberService.createMember(command);
+        CreateMemberResponse response = memberMapper.toCreateMemberResponse(result);
+
+        return ApiResponse.success(response);
     }
 
     @Override
@@ -61,21 +61,21 @@ public class MemberController implements MemberApi {
     @Override
     @PatchMapping("/me")
     public ApiResponse<UpdateMemberResponse> updateMyProfile(@Valid @RequestBody UpdateMemberBasicInfoRequest request) {
-        return ApiResponse.success(
-                memberMapper.toUpdateMemberResponse(
-                        memberService.updateMyProfile(memberMapper.toUpdateMemberBasicInfoCommand(request.nickname()))
-                )
-        );
+        var command = memberMapper.toUpdateMemberBasicInfoCommand(request.nickname());
+        var result = memberService.updateMyProfile(command);
+        UpdateMemberResponse response = memberMapper.toUpdateMemberResponse(result);
+
+        return ApiResponse.success(response);
     }
 
     @Override
     @PatchMapping("/me/taste-profile")
     public ApiResponse<UpdateMemberResponse> updateMyTasteProfile(@Valid @RequestBody UpdateMemberTasteProfileRequest request) {
-        return ApiResponse.success(
-                memberMapper.toUpdateMemberResponse(
-                        memberService.updateMyTasteProfile(memberMapper.toUpdateMemberTasteProfileCommand(request.profileVersion()))
-                )
-        );
+        var command = memberMapper.toUpdateMemberTasteProfileCommand(request.profileVersion());
+        var result = memberService.updateMyTasteProfile(command);
+        UpdateMemberResponse response = memberMapper.toUpdateMemberResponse(result);
+
+        return ApiResponse.success(response);
     }
 
     @Override

--- a/src/main/java/matchuri/backend/api/member/MemberController.java
+++ b/src/main/java/matchuri/backend/api/member/MemberController.java
@@ -35,7 +35,11 @@ public class MemberController implements MemberApi {
     @Override
     @PostMapping
     public ApiResponse<CreateMemberResponse> createMember(@Valid @RequestBody CreateMemberRequest request) {
-        return ApiResponse.success(memberService.createMember(request));
+        return ApiResponse.success(
+                memberMapper.toCreateMemberResponse(
+                        memberService.createMember(memberMapper.toCreateMemberCommand(request.loginId(), request.password()))
+                )
+        );
     }
 
     @Override
@@ -51,25 +55,33 @@ public class MemberController implements MemberApi {
     @Override
     @GetMapping("/me")
     public ApiResponse<MemberProfileResponse> getMyProfile() {
-        return ApiResponse.success(memberService.getMyProfile());
+        return ApiResponse.success(memberMapper.toMemberProfileResponse(memberService.getMyProfile()));
     }
 
     @Override
     @PatchMapping("/me")
     public ApiResponse<UpdateMemberResponse> updateMyProfile(@Valid @RequestBody UpdateMemberBasicInfoRequest request) {
-        return ApiResponse.success(memberService.updateMyProfile(request));
+        return ApiResponse.success(
+                memberMapper.toUpdateMemberResponse(
+                        memberService.updateMyProfile(memberMapper.toUpdateMemberBasicInfoCommand(request.nickname()))
+                )
+        );
     }
 
     @Override
     @PatchMapping("/me/taste-profile")
     public ApiResponse<UpdateMemberResponse> updateMyTasteProfile(@Valid @RequestBody UpdateMemberTasteProfileRequest request) {
-        return ApiResponse.success(memberService.updateMyTasteProfile(request));
+        return ApiResponse.success(
+                memberMapper.toUpdateMemberResponse(
+                        memberService.updateMyTasteProfile(memberMapper.toUpdateMemberTasteProfileCommand(request.profileVersion()))
+                )
+        );
     }
 
     @Override
     @DeleteMapping("/me")
     public ApiResponse<WithdrawMemberResponse> withdraw() {
-        return ApiResponse.success(memberService.withdraw());
+        return ApiResponse.success(memberMapper.toWithdrawMemberResponse(memberService.withdraw()));
     }
 
     private void validateLoginId(String loginId) {

--- a/src/main/java/matchuri/backend/api/member/mapper/MemberMapper.java
+++ b/src/main/java/matchuri/backend/api/member/mapper/MemberMapper.java
@@ -8,6 +8,17 @@ import matchuri.backend.api.member.dto.MemberProfileResponse;
 import matchuri.backend.api.member.dto.MemberTasteProfileSummaryResponse;
 import matchuri.backend.api.member.dto.UpdateMemberResponse;
 import matchuri.backend.api.member.dto.WithdrawMemberResponse;
+import matchuri.backend.domain.auth.service.LoginCommand;
+import matchuri.backend.domain.auth.service.LoginPayload;
+import matchuri.backend.domain.auth.service.LogoutResult;
+import matchuri.backend.domain.auth.service.OAuth2ExchangeCommand;
+import matchuri.backend.domain.member.service.CreateMemberCommand;
+import matchuri.backend.domain.member.service.CreateMemberResult;
+import matchuri.backend.domain.member.service.MemberProfileResult;
+import matchuri.backend.domain.member.service.UpdateMemberBasicInfoCommand;
+import matchuri.backend.domain.member.service.UpdateMemberResult;
+import matchuri.backend.domain.member.service.UpdateMemberTasteProfileCommand;
+import matchuri.backend.domain.member.service.WithdrawMemberResult;
 import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.entity.MemberTasteProfile;
 import org.springframework.stereotype.Component;
@@ -17,6 +28,35 @@ public class MemberMapper {
 
     public LoginIdExistsResponse toLoginIdExistsResponse(String loginId, boolean exists) {
         return new LoginIdExistsResponse(loginId, exists);
+    }
+
+    public CreateMemberCommand toCreateMemberCommand(String loginId, String password) {
+        return new CreateMemberCommand(loginId, password);
+    }
+
+    public CreateMemberResponse toCreateMemberResponse(CreateMemberResult result) {
+        return new CreateMemberResponse(result.memberId(), result.loginId(), result.createdAt());
+    }
+
+    public LoginCommand toLoginCommand(String loginId, String password) {
+        return new LoginCommand(loginId, password);
+    }
+
+    public OAuth2ExchangeCommand toOAuth2ExchangeCommand(matchuri.backend.domain.member.entity.SocialProviderType provider, String code) {
+        return new OAuth2ExchangeCommand(provider, code);
+    }
+
+    public LoginResponse toLoginResponse(LoginPayload payload) {
+        return new LoginResponse(
+                payload.accessToken(),
+                null,
+                payload.expiresIn(),
+                new LoginResponse.LoginMemberSummary(payload.memberId(), payload.role())
+        );
+    }
+
+    public matchuri.backend.api.auth.dto.LogoutResponse toLogoutResponse(LogoutResult result) {
+        return new matchuri.backend.api.auth.dto.LogoutResponse(result.loggedOut());
     }
 
     public CreateMemberResponse toCreateMemberResponse(Member member) {
@@ -39,12 +79,32 @@ public class MemberMapper {
         );
     }
 
+    public MemberProfileResponse toMemberProfileResponse(MemberProfileResult result) {
+        return new MemberProfileResponse(result.id(), result.nickname());
+    }
+
+    public UpdateMemberBasicInfoCommand toUpdateMemberBasicInfoCommand(String nickname) {
+        return new UpdateMemberBasicInfoCommand(nickname);
+    }
+
+    public UpdateMemberTasteProfileCommand toUpdateMemberTasteProfileCommand(String profileVersion) {
+        return new UpdateMemberTasteProfileCommand(profileVersion);
+    }
+
     public UpdateMemberResponse toUpdateMemberResponse(Member member) {
         return new UpdateMemberResponse(member.getId(), member.getUpdatedAt());
     }
 
+    public UpdateMemberResponse toUpdateMemberResponse(UpdateMemberResult result) {
+        return new UpdateMemberResponse(result.id(), result.updatedAt());
+    }
+
     public WithdrawMemberResponse toWithdrawMemberResponse(Member member) {
         return new WithdrawMemberResponse(member.getId(), member.getStatus().name());
+    }
+
+    public WithdrawMemberResponse toWithdrawMemberResponse(WithdrawMemberResult result) {
+        return new WithdrawMemberResponse(result.id(), result.status());
     }
 
     private MemberTasteProfileSummaryResponse toTasteProfileSummary(MemberTasteProfile tasteProfile) {

--- a/src/main/java/matchuri/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/AuthService.java
@@ -1,15 +1,10 @@
 package matchuri.backend.domain.auth.service;
 
-import matchuri.backend.api.auth.dto.LoginRequest;
-import matchuri.backend.api.auth.dto.LoginResponse;
-import matchuri.backend.api.auth.dto.LogoutResponse;
-import matchuri.backend.api.auth.dto.OAuth2ExchangeRequest;
-
 public interface AuthService {
 
-    LoginResult login(LoginRequest request, String clientIp);
+    LoginResult login(LoginCommand command, String clientIp);
 
-    LogoutResponse logout(String refreshToken, String clientIp);
+    LogoutResult logout(String refreshToken, String clientIp);
 
-    LoginResponse exchangeOAuth2Code(OAuth2ExchangeRequest request, String clientIp);
+    LoginPayload exchangeOAuth2Code(OAuth2ExchangeCommand command, String clientIp);
 }

--- a/src/main/java/matchuri/backend/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/AuthServiceImpl.java
@@ -2,11 +2,6 @@ package matchuri.backend.domain.auth.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import matchuri.backend.api.auth.dto.LoginRequest;
-import matchuri.backend.api.auth.dto.LoginResponse;
-import matchuri.backend.api.auth.dto.LogoutResponse;
-import matchuri.backend.api.auth.dto.OAuth2ExchangeRequest;
-import matchuri.backend.api.member.mapper.MemberMapper;
 import matchuri.backend.domain.auth.AuthErrorCode;
 import matchuri.backend.domain.member.MemberErrorCode;
 import matchuri.backend.domain.member.entity.Member;
@@ -29,20 +24,19 @@ public class AuthServiceImpl implements AuthService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
-    private final MemberMapper memberMapper;
     private final SessionTokenService sessionTokenService;
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthenticationFacade authenticationFacade;
 
     @Override
     @Transactional
-    public LoginResult login(LoginRequest request, String clientIp) {
-        Member member = memberRepository.findByLoginId(request.loginId())
+    public LoginResult login(LoginCommand command, String clientIp) {
+        Member member = memberRepository.findByLoginId(command.loginId())
                 .orElseThrow(() -> new AuthenticationException(AuthErrorCode.LOGIN_FAILED));
 
         ensureActive(member);
 
-        if (!passwordEncoder.matches(request.password(), member.getPasswordHash())) {
+        if (!passwordEncoder.matches(command.password(), member.getPasswordHash())) {
             throw new AuthenticationException(AuthErrorCode.LOGIN_FAILED);
         }
 
@@ -50,40 +44,50 @@ public class AuthServiceImpl implements AuthService {
         log.info("auth event=login_success provider=local memberId={} ip={}", member.getId(), clientIp);
 
         return new LoginResult(
-                memberMapper.toLoginResponse(member, tokenPair.accessToken(), tokenPair.accessTokenExpiresIn(), null),
+                new LoginPayload(
+                        tokenPair.accessToken(),
+                        tokenPair.accessTokenExpiresIn(),
+                        member.getId(),
+                        member.getMemberRole().name()
+                ),
                 tokenPair.refreshToken()
         );
     }
 
     @Override
     @Transactional
-    public LogoutResponse logout(String refreshToken, String clientIp) {
+    public LogoutResult logout(String refreshToken, String clientIp) {
         AuthenticatedMember authenticatedMember = authenticationFacade.getCurrentMember();
         sessionTokenService.revokeRefreshToken(refreshToken);
         log.info("auth event=logout provider=local memberId={} ip={}", authenticatedMember.memberId(), clientIp);
 
-        return new LogoutResponse(true);
+        return new LogoutResult(true);
     }
 
     @Override
     @Transactional
-    public LoginResponse exchangeOAuth2Code(OAuth2ExchangeRequest request, String clientIp) {
-        if (request.provider() != SocialProviderType.GOOGLE) {
+    public LoginPayload exchangeOAuth2Code(OAuth2ExchangeCommand command, String clientIp) {
+        if (command.provider() != SocialProviderType.GOOGLE) {
             throw new AuthenticationException(AuthErrorCode.OAUTH2_PROVIDER_NOT_SUPPORTED);
         }
 
-        Member member = sessionTokenService.consumeExchangeCode(request.provider(), request.code());
+        Member member = sessionTokenService.consumeExchangeCode(command.provider(), command.code());
         ensureActive(member);
 
         IssuedAccessToken issuedAccessToken = jwtTokenProvider.issueAccessToken(member);
         log.info(
                 "auth event=oauth2_exchange_success provider={} memberId={} ip={}",
-                request.provider().name().toLowerCase(),
+                command.provider().name().toLowerCase(),
                 member.getId(),
                 clientIp
         );
 
-        return memberMapper.toLoginResponse(member, issuedAccessToken.accessToken(), issuedAccessToken.expiresIn(), null);
+        return new LoginPayload(
+                issuedAccessToken.accessToken(),
+                issuedAccessToken.expiresIn(),
+                member.getId(),
+                member.getMemberRole().name()
+        );
     }
 
     private void ensureActive(Member member) {

--- a/src/main/java/matchuri/backend/domain/auth/service/LoginCommand.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/LoginCommand.java
@@ -1,0 +1,7 @@
+package matchuri.backend.domain.auth.service;
+
+public record LoginCommand(
+        String loginId,
+        String password
+) {
+}

--- a/src/main/java/matchuri/backend/domain/auth/service/LoginPayload.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/LoginPayload.java
@@ -1,0 +1,9 @@
+package matchuri.backend.domain.auth.service;
+
+public record LoginPayload(
+        String accessToken,
+        long expiresIn,
+        Long memberId,
+        String role
+) {
+}

--- a/src/main/java/matchuri/backend/domain/auth/service/LoginResult.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/LoginResult.java
@@ -1,9 +1,7 @@
 package matchuri.backend.domain.auth.service;
 
-import matchuri.backend.api.auth.dto.LoginResponse;
-
 public record LoginResult(
-        LoginResponse response,
+        LoginPayload payload,
         String refreshToken
 ) {
 }

--- a/src/main/java/matchuri/backend/domain/auth/service/LogoutResult.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/LogoutResult.java
@@ -1,0 +1,6 @@
+package matchuri.backend.domain.auth.service;
+
+public record LogoutResult(
+        boolean loggedOut
+) {
+}

--- a/src/main/java/matchuri/backend/domain/auth/service/OAuth2ExchangeCommand.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/OAuth2ExchangeCommand.java
@@ -1,0 +1,9 @@
+package matchuri.backend.domain.auth.service;
+
+import matchuri.backend.domain.member.entity.SocialProviderType;
+
+public record OAuth2ExchangeCommand(
+        SocialProviderType provider,
+        String code
+) {
+}

--- a/src/main/java/matchuri/backend/domain/member/service/CreateMemberCommand.java
+++ b/src/main/java/matchuri/backend/domain/member/service/CreateMemberCommand.java
@@ -1,0 +1,7 @@
+package matchuri.backend.domain.member.service;
+
+public record CreateMemberCommand(
+        String loginId,
+        String password
+) {
+}

--- a/src/main/java/matchuri/backend/domain/member/service/CreateMemberResult.java
+++ b/src/main/java/matchuri/backend/domain/member/service/CreateMemberResult.java
@@ -1,0 +1,10 @@
+package matchuri.backend.domain.member.service;
+
+import java.time.LocalDateTime;
+
+public record CreateMemberResult(
+        Long memberId,
+        String loginId,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/matchuri/backend/domain/member/service/MemberProfileResult.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberProfileResult.java
@@ -1,0 +1,7 @@
+package matchuri.backend.domain.member.service;
+
+public record MemberProfileResult(
+        Long id,
+        String nickname
+) {
+}

--- a/src/main/java/matchuri/backend/domain/member/service/MemberService.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberService.java
@@ -1,24 +1,16 @@
 package matchuri.backend.domain.member.service;
 
-import matchuri.backend.api.member.dto.CreateMemberRequest;
-import matchuri.backend.api.member.dto.CreateMemberResponse;
-import matchuri.backend.api.member.dto.MemberProfileResponse;
-import matchuri.backend.api.member.dto.UpdateMemberBasicInfoRequest;
-import matchuri.backend.api.member.dto.UpdateMemberResponse;
-import matchuri.backend.api.member.dto.UpdateMemberTasteProfileRequest;
-import matchuri.backend.api.member.dto.WithdrawMemberResponse;
-
 public interface MemberService {
 
     boolean existsByLoginId(String loginId);
 
-    CreateMemberResponse createMember(CreateMemberRequest request);
+    CreateMemberResult createMember(CreateMemberCommand command);
 
-    MemberProfileResponse getMyProfile();
+    MemberProfileResult getMyProfile();
 
-    UpdateMemberResponse updateMyProfile(UpdateMemberBasicInfoRequest request);
+    UpdateMemberResult updateMyProfile(UpdateMemberBasicInfoCommand command);
 
-    UpdateMemberResponse updateMyTasteProfile(UpdateMemberTasteProfileRequest request);
+    UpdateMemberResult updateMyTasteProfile(UpdateMemberTasteProfileCommand command);
 
-    WithdrawMemberResponse withdraw();
+    WithdrawMemberResult withdraw();
 }

--- a/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
@@ -1,13 +1,6 @@
 package matchuri.backend.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
-import matchuri.backend.api.member.dto.CreateMemberRequest;
-import matchuri.backend.api.member.dto.CreateMemberResponse;
-import matchuri.backend.api.member.dto.MemberProfileResponse;
-import matchuri.backend.api.member.dto.UpdateMemberBasicInfoRequest;
-import matchuri.backend.api.member.dto.UpdateMemberResponse;
-import matchuri.backend.api.member.dto.UpdateMemberTasteProfileRequest;
-import matchuri.backend.api.member.dto.WithdrawMemberResponse;
 import matchuri.backend.api.member.mapper.MemberMapper;
 import matchuri.backend.domain.member.MemberErrorCode;
 import matchuri.backend.domain.member.entity.Member;
@@ -41,57 +34,58 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional
-    public CreateMemberResponse createMember(CreateMemberRequest request) {
-        if (memberRepository.existsByLoginId(request.loginId())) {
+    public CreateMemberResult createMember(CreateMemberCommand command) {
+        if (memberRepository.existsByLoginId(command.loginId())) {
             throw new BusinessException(
                     MemberErrorCode.DUPLICATE_LOGIN_ID,
-                    MemberErrorCode.DUPLICATE_LOGIN_ID.format(request.loginId())
+                    MemberErrorCode.DUPLICATE_LOGIN_ID.format(command.loginId())
             );
         }
 
-        String passwordHash = passwordEncoder.encode(request.password());
-        Member member = createLocalMember(request.loginId(), passwordHash);
+        String passwordHash = passwordEncoder.encode(command.password());
+        Member member = createLocalMember(command.loginId(), passwordHash);
 
-        return memberMapper.toCreateMemberResponse(member);
+        return new CreateMemberResult(member.getId(), member.getLoginId(), member.getCreatedAt());
     }
 
     @Override
-    public MemberProfileResponse getMyProfile() {
-        return memberMapper.toMemberProfileResponse(getCurrentActiveMember());
+    public MemberProfileResult getMyProfile() {
+        Member member = getCurrentActiveMember();
+        return new MemberProfileResult(member.getId(), member.getNickname());
     }
 
     @Override
     @Transactional
-    public UpdateMemberResponse updateMyProfile(UpdateMemberBasicInfoRequest request) {
+    public UpdateMemberResult updateMyProfile(UpdateMemberBasicInfoCommand command) {
         Member member = getCurrentActiveMember();
 
-        if (request.nickname() != null) {
-            member.updateNickname(request.nickname().isBlank() ? null : request.nickname());
+        if (command.nickname() != null) {
+            member.updateNickname(command.nickname().isBlank() ? null : command.nickname());
         }
 
-        return memberMapper.toUpdateMemberResponse(member);
+        return new UpdateMemberResult(member.getId(), member.getUpdatedAt());
     }
 
     @Override
     @Transactional
-    public UpdateMemberResponse updateMyTasteProfile(UpdateMemberTasteProfileRequest request) {
+    public UpdateMemberResult updateMyTasteProfile(UpdateMemberTasteProfileCommand command) {
         Member member = getCurrentActiveMember();
 
         MemberTasteProfile tasteProfile = memberTasteProfileRepository.findByMemberId(member.getId())
                 .orElseGet(() -> memberTasteProfileRepository.save(
-                        new MemberTasteProfile(member, request.profileVersion())
+                        new MemberTasteProfile(member, command.profileVersion())
                 ));
-        tasteProfile.updateProfileVersion(request.profileVersion());
+        tasteProfile.updateProfileVersion(command.profileVersion());
 
-        return memberMapper.toUpdateMemberResponse(member);
+        return new UpdateMemberResult(member.getId(), member.getUpdatedAt());
     }
 
     @Override
     @Transactional
-    public WithdrawMemberResponse withdraw() {
+    public WithdrawMemberResult withdraw() {
         Member member = getCurrentActiveMember();
         member.withdraw();
-        return memberMapper.toWithdrawMemberResponse(member);
+        return new WithdrawMemberResult(member.getId(), member.getStatus().name());
     }
 
     private Member getCurrentActiveMember() {

--- a/src/main/java/matchuri/backend/domain/member/service/UpdateMemberBasicInfoCommand.java
+++ b/src/main/java/matchuri/backend/domain/member/service/UpdateMemberBasicInfoCommand.java
@@ -1,0 +1,6 @@
+package matchuri.backend.domain.member.service;
+
+public record UpdateMemberBasicInfoCommand(
+        String nickname
+) {
+}

--- a/src/main/java/matchuri/backend/domain/member/service/UpdateMemberResult.java
+++ b/src/main/java/matchuri/backend/domain/member/service/UpdateMemberResult.java
@@ -1,0 +1,9 @@
+package matchuri.backend.domain.member.service;
+
+import java.time.LocalDateTime;
+
+public record UpdateMemberResult(
+        Long id,
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/matchuri/backend/domain/member/service/UpdateMemberTasteProfileCommand.java
+++ b/src/main/java/matchuri/backend/domain/member/service/UpdateMemberTasteProfileCommand.java
@@ -1,0 +1,6 @@
+package matchuri.backend.domain.member.service;
+
+public record UpdateMemberTasteProfileCommand(
+        String profileVersion
+) {
+}

--- a/src/main/java/matchuri/backend/domain/member/service/WithdrawMemberResult.java
+++ b/src/main/java/matchuri/backend/domain/member/service/WithdrawMemberResult.java
@@ -1,0 +1,7 @@
+package matchuri.backend.domain.member.service;
+
+public record WithdrawMemberResult(
+        Long id,
+        String status
+) {
+}

--- a/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
+++ b/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import matchuri.backend.api.member.dto.CreateMemberRequest;
 import matchuri.backend.api.member.mapper.MemberMapper;
 import matchuri.backend.domain.member.MemberErrorCode;
 import matchuri.backend.domain.member.entity.Member;
@@ -45,14 +44,14 @@ class MemberServiceImplTest {
     @Test
     @DisplayName("회원 가입 저장 충돌은 MEMBER_DUPLICATE_LOGIN_ID로 번역한다")
     void createMemberTranslatesIntegrityViolationToDuplicateLoginId() {
-        CreateMemberRequest request = new CreateMemberRequest("tester01", "P@ssw0rd!");
+        CreateMemberCommand command = new CreateMemberCommand("tester01", "P@ssw0rd!");
 
         when(memberRepository.existsByLoginId("tester01")).thenReturn(false);
         when(passwordEncoder.encode("P@ssw0rd!")).thenReturn("encoded-password");
         when(memberRepository.saveAndFlush(any(Member.class)))
                 .thenThrow(new DataIntegrityViolationException("duplicate login id"));
 
-        assertThatThrownBy(() -> memberService.createMember(request))
+        assertThatThrownBy(() -> memberService.createMember(command))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(MemberErrorCode.DUPLICATE_LOGIN_ID);


### PR DESCRIPTION
## 관련 이슈
Closes #31 

## 📝 작업 내용
- presentation 영역에는 DTO, 도메인/모델 영역에는 Command를 분리하여 관리
- 의존성 감소

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
