### PR TITLE
[Feat] member auth 테스트 케이스 추가

### DIFF
--- a/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
@@ -13,8 +13,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Jwts;
 import jakarta.servlet.http.Cookie;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.util.Date;
+import javax.crypto.SecretKey;
 import matchuri.backend.domain.auth.entity.AuthExchangeCode;
 import matchuri.backend.domain.auth.repository.AuthExchangeCodeRepository;
 import matchuri.backend.domain.auth.repository.AuthRefreshTokenRepository;
@@ -24,6 +29,7 @@ import matchuri.backend.domain.member.entity.MemberStatus;
 import matchuri.backend.domain.member.entity.SocialProviderType;
 import matchuri.backend.domain.member.repository.MemberRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileRepository;
+import matchuri.backend.global.config.MatchuriProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,6 +38,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import io.jsonwebtoken.security.Keys;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -58,6 +65,9 @@ class MemberAuthIntegrationTest {
 
     @Autowired
     private MemberTasteProfileRepository memberTasteProfileRepository;
+
+    @Autowired
+    private MatchuriProperties matchuriProperties;
 
     @BeforeEach
     void setUp() {
@@ -205,11 +215,36 @@ class MemberAuthIntegrationTest {
     }
 
     @Test
+    @DisplayName("만료된 access token으로 보호 API에 접근하면 AUTH_TOKEN_EXPIRED를 반환한다")
+    void protectedApiRejectsExpiredAccessToken() throws Exception {
+        createMemberThroughApi("expired-user", "P@ssw0rd!");
+        Member member = memberRepository.findByLoginId("expired-user").orElseThrow();
+        String expiredAccessToken = expiredAccessToken(member);
+
+        mockMvc.perform(get("/api/v1/members/me")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(expiredAccessToken)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("AUTH_TOKEN_EXPIRED"));
+    }
+
+    @Test
     @DisplayName("로그아웃 API는 토큰 없이 접근하면 AUTH_TOKEN_MISSING을 반환한다")
     void logoutRequiresAuthentication() throws Exception {
         mockMvc.perform(post("/api/v1/auth/logout"))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.error.code").value("AUTH_TOKEN_MISSING"));
+    }
+
+    @Test
+    @DisplayName("로그아웃 시 refresh token 쿠키가 없으면 AUTH_LOGOUT_FAILED를 반환한다")
+    void logoutFailsWhenRefreshTokenCookieIsMissing() throws Exception {
+        createMemberThroughApi("logout-user", "P@ssw0rd!");
+        AuthSession authSession = login("logout-user", "P@ssw0rd!");
+
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(authSession.accessToken())))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("AUTH_LOGOUT_FAILED"));
     }
 
     @Test
@@ -246,6 +281,63 @@ class MemberAuthIntegrationTest {
     }
 
     @Test
+    @DisplayName("소셜 교환 코드는 한 번 사용 후 재사용할 수 없다")
+    void exchangeOAuth2CodeCannotBeReused() throws Exception {
+        Member member = memberRepository.save(Member.createGoogleSocialMember("google-user-2", "google2@example.com", "구글사용자2"));
+        authExchangeCodeRepository.save(AuthExchangeCode.issue(
+                member,
+                SocialProviderType.GOOGLE,
+                "single-use-code",
+                LocalDateTime.now().plusMinutes(5)
+        ));
+
+        mockMvc.perform(post("/api/v1/auth/oauth2/exchange")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "provider": "GOOGLE",
+                                  "code": "single-use-code"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").isString());
+
+        mockMvc.perform(post("/api/v1/auth/oauth2/exchange")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "provider": "GOOGLE",
+                                  "code": "single-use-code"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("AUTH_OAUTH2_EXCHANGE_CODE_INVALID"));
+    }
+
+    @Test
+    @DisplayName("만료된 소셜 교환 코드는 AUTH_OAUTH2_EXCHANGE_CODE_INVALID를 반환한다")
+    void exchangeOAuth2CodeFailsWhenCodeIsExpired() throws Exception {
+        Member member = memberRepository.save(Member.createGoogleSocialMember("google-user-3", "google3@example.com", "구글사용자3"));
+        authExchangeCodeRepository.save(AuthExchangeCode.issue(
+                member,
+                SocialProviderType.GOOGLE,
+                "expired-exchange-code",
+                LocalDateTime.now().minusMinutes(1)
+        ));
+
+        mockMvc.perform(post("/api/v1/auth/oauth2/exchange")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "provider": "GOOGLE",
+                                  "code": "expired-exchange-code"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("AUTH_OAUTH2_EXCHANGE_CODE_INVALID"));
+    }
+
+    @Test
     @DisplayName("유효하지 않은 소셜 교환 코드는 AUTH_OAUTH2_EXCHANGE_CODE_INVALID를 반환한다")
     void exchangeOAuth2CodeFailsWhenCodeIsInvalid() throws Exception {
         mockMvc.perform(post("/api/v1/auth/oauth2/exchange")
@@ -258,6 +350,29 @@ class MemberAuthIntegrationTest {
                                 """))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.error.code").value("AUTH_OAUTH2_EXCHANGE_CODE_INVALID"));
+    }
+
+    @Test
+    @DisplayName("탈퇴한 회원은 다시 로컬 로그인할 수 없다")
+    void withdrawnMemberCannotLoginAgain() throws Exception {
+        createMemberThroughApi("withdrawn-user", "P@ssw0rd!");
+        AuthSession authSession = login("withdrawn-user", "P@ssw0rd!");
+
+        mockMvc.perform(delete("/api/v1/members/me")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(authSession.accessToken())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("INACTIVE"));
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "loginId": "withdrawn-user",
+                                  "password": "P@ssw0rd!"
+                                }
+                                """))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("MEMBER_INACTIVE_MEMBER"));
     }
 
     @Test
@@ -308,6 +423,25 @@ class MemberAuthIntegrationTest {
 
     private String bearer(String accessToken) {
         return "Bearer " + accessToken;
+    }
+
+    private String expiredAccessToken(Member member) {
+        Instant now = Instant.now();
+        Instant issuedAt = now.minusSeconds(3600);
+        Instant expiredAt = now.minusSeconds(1800);
+        SecretKey signingKey = Keys.hmacShaKeyFor(
+                matchuriProperties.getAuth().getJwt().getSecret().getBytes(StandardCharsets.UTF_8)
+        );
+
+        return Jwts.builder()
+                .issuer(matchuriProperties.getAuth().getJwt().getIssuer())
+                .subject(String.valueOf(member.getId()))
+                .claim("role", member.getMemberRole().name())
+                .claim("loginId", member.getLoginId())
+                .issuedAt(Date.from(issuedAt))
+                .expiration(Date.from(expiredAt))
+                .signWith(signingKey)
+                .compact();
     }
 
     private record AuthSession(

--- a/src/test/java/matchuri/backend/api/member/MemberControllerIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/member/MemberControllerIntegrationTest.java
@@ -16,6 +16,9 @@ import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.entity.MemberRole;
 import matchuri.backend.domain.member.entity.MemberStatus;
 import matchuri.backend.domain.member.repository.MemberRepository;
+import matchuri.backend.domain.member.repository.MemberTasteProfileRepository;
+import matchuri.backend.domain.auth.repository.AuthExchangeCodeRepository;
+import matchuri.backend.domain.auth.repository.AuthRefreshTokenRepository;
 import matchuri.backend.global.docs.RestDocsSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -44,10 +47,22 @@ class MemberControllerIntegrationTest {
     @Autowired
     private MemberRepository memberRepository;
 
+    @Autowired
+    private MemberTasteProfileRepository memberTasteProfileRepository;
+
+    @Autowired
+    private AuthRefreshTokenRepository authRefreshTokenRepository;
+
+    @Autowired
+    private AuthExchangeCodeRepository authExchangeCodeRepository;
+
     private MockMvc mockMvc;
 
     @BeforeEach
     void setUp(RestDocumentationContextProvider restDocumentation) {
+        authExchangeCodeRepository.deleteAll();
+        authRefreshTokenRepository.deleteAll();
+        memberTasteProfileRepository.deleteAll();
         memberRepository.deleteAll();
         this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
                 .apply(documentationConfiguration(restDocumentation))

--- a/src/test/java/matchuri/backend/global/security/GoogleOAuth2AuthenticationFailureHandlerTest.java
+++ b/src/test/java/matchuri/backend/global/security/GoogleOAuth2AuthenticationFailureHandlerTest.java
@@ -1,0 +1,73 @@
+package matchuri.backend.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import matchuri.backend.domain.auth.AuthErrorCode;
+import matchuri.backend.domain.auth.service.RefreshTokenCookieService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+
+@ExtendWith(MockitoExtension.class)
+class GoogleOAuth2AuthenticationFailureHandlerTest {
+
+    @Mock
+    private HttpCookieOAuth2AuthorizationRequestRepository authorizationRequestRepository;
+
+    @Mock
+    private RefreshTokenCookieService refreshTokenCookieService;
+
+    @Mock
+    private GoogleOAuth2RedirectService redirectService;
+
+    @InjectMocks
+    private GoogleOAuth2AuthenticationFailureHandler failureHandler;
+
+    @Test
+    @DisplayName("제공자 인증 거절은 AUTH_OAUTH2_PROVIDER_REJECTED로 리다이렉트한다")
+    void redirectsWithProviderRejectedCode() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("127.0.0.1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AuthenticationException exception = new OAuth2AuthenticationException(new OAuth2Error("access_denied"));
+
+        when(redirectService.buildFailureRedirectUrl(AuthErrorCode.OAUTH2_PROVIDER_REJECTED))
+                .thenReturn("http://localhost:3000/login?loginResult=failed&provider=google&errorCode=AUTH_OAUTH2_PROVIDER_REJECTED");
+
+        failureHandler.onAuthenticationFailure(request, response, exception);
+
+        verify(authorizationRequestRepository).removeAuthorizationRequestCookies(request, response);
+        verify(refreshTokenCookieService).clearRefreshToken(response);
+        assertThat(response.getRedirectedUrl())
+                .isEqualTo("http://localhost:3000/login?loginResult=failed&provider=google&errorCode=AUTH_OAUTH2_PROVIDER_REJECTED");
+    }
+
+    @Test
+    @DisplayName("기타 OAuth2 실패는 AUTH_OAUTH2_PROCESSING_FAILED로 리다이렉트한다")
+    void redirectsWithProcessingFailedCode() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("127.0.0.1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AuthenticationException exception = new OAuth2AuthenticationException(new OAuth2Error("server_error"));
+
+        when(redirectService.buildFailureRedirectUrl(AuthErrorCode.OAUTH2_PROCESSING_FAILED))
+                .thenReturn("http://localhost:3000/login?loginResult=failed&provider=google&errorCode=AUTH_OAUTH2_PROCESSING_FAILED");
+
+        failureHandler.onAuthenticationFailure(request, response, exception);
+
+        verify(authorizationRequestRepository).removeAuthorizationRequestCookies(request, response);
+        verify(refreshTokenCookieService).clearRefreshToken(response);
+        assertThat(response.getRedirectedUrl())
+                .isEqualTo("http://localhost:3000/login?loginResult=failed&provider=google&errorCode=AUTH_OAUTH2_PROCESSING_FAILED");
+    }
+}

--- a/src/test/java/matchuri/backend/global/security/GoogleOAuth2AuthenticationSuccessHandlerTest.java
+++ b/src/test/java/matchuri/backend/global/security/GoogleOAuth2AuthenticationSuccessHandlerTest.java
@@ -1,0 +1,100 @@
+package matchuri.backend.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import matchuri.backend.domain.auth.AuthErrorCode;
+import matchuri.backend.domain.auth.service.GoogleOAuth2LoginResult;
+import matchuri.backend.domain.auth.service.GoogleOAuth2LoginService;
+import matchuri.backend.domain.auth.service.RefreshTokenCookieService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@ExtendWith(MockitoExtension.class)
+class GoogleOAuth2AuthenticationSuccessHandlerTest {
+
+    @Mock
+    private GoogleOAuth2LoginService googleOAuth2LoginService;
+
+    @Mock
+    private RefreshTokenCookieService refreshTokenCookieService;
+
+    @Mock
+    private HttpCookieOAuth2AuthorizationRequestRepository authorizationRequestRepository;
+
+    @Mock
+    private GoogleOAuth2RedirectService redirectService;
+
+    @InjectMocks
+    private GoogleOAuth2AuthenticationSuccessHandler successHandler;
+
+    @Test
+    @DisplayName("OAuth2 로그인 성공 시 쿠키를 정리하고 refresh token을 설정한 뒤 성공 URL로 리다이렉트한다")
+    void redirectsToSuccessUrlAfterSettingCookies() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("127.0.0.1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        Authentication authentication = authentication(createOAuth2User("google-user-1", "google@example.com", "구글사용자"));
+
+        when(googleOAuth2LoginService.login("google-user-1", "google@example.com", "구글사용자", "127.0.0.1"))
+                .thenReturn(new GoogleOAuth2LoginResult(1L, "refresh-token", "exchange-code"));
+        when(redirectService.buildSuccessRedirectUrl("exchange-code"))
+                .thenReturn("http://localhost:3000/auth/callback/google?loginResult=success&code=exchange-code");
+
+        successHandler.onAuthenticationSuccess(request, response, authentication);
+
+        verify(authorizationRequestRepository).removeAuthorizationRequestCookies(request, response);
+        verify(refreshTokenCookieService).addRefreshToken(response, "refresh-token");
+        assertThat(response.getRedirectedUrl())
+                .isEqualTo("http://localhost:3000/auth/callback/google?loginResult=success&code=exchange-code");
+    }
+
+    @Test
+    @DisplayName("OAuth2 로그인 후속 처리 실패 시 refresh token 쿠키를 지우고 실패 URL로 리다이렉트한다")
+    void redirectsToFailureUrlWhenPostLoginProcessingFails() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("127.0.0.1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        Authentication authentication = authentication(createOAuth2User("google-user-1", "google@example.com", "구글사용자"));
+
+        when(googleOAuth2LoginService.login("google-user-1", "google@example.com", "구글사용자", "127.0.0.1"))
+                .thenThrow(new IllegalStateException("boom"));
+        when(redirectService.buildFailureRedirectUrl(AuthErrorCode.OAUTH2_PROCESSING_FAILED))
+                .thenReturn("http://localhost:3000/login?loginResult=failed&provider=google&errorCode=AUTH_OAUTH2_PROCESSING_FAILED");
+
+        successHandler.onAuthenticationSuccess(request, response, authentication);
+
+        verify(authorizationRequestRepository).removeAuthorizationRequestCookies(request, response);
+        verify(refreshTokenCookieService).clearRefreshToken(response);
+        assertThat(response.getRedirectedUrl())
+                .isEqualTo("http://localhost:3000/login?loginResult=failed&provider=google&errorCode=AUTH_OAUTH2_PROCESSING_FAILED");
+    }
+
+    private Authentication authentication(OAuth2User principal) {
+        return new TestingAuthenticationToken(principal, null);
+    }
+
+    private OAuth2User createOAuth2User(String sub, String email, String name) {
+        return new DefaultOAuth2User(
+                java.util.List.of(),
+                Map.of(
+                        "sub", sub,
+                        "email", email,
+                        "name", name
+                ),
+                "sub"
+        );
+    }
+}


### PR DESCRIPTION
## 관련 이슈
Closes #34 

## 📝 작업 내용
- 기타 OAuth2 실패는 AUTH_OAUTH2_PROCESSING_FAILED
- OAuth2 로그인 성공 시 쿠키를 정리하고 refresh token을 설정한 뒤 성공 URL로 리다이렉트
- 만료된 access token 접근 시 AUTH_TOKEN_EXPIRED
- access token은 있지만 refresh token 쿠키 없는 로그아웃 시 AUTH_LOGOUT_FAILED
- OAuth2 exchange code 1회 사용 후 재사용 시 AUTH_OAUTH2_EXCHANGE_CODE_INVALID
- 만료된 OAuth2 exchange code 사용 시 AUTH_OAUTH2_EXCHANGE_CODE_INVALID
- 탈퇴 회원 재로그인 시 MEMBER_INACTIVE_MEMBER

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
