### PR TITLE
[Docs] Auth, Member API 명세 보강 

### DIFF
--- a/src/main/java/matchuri/backend/api/auth/AuthApi.java
+++ b/src/main/java/matchuri/backend/api/auth/AuthApi.java
@@ -1,5 +1,11 @@
 package matchuri.backend.api.auth;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -9,18 +15,224 @@ import matchuri.backend.api.auth.dto.LogoutResponse;
 import matchuri.backend.api.auth.dto.OAuth2ExchangeRequest;
 import matchuri.backend.global.api.ApiResponse;
 
+@Tag(name = "Auth", description = "로그인, 로그아웃, Google OAuth2 로그인 관련 API")
 public interface AuthApi {
 
+    @Operation(
+            summary = "로컬 로그인",
+            description = """
+                    `loginId + password`로 로그인합니다.
+
+                    프론트 구현 포인트:
+                    - 응답 body에는 `accessToken`과 회원 요약 정보가 포함됩니다.
+                    - `refreshToken`은 응답 body가 아니라 `HttpOnly` 쿠키로 내려갑니다.
+                    - 프론트는 이후 보호 API 호출 시 `Authorization: Bearer <accessToken>` 헤더를 사용합니다.
+                    """,
+            security = {}
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "로그인 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = LoginResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "data": {
+                                                "accessToken": "eyJhbGciOiJIUzI1NiJ9...",
+                                                "refreshToken": null,
+                                                "expiresIn": 3600,
+                                                "member": {
+                                                  "id": 1,
+                                                  "role": "MEMBER"
+                                                }
+                                              },
+                                              "error": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "아이디 또는 비밀번호가 올바르지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "loginFailed",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "data": null,
+                                              "error": {
+                                                "status": 401,
+                                                "code": "AUTH_LOGIN_FAILED",
+                                                "message": "아이디 또는 비밀번호가 올바르지 않습니다.",
+                                                "details": []
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     ApiResponse<LoginResponse> login(
             LoginRequest request,
             HttpServletRequest httpRequest,
             HttpServletResponse httpResponse
     );
 
+    @Operation(
+            summary = "로그아웃",
+            description = """
+                    현재 로그인 세션의 `refreshToken`만 폐기합니다.
+
+                    프론트 구현 포인트:
+                    - 서버는 `refreshToken` 쿠키를 삭제합니다.
+                    - 이미 발급된 `accessToken`은 즉시 무효화되지 않으며, 만료 시점까지는 보호 API 호출에 사용할 수 있습니다.
+                    - 즉, 현재 단계의 로그아웃 의미는 `재발급 차단`이지 `즉시 전역 세션 종료`가 아닙니다.
+                    """)
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "로그아웃 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = LogoutResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "data": {
+                                                "loggedOut": true
+                                              },
+                                              "error": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "refreshToken 쿠키가 없거나 서버 저장소에서 현재 세션을 찾지 못함",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "logoutFailed",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "data": null,
+                                              "error": {
+                                                "status": 400,
+                                                "code": "AUTH_LOGOUT_FAILED",
+                                                "message": "로그아웃 처리에 실패했습니다.",
+                                                "details": []
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken이 없거나 유효하지 않음"
+            )
+    })
     ApiResponse<LogoutResponse> logout(HttpServletRequest httpRequest, HttpServletResponse httpResponse);
 
+    @Operation(
+            summary = "Google OAuth2 로그인 시작",
+            description = """
+                    Google 로그인 화면으로 리다이렉트합니다.
+
+                    프론트 구현 포인트:
+                    - 일반 JSON API가 아니라 `302 Redirect` 응답입니다.
+                    - 브라우저 이동 또는 팝업/리다이렉트 흐름에서 사용합니다.
+                    - 로그인 성공 후 프론트는 최종적으로 `code`를 전달받고, 별도 교환 API를 호출해 `accessToken`을 받습니다.
+                    """,
+            security = {}
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "302",
+                    description = "Google 인증 페이지로 리다이렉트"
+            )
+    })
     void startGoogleOAuth2Login(HttpServletResponse response) throws IOException;
 
+    @Operation(
+            summary = "Google OAuth2 교환 코드 -> Access Token 교환",
+            description = """
+                    Google OAuth2 로그인 성공 후 프론트가 받은 단기 교환 코드를 Matchuri `accessToken`으로 교환합니다.
+
+                    프론트 구현 포인트:
+                    - 성공 시 응답 body에는 `accessToken`과 회원 요약 정보가 포함됩니다.
+                    - `refreshToken`은 이미 OAuth2 성공 리다이렉트 단계에서 `HttpOnly` 쿠키로 처리되므로 body에는 포함되지 않습니다.
+                    - 같은 교환 코드는 한 번만 사용할 수 있습니다.
+                    - 만료되었거나 이미 사용한 코드는 `AUTH_OAUTH2_EXCHANGE_CODE_INVALID`를 반환합니다.
+                    """,
+            security = {}
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "교환 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = LoginResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "data": {
+                                                "accessToken": "eyJhbGciOiJIUzI1NiJ9...",
+                                                "refreshToken": null,
+                                                "expiresIn": 3600,
+                                                "member": {
+                                                  "id": 7,
+                                                  "role": "MEMBER"
+                                                }
+                                              },
+                                              "error": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "지원하지 않는 소셜 로그인 provider"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "교환 코드가 없거나, 만료되었거나, 이미 사용되었음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "invalidExchangeCode",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "data": null,
+                                              "error": {
+                                                "status": 401,
+                                                "code": "AUTH_OAUTH2_EXCHANGE_CODE_INVALID",
+                                                "message": "유효하지 않은 소셜 로그인 교환 코드입니다.",
+                                                "details": []
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     ApiResponse<LoginResponse> exchangeOAuth2Code(
             OAuth2ExchangeRequest request,
             HttpServletRequest httpRequest,

--- a/src/main/java/matchuri/backend/api/auth/AuthApi.java
+++ b/src/main/java/matchuri/backend/api/auth/AuthApi.java
@@ -23,7 +23,6 @@ public interface AuthApi {
             description = """
                     `loginId + password`로 로그인합니다.
 
-                    프론트 구현 포인트:
                     - 응답 body에는 `accessToken`과 회원 요약 정보가 포함됩니다.
                     - `refreshToken`은 응답 body가 아니라 `HttpOnly` 쿠키로 내려갑니다.
                     - 프론트는 이후 보호 API 호출 시 `Authorization: Bearer <accessToken>` 헤더를 사용합니다.
@@ -91,7 +90,6 @@ public interface AuthApi {
             description = """
                     현재 로그인 세션의 `refreshToken`만 폐기합니다.
 
-                    프론트 구현 포인트:
                     - 서버는 `refreshToken` 쿠키를 삭제합니다.
                     - 이미 발급된 `accessToken`은 즉시 무효화되지 않으며, 만료 시점까지는 보호 API 호출에 사용할 수 있습니다.
                     - 즉, 현재 단계의 로그아웃 의미는 `재발급 차단`이지 `즉시 전역 세션 종료`가 아닙니다.
@@ -151,7 +149,6 @@ public interface AuthApi {
             description = """
                     Google 로그인 화면으로 리다이렉트합니다.
 
-                    프론트 구현 포인트:
                     - 일반 JSON API가 아니라 `302 Redirect` 응답입니다.
                     - 브라우저 이동 또는 팝업/리다이렉트 흐름에서 사용합니다.
                     - 로그인 성공 후 프론트는 최종적으로 `code`를 전달받고, 별도 교환 API를 호출해 `accessToken`을 받습니다.
@@ -171,7 +168,6 @@ public interface AuthApi {
             description = """
                     Google OAuth2 로그인 성공 후 프론트가 받은 단기 교환 코드를 Matchuri `accessToken`으로 교환합니다.
 
-                    프론트 구현 포인트:
                     - 성공 시 응답 body에는 `accessToken`과 회원 요약 정보가 포함됩니다.
                     - `refreshToken`은 이미 OAuth2 성공 리다이렉트 단계에서 `HttpOnly` 쿠키로 처리되므로 body에는 포함되지 않습니다.
                     - 같은 교환 코드는 한 번만 사용할 수 있습니다.

--- a/src/main/java/matchuri/backend/api/auth/dto/LoginRequest.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/LoginRequest.java
@@ -3,25 +3,30 @@ package matchuri.backend.api.auth.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import matchuri.backend.domain.member.entity.Member;
 
 public record LoginRequest(
         @Schema(
                 description = "일반 로그인에 사용하는 loginId입니다.",
                 example = "tester01",
-                maxLength = 50
+                maxLength = Member.LOGIN_ID_MAX_SIZE
         )
         @NotBlank(message = "loginId는 비어 있을 수 없습니다.")
-        @Size(max = 50, message = "loginId는 50자를 초과할 수 없습니다.")
+        @Size(max = Member.LOGIN_ID_MAX_SIZE, message = "loginId는 " + Member.LOGIN_ID_MAX_SIZE + "자를 초과할 수 없습니다.")
         String loginId,
 
         @Schema(
                 description = "일반 로그인 비밀번호입니다. 평문은 요청 시에만 사용되며 서버에는 해시로 저장됩니다.",
                 example = "P@ssw0rd!",
-                minLength = 8,
-                maxLength = 100
+                minLength = Member.PASSWORD_MIN_SIZE,
+                maxLength = Member.PASSWORD_MAX_SIZE
         )
         @NotBlank(message = "password는 비어 있을 수 없습니다.")
-        @Size(min = 8, max = 100, message = "password는 8자 이상 100자 이하여야 합니다.")
+        @Size(
+                min = Member.PASSWORD_MIN_SIZE,
+                max = Member.PASSWORD_MAX_SIZE,
+                message = "password는 " + Member.PASSWORD_MIN_SIZE + "자 이상 " + Member.PASSWORD_MAX_SIZE + "자 이하여야 합니다."
+        )
         String password
 ) {
 }

--- a/src/main/java/matchuri/backend/api/auth/dto/LoginRequest.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/LoginRequest.java
@@ -1,13 +1,25 @@
 package matchuri.backend.api.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record LoginRequest(
+        @Schema(
+                description = "일반 로그인에 사용하는 loginId입니다.",
+                example = "tester01",
+                maxLength = 50
+        )
         @NotBlank(message = "loginId는 비어 있을 수 없습니다.")
         @Size(max = 50, message = "loginId는 50자를 초과할 수 없습니다.")
         String loginId,
 
+        @Schema(
+                description = "일반 로그인 비밀번호입니다. 평문은 요청 시에만 사용되며 서버에는 해시로 저장됩니다.",
+                example = "P@ssw0rd!",
+                minLength = 8,
+                maxLength = 100
+        )
         @NotBlank(message = "password는 비어 있을 수 없습니다.")
         @Size(min = 8, max = 100, message = "password는 8자 이상 100자 이하여야 합니다.")
         String password

--- a/src/main/java/matchuri/backend/api/auth/dto/LoginResponse.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/LoginResponse.java
@@ -1,14 +1,36 @@
 package matchuri.backend.api.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record LoginResponse(
+        @Schema(
+                description = "보호 API 호출에 사용하는 Matchuri access token입니다. 프론트는 이후 `Authorization: Bearer <token>` 헤더에 이 값을 사용합니다.",
+                example = "eyJhbGciOiJIUzI1NiJ9..."
+        )
         String accessToken,
+
+        @Schema(
+                description = "현재 단계에서는 응답 body에 refresh token을 내려주지 않으므로 항상 null입니다. 실제 refresh token은 HttpOnly 쿠키로 처리됩니다.",
+                nullable = true,
+                example = "null"
+        )
         String refreshToken,
+
+        @Schema(
+                description = "access token 만료까지 남은 시간(초)입니다.",
+                example = "3600"
+        )
         long expiresIn,
+
+        @Schema(description = "로그인한 회원의 최소 요약 정보입니다.")
         LoginMemberSummary member
 ) {
 
     public record LoginMemberSummary(
+            @Schema(description = "로그인한 회원 ID입니다.", example = "1")
             Long id,
+
+            @Schema(description = "로그인한 회원 역할입니다.", example = "MEMBER")
             String role
     ) {
     }

--- a/src/main/java/matchuri/backend/api/auth/dto/OAuth2ExchangeRequest.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/OAuth2ExchangeRequest.java
@@ -1,13 +1,22 @@
 package matchuri.backend.api.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import matchuri.backend.domain.member.entity.SocialProviderType;
 
 public record OAuth2ExchangeRequest(
+        @Schema(
+                description = "교환 코드가 속한 소셜 로그인 제공자입니다. 현재 단계에서는 GOOGLE만 지원합니다.",
+                example = "GOOGLE"
+        )
         @NotNull(message = "provider는 비어 있을 수 없습니다.")
         SocialProviderType provider,
 
+        @Schema(
+                description = "OAuth2 로그인 성공 후 프론트가 전달받은 단기 교환 코드입니다. 한 번만 사용할 수 있습니다.",
+                example = "temporary_exchange_code"
+        )
         @NotBlank(message = "code는 비어 있을 수 없습니다.")
         String code
 ) {

--- a/src/main/java/matchuri/backend/api/member/MemberApi.java
+++ b/src/main/java/matchuri/backend/api/member/MemberApi.java
@@ -25,7 +25,6 @@ public interface MemberApi {
             description = """
                     일반 회원 계정을 생성합니다.
 
-                    프론트 구현 포인트:
                     - 가입 성공 시 자동 로그인되지 않습니다.
                     - 응답에는 생성된 회원의 `memberId`, `loginId`, `createdAt`이 포함됩니다.
                     - 가입 직후 로그인 화면으로 이동하거나, 같은 `loginId`로 로그인 API를 이어 호출하면 됩니다.
@@ -162,7 +161,6 @@ public interface MemberApi {
             description = """
                     현재 로그인한 회원의 기본 프로필 정보를 조회합니다.
 
-                    프론트 구현 포인트:
                     - `Authorization: Bearer <accessToken>` 헤더가 필요합니다.
                     - 현재 단계에서는 최소 프로필만 반환하므로 `id`, `nickname`만 사용하면 됩니다.
                     - `loginId`, `email`, 취향 프로필 상세 필드는 이 응답에 포함되지 않습니다.
@@ -174,7 +172,6 @@ public interface MemberApi {
             description = """
                     현재 로그인한 회원의 기본 정보 중 `nickname`만 수정합니다.
 
-                    프론트 구현 포인트:
                     - 부분 수정 API이므로 필요한 필드만 보내면 됩니다.
                     - `nickname`을 보내지 않으면 변경하지 않습니다.
                     - 성공 시 최신 수정 시각(`updatedAt`)을 반환합니다.
@@ -186,7 +183,6 @@ public interface MemberApi {
             description = """
                     현재 로그인한 회원의 취향 프로필 최소 정보(`profileVersion`)를 수정합니다.
 
-                    프론트 구현 포인트:
                     - 현재 단계에서는 취향 프로필 전체가 아니라 서버가 이해하는 버전 문자열만 받습니다.
                     - 취향 설문 결과를 저장한 뒤 이 API로 버전을 연결하는 식으로 사용할 수 있습니다.
                     """)
@@ -197,7 +193,6 @@ public interface MemberApi {
             description = """
                     현재 로그인한 회원을 비활성화 처리합니다.
 
-                    프론트 구현 포인트:
                     - 물리 삭제가 아니라 `status=INACTIVE`로 전환됩니다.
                     - 탈퇴 후 같은 계정으로 다시 로그인할 수 없습니다.
                     - 이미 발급된 access token이 남아 있어도 이후 보호 API에서는 비활성 회원으로 거절됩니다.

--- a/src/main/java/matchuri/backend/api/member/MemberApi.java
+++ b/src/main/java/matchuri/backend/api/member/MemberApi.java
@@ -22,9 +22,62 @@ public interface MemberApi {
 
     @Operation(
             summary = "회원 가입",
-            description = "일반 회원 계정을 생성합니다.",
+            description = """
+                    일반 회원 계정을 생성합니다.
+
+                    프론트 구현 포인트:
+                    - 가입 성공 시 자동 로그인되지 않습니다.
+                    - 응답에는 생성된 회원의 `memberId`, `loginId`, `createdAt`이 포함됩니다.
+                    - 가입 직후 로그인 화면으로 이동하거나, 같은 `loginId`로 로그인 API를 이어 호출하면 됩니다.
+                    """,
             security = {}
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "회원 가입 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CreateMemberResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "data": {
+                                                "memberId": 1,
+                                                "loginId": "tester01",
+                                                "createdAt": "2026-04-07T10:15:30"
+                                              },
+                                              "error": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "이미 사용 중인 loginId",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "duplicateLoginId",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "data": null,
+                                              "error": {
+                                                "status": 409,
+                                                "code": "MEMBER_DUPLICATE_LOGIN_ID",
+                                                "message": "이미 사용 중인 로그인 아이디입니다. loginId : tester01",
+                                                "details": []
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     ApiResponse<CreateMemberResponse> createMember(CreateMemberRequest request);
 
     @Operation(
@@ -104,15 +157,50 @@ public interface MemberApi {
             String loginId
     );
 
-    @Operation(summary = "내 프로필 조회", description = "현재 로그인한 회원의 기본 프로필 정보를 조회합니다.")
+    @Operation(
+            summary = "내 프로필 조회",
+            description = """
+                    현재 로그인한 회원의 기본 프로필 정보를 조회합니다.
+
+                    프론트 구현 포인트:
+                    - `Authorization: Bearer <accessToken>` 헤더가 필요합니다.
+                    - 현재 단계에서는 최소 프로필만 반환하므로 `id`, `nickname`만 사용하면 됩니다.
+                    - `loginId`, `email`, 취향 프로필 상세 필드는 이 응답에 포함되지 않습니다.
+                    """)
     ApiResponse<MemberProfileResponse> getMyProfile();
 
-    @Operation(summary = "내 기본 정보 수정", description = "현재 로그인한 회원의 기본 정보 중 닉네임만 수정합니다.")
+    @Operation(
+            summary = "내 기본 정보 수정",
+            description = """
+                    현재 로그인한 회원의 기본 정보 중 `nickname`만 수정합니다.
+
+                    프론트 구현 포인트:
+                    - 부분 수정 API이므로 필요한 필드만 보내면 됩니다.
+                    - `nickname`을 보내지 않으면 변경하지 않습니다.
+                    - 성공 시 최신 수정 시각(`updatedAt`)을 반환합니다.
+                    """)
     ApiResponse<UpdateMemberResponse> updateMyProfile(UpdateMemberBasicInfoRequest request);
 
-    @Operation(summary = "내 취향 프로필 수정", description = "현재 로그인한 회원의 취향 프로필 최소 정보를 수정합니다.")
+    @Operation(
+            summary = "내 취향 프로필 수정",
+            description = """
+                    현재 로그인한 회원의 취향 프로필 최소 정보(`profileVersion`)를 수정합니다.
+
+                    프론트 구현 포인트:
+                    - 현재 단계에서는 취향 프로필 전체가 아니라 서버가 이해하는 버전 문자열만 받습니다.
+                    - 취향 설문 결과를 저장한 뒤 이 API로 버전을 연결하는 식으로 사용할 수 있습니다.
+                    """)
     ApiResponse<UpdateMemberResponse> updateMyTasteProfile(UpdateMemberTasteProfileRequest request);
 
-    @Operation(summary = "회원 탈퇴", description = "현재 로그인한 회원을 비활성화 처리합니다.")
+    @Operation(
+            summary = "회원 탈퇴",
+            description = """
+                    현재 로그인한 회원을 비활성화 처리합니다.
+
+                    프론트 구현 포인트:
+                    - 물리 삭제가 아니라 `status=INACTIVE`로 전환됩니다.
+                    - 탈퇴 후 같은 계정으로 다시 로그인할 수 없습니다.
+                    - 이미 발급된 access token이 남아 있어도 이후 보호 API에서는 비활성 회원으로 거절됩니다.
+                    """)
     ApiResponse<WithdrawMemberResponse> withdraw();
 }

--- a/src/main/java/matchuri/backend/api/member/MemberController.java
+++ b/src/main/java/matchuri/backend/api/member/MemberController.java
@@ -90,7 +90,10 @@ public class MemberController implements MemberApi {
         }
 
         if (loginId.length() > Member.LOGIN_ID_MAX_SIZE) {
-            throw RequestValidationException.invalidPathVariable("loginId", "로그인 아이디는 50자를 초과할 수 없습니다.");
+            throw RequestValidationException.invalidPathVariable(
+                    "loginId",
+                    "로그인 아이디는 " + Member.LOGIN_ID_MAX_SIZE + "자를 초과할 수 없습니다."
+            );
         }
 
         if (!loginId.matches(Member.LOGIN_ID_PATTERN)) {

--- a/src/main/java/matchuri/backend/api/member/dto/CreateMemberRequest.java
+++ b/src/main/java/matchuri/backend/api/member/dto/CreateMemberRequest.java
@@ -13,18 +13,22 @@ public record CreateMemberRequest(
                 maxLength = Member.LOGIN_ID_MAX_SIZE
         )
         @NotBlank(message = "loginId는 비어 있을 수 없습니다.")
-        @Size(max = Member.LOGIN_ID_MAX_SIZE, message = "loginId는 50자를 초과할 수 없습니다.")
+        @Size(max = Member.LOGIN_ID_MAX_SIZE, message = "loginId는 " + Member.LOGIN_ID_MAX_SIZE + "자를 초과할 수 없습니다.")
         @Pattern(regexp = Member.LOGIN_ID_PATTERN, message = "loginId는 영문, 숫자, 점(.), 밑줄(_), 하이픈(-)만 사용할 수 있습니다.")
         String loginId,
 
         @Schema(
                 description = "회원 가입 비밀번호입니다. 8자 이상 100자 이하를 사용합니다.",
                 example = "P@ssw0rd!",
-                minLength = 8,
-                maxLength = 100
+                minLength = Member.PASSWORD_MIN_SIZE,
+                maxLength = Member.PASSWORD_MAX_SIZE
         )
         @NotBlank(message = "password는 비어 있을 수 없습니다.")
-        @Size(min = 8, max = 100, message = "password는 8자 이상 100자 이하여야 합니다.")
+        @Size(
+                min = Member.PASSWORD_MIN_SIZE,
+                max = Member.PASSWORD_MAX_SIZE,
+                message = "password는 " + Member.PASSWORD_MIN_SIZE + "자 이상 " + Member.PASSWORD_MAX_SIZE + "자 이하여야 합니다."
+        )
         String password
 ) {
 }

--- a/src/main/java/matchuri/backend/api/member/dto/CreateMemberRequest.java
+++ b/src/main/java/matchuri/backend/api/member/dto/CreateMemberRequest.java
@@ -1,17 +1,28 @@
 package matchuri.backend.api.member.dto;
 
-import jakarta.validation.constraints.Email;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import matchuri.backend.domain.member.entity.Member;
 
 public record CreateMemberRequest(
+        @Schema(
+                description = "회원 가입에 사용할 loginId입니다. 영문, 숫자, 점(.), 밑줄(_), 하이픈(-)만 사용할 수 있습니다.",
+                example = "tester01",
+                maxLength = Member.LOGIN_ID_MAX_SIZE
+        )
         @NotBlank(message = "loginId는 비어 있을 수 없습니다.")
         @Size(max = Member.LOGIN_ID_MAX_SIZE, message = "loginId는 50자를 초과할 수 없습니다.")
         @Pattern(regexp = Member.LOGIN_ID_PATTERN, message = "loginId는 영문, 숫자, 점(.), 밑줄(_), 하이픈(-)만 사용할 수 있습니다.")
         String loginId,
 
+        @Schema(
+                description = "회원 가입 비밀번호입니다. 8자 이상 100자 이하를 사용합니다.",
+                example = "P@ssw0rd!",
+                minLength = 8,
+                maxLength = 100
+        )
         @NotBlank(message = "password는 비어 있을 수 없습니다.")
         @Size(min = 8, max = 100, message = "password는 8자 이상 100자 이하여야 합니다.")
         String password

--- a/src/main/java/matchuri/backend/api/member/dto/CreateMemberRequest.java
+++ b/src/main/java/matchuri/backend/api/member/dto/CreateMemberRequest.java
@@ -18,7 +18,7 @@ public record CreateMemberRequest(
         String loginId,
 
         @Schema(
-                description = "회원 가입 비밀번호입니다. 8자 이상 100자 이하를 사용합니다.",
+                description = "회원 가입 비밀번호입니다. "+ Member.PASSWORD_MIN_SIZE + "자 이상 " + Member.PASSWORD_MAX_SIZE + "자 이하를 사용합니다.",
                 example = "P@ssw0rd!",
                 minLength = Member.PASSWORD_MIN_SIZE,
                 maxLength = Member.PASSWORD_MAX_SIZE

--- a/src/main/java/matchuri/backend/api/member/dto/CreateMemberResponse.java
+++ b/src/main/java/matchuri/backend/api/member/dto/CreateMemberResponse.java
@@ -1,10 +1,16 @@
 package matchuri.backend.api.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 public record CreateMemberResponse(
+        @Schema(description = "생성된 회원 ID입니다.", example = "1")
         Long memberId,
+
+        @Schema(description = "생성된 계정의 loginId입니다.", example = "tester01")
         String loginId,
+
+        @Schema(description = "회원 생성 시각입니다.", example = "2026-04-07T10:15:30")
         LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/matchuri/backend/api/member/dto/MemberProfileResponse.java
+++ b/src/main/java/matchuri/backend/api/member/dto/MemberProfileResponse.java
@@ -1,7 +1,12 @@
 package matchuri.backend.api.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record MemberProfileResponse(
+        @Schema(description = "현재 로그인한 회원 ID입니다.", example = "1")
         Long id,
+
+        @Schema(description = "현재 로그인한 회원 닉네임입니다. 아직 설정하지 않았다면 null일 수 있습니다.", example = "점심탐험가", nullable = true)
         String nickname
 ) {
 }

--- a/src/main/java/matchuri/backend/api/member/dto/UpdateMemberBasicInfoRequest.java
+++ b/src/main/java/matchuri/backend/api/member/dto/UpdateMemberBasicInfoRequest.java
@@ -1,9 +1,16 @@
 package matchuri.backend.api.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record UpdateMemberBasicInfoRequest(
+        @Schema(
+                description = "수정할 닉네임입니다. null이면 닉네임을 변경하지 않습니다.",
+                example = "점심탐험가",
+                nullable = true,
+                maxLength = 50
+        )
         @Pattern(regexp = "^(?!\\s*$).+", message = "nickname은 비어 있을 수 없습니다.")
         @Size(max = 50, message = "nickname은 50자를 초과할 수 없습니다.")
         String nickname

--- a/src/main/java/matchuri/backend/api/member/dto/UpdateMemberBasicInfoRequest.java
+++ b/src/main/java/matchuri/backend/api/member/dto/UpdateMemberBasicInfoRequest.java
@@ -3,16 +3,17 @@ package matchuri.backend.api.member.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import matchuri.backend.domain.member.entity.Member;
 
 public record UpdateMemberBasicInfoRequest(
         @Schema(
                 description = "수정할 닉네임입니다. null이면 닉네임을 변경하지 않습니다.",
                 example = "점심탐험가",
                 nullable = true,
-                maxLength = 50
+                maxLength = Member.NICKNAME_MAX_SIZE
         )
         @Pattern(regexp = "^(?!\\s*$).+", message = "nickname은 비어 있을 수 없습니다.")
-        @Size(max = 50, message = "nickname은 50자를 초과할 수 없습니다.")
+        @Size(max = Member.NICKNAME_MAX_SIZE, message = "nickname은 " + Member.NICKNAME_MAX_SIZE + "자를 초과할 수 없습니다.")
         String nickname
 ) {
 }

--- a/src/main/java/matchuri/backend/api/member/dto/UpdateMemberResponse.java
+++ b/src/main/java/matchuri/backend/api/member/dto/UpdateMemberResponse.java
@@ -1,9 +1,13 @@
 package matchuri.backend.api.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 public record UpdateMemberResponse(
+        @Schema(description = "수정 대상 회원 ID입니다.", example = "1")
         Long id,
+
+        @Schema(description = "서버가 기록한 마지막 수정 시각입니다.", example = "2026-04-07T10:20:45")
         LocalDateTime updatedAt
 ) {
 }

--- a/src/main/java/matchuri/backend/api/member/dto/UpdateMemberTasteProfileRequest.java
+++ b/src/main/java/matchuri/backend/api/member/dto/UpdateMemberTasteProfileRequest.java
@@ -3,15 +3,19 @@ package matchuri.backend.api.member.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import matchuri.backend.domain.member.entity.MemberTasteProfile;
 
 public record UpdateMemberTasteProfileRequest(
         @Schema(
                 description = "현재 프론트가 저장한 취향 프로필 버전입니다.",
                 example = "v1",
-                maxLength = 20
+                maxLength = MemberTasteProfile.PROFILE_VERSION_MAX_SIZE
         )
         @NotBlank(message = "profileVersion은 비어 있을 수 없습니다.")
-        @Size(max = 20, message = "profileVersion은 20자를 초과할 수 없습니다.")
+        @Size(
+                max = MemberTasteProfile.PROFILE_VERSION_MAX_SIZE,
+                message = "profileVersion은 " + MemberTasteProfile.PROFILE_VERSION_MAX_SIZE + "자를 초과할 수 없습니다."
+        )
         String profileVersion
 ) {
 }

--- a/src/main/java/matchuri/backend/api/member/dto/UpdateMemberTasteProfileRequest.java
+++ b/src/main/java/matchuri/backend/api/member/dto/UpdateMemberTasteProfileRequest.java
@@ -1,9 +1,15 @@
 package matchuri.backend.api.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record UpdateMemberTasteProfileRequest(
+        @Schema(
+                description = "현재 프론트가 저장한 취향 프로필 버전입니다.",
+                example = "v1",
+                maxLength = 20
+        )
         @NotBlank(message = "profileVersion은 비어 있을 수 없습니다.")
         @Size(max = 20, message = "profileVersion은 20자를 초과할 수 없습니다.")
         String profileVersion

--- a/src/main/java/matchuri/backend/api/member/dto/WithdrawMemberResponse.java
+++ b/src/main/java/matchuri/backend/api/member/dto/WithdrawMemberResponse.java
@@ -1,7 +1,12 @@
 package matchuri.backend.api.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record WithdrawMemberResponse(
+        @Schema(description = "탈퇴 처리된 회원 ID입니다.", example = "1")
         Long id,
+
+        @Schema(description = "탈퇴 후 회원 상태입니다. 현재 단계에서는 INACTIVE를 반환합니다.", example = "INACTIVE")
         String status
 ) {
 }

--- a/src/main/java/matchuri/backend/domain/member/entity/Member.java
+++ b/src/main/java/matchuri/backend/domain/member/entity/Member.java
@@ -41,6 +41,9 @@ import matchuri.backend.domain.common.BaseEntity;
 public class Member extends BaseEntity {
 
     public static final int LOGIN_ID_MAX_SIZE = 50;
+    public static final int PASSWORD_MIN_SIZE = 8;
+    public static final int PASSWORD_MAX_SIZE = 100;
+    public static final int NICKNAME_MAX_SIZE = 50;
     public static final String LOGIN_ID_PATTERN = "^[A-Za-z0-9._-]+$";
 
     @Id
@@ -54,7 +57,7 @@ public class Member extends BaseEntity {
     @Column(name = "password_hash", length = 255, comment = "비밀번호 해시")
     private String passwordHash;
 
-    @Column(name = "nickname", length = 50, comment = "닉네임 (자체 로그인은 수집)")
+    @Column(name = "nickname", length = NICKNAME_MAX_SIZE, comment = "닉네임 (자체 로그인은 수집)")
     private String nickname;
 
     @Column(length = 150, comment = "이메일")

--- a/src/main/java/matchuri/backend/domain/member/entity/MemberTasteProfile.java
+++ b/src/main/java/matchuri/backend/domain/member/entity/MemberTasteProfile.java
@@ -27,6 +27,8 @@ import matchuri.backend.domain.common.BaseEntity;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberTasteProfile extends BaseEntity {
 
+    public static final int PROFILE_VERSION_MAX_SIZE = 20;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(comment = "회원 취향 프로필 ID")
@@ -36,7 +38,7 @@ public class MemberTasteProfile extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false, unique = true, comment = "회원 ID")
     private Member member;
 
-    @Column(name = "profile_version", nullable = false, length = 20, comment = "프로필 버전")
+    @Column(name = "profile_version", nullable = false, length = PROFILE_VERSION_MAX_SIZE, comment = "프로필 버전")
     private String profileVersion;
 
     public MemberTasteProfile(Member member, String profileVersion) {


### PR DESCRIPTION
## 관련 이슈
Closes #48 

## 📝 작업 내용
- `@Schema`를 사용하여 스키마 명세
- description 작성
- 도메인 상수값으로 매직 넘버 삭제  

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항: