### PR TITLE
[Feat] 회원 약관 동의 API

### DIFF
--- a/src/main/java/matchuri/backend/api/auth/AuthController.java
+++ b/src/main/java/matchuri/backend/api/auth/AuthController.java
@@ -10,6 +10,7 @@ import matchuri.backend.api.auth.dto.LoginResponse;
 import matchuri.backend.api.auth.dto.LogoutResponse;
 import matchuri.backend.api.auth.dto.OAuth2ExchangeRequest;
 import matchuri.backend.api.member.mapper.MemberMapper;
+import matchuri.backend.domain.auth.AuthErrorCode;
 import matchuri.backend.domain.auth.service.AuthService;
 import matchuri.backend.domain.auth.service.LoginResult;
 import matchuri.backend.domain.auth.service.RefreshTokenCookieService;
@@ -48,7 +49,7 @@ public class AuthController implements AuthApi {
     @PostMapping("/logout")
     public ApiResponse<LogoutResponse> logout(HttpServletRequest httpRequest, HttpServletResponse httpResponse) {
         String refreshToken = refreshTokenCookieService.resolveRefreshToken(httpRequest)
-                .orElseThrow(() -> new matchuri.backend.global.exception.AuthenticationException(matchuri.backend.domain.auth.AuthErrorCode.LOGOUT_FAILED));
+                .orElseThrow(() -> new matchuri.backend.global.exception.AuthenticationException(AuthErrorCode.LOGOUT_FAILED));
 
         var result = authService.logout(refreshToken, resolveClientIp(httpRequest));
         LogoutResponse response = memberMapper.toLogoutResponse(result);

--- a/src/main/java/matchuri/backend/api/memberagreement/MemberAgreementApi.java
+++ b/src/main/java/matchuri/backend/api/memberagreement/MemberAgreementApi.java
@@ -1,0 +1,90 @@
+package matchuri.backend.api.memberagreement;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import matchuri.backend.api.memberagreement.dto.RequiredAgreementStatusResponse;
+import matchuri.backend.api.memberagreement.dto.SubmitRequiredAgreementsRequest;
+import matchuri.backend.global.api.ApiResponse;
+
+@Tag(name = "Member Agreement", description = "회원 필수 약관 상태 조회 및 동의 API")
+public interface MemberAgreementApi {
+
+    @Operation(
+            summary = "필수 약관 상태 조회",
+            description = """
+                    현재 로그인한 회원의 필수 약관 완료 상태를 조회합니다.
+
+                    - 로그인은 필요하지만 필수 약관 미완료 상태에서도 호출할 수 있습니다.
+                    - 프론트는 로그인 직후 이 API를 호출해 약관 동의 화면 이동 여부를 판단합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = RequiredAgreementStatusResponse.class),
+                            examples = @ExampleObject(
+                                    name = "pending",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "data": {
+                                                "requiredAgreementsCompleted": false,
+                                                "missingAgreementTypes": [
+                                                  "PRIVACY_POLICY",
+                                                  "TERMS_OF_SERVICE"
+                                                ]
+                                              },
+                                              "error": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")
+    })
+    ApiResponse<RequiredAgreementStatusResponse> getRequiredAgreementStatus();
+
+    @Operation(
+            summary = "필수 약관 동의 제출",
+            description = """
+                    현재 로그인한 회원의 필수 약관 동의를 저장합니다.
+
+                    - 요청에는 최신 필수 버전의 `TERMS_OF_SERVICE`, `PRIVACY_POLICY`가 모두 포함되어야 합니다.
+                    - 동일 타입/버전 재제출은 멱등하게 처리합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "동의 저장 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = RequiredAgreementStatusResponse.class),
+                            examples = @ExampleObject(
+                                    name = "completed",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "data": {
+                                                "requiredAgreementsCompleted": true,
+                                                "missingAgreementTypes": []
+                                              },
+                                              "error": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 약관 종류 또는 필수 약관 누락"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "최신 필수 버전과 불일치")
+    })
+    ApiResponse<RequiredAgreementStatusResponse> submitRequiredAgreements(SubmitRequiredAgreementsRequest request);
+}

--- a/src/main/java/matchuri/backend/api/memberagreement/MemberAgreementController.java
+++ b/src/main/java/matchuri/backend/api/memberagreement/MemberAgreementController.java
@@ -1,0 +1,42 @@
+package matchuri.backend.api.memberagreement;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import matchuri.backend.api.memberagreement.dto.RequiredAgreementStatusResponse;
+import matchuri.backend.api.memberagreement.dto.SubmitRequiredAgreementsRequest;
+import matchuri.backend.domain.member.service.MemberAgreementService;
+import matchuri.backend.global.api.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/member-agreements")
+public class MemberAgreementController implements MemberAgreementApi {
+
+    private final MemberAgreementService memberAgreementService;
+    private final MemberAgreementMapper memberAgreementMapper;
+
+    @Override
+    @GetMapping("/required-status")
+    public ApiResponse<RequiredAgreementStatusResponse> getRequiredAgreementStatus() {
+        return ApiResponse.success(
+                memberAgreementMapper.toResponse(memberAgreementService.getRequiredAgreementStatus())
+        );
+    }
+
+    @Override
+    @PostMapping("/consents")
+    public ApiResponse<RequiredAgreementStatusResponse> submitRequiredAgreements(
+            @Valid @RequestBody SubmitRequiredAgreementsRequest request
+    ) {
+        return ApiResponse.success(
+                memberAgreementMapper.toResponse(
+                        memberAgreementService.submitRequiredAgreements(memberAgreementMapper.toCommand(request))
+                )
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/api/memberagreement/MemberAgreementMapper.java
+++ b/src/main/java/matchuri/backend/api/memberagreement/MemberAgreementMapper.java
@@ -1,0 +1,31 @@
+package matchuri.backend.api.memberagreement;
+
+import matchuri.backend.api.memberagreement.dto.RequiredAgreementStatusResponse;
+import matchuri.backend.api.memberagreement.dto.SubmitRequiredAgreementsRequest;
+import matchuri.backend.domain.member.service.RequiredAgreementStatusResult;
+import matchuri.backend.domain.member.service.SubmitRequiredAgreementsCommand;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberAgreementMapper {
+
+    public SubmitRequiredAgreementsCommand toCommand(SubmitRequiredAgreementsRequest request) {
+        return new SubmitRequiredAgreementsCommand(
+                request.agreements().stream()
+                        .map(agreement -> new SubmitRequiredAgreementsCommand.AgreementConsentCommand(
+                                agreement.agreementType(),
+                                agreement.agreementVersion()
+                        ))
+                        .toList()
+        );
+    }
+
+    public RequiredAgreementStatusResponse toResponse(RequiredAgreementStatusResult result) {
+        return new RequiredAgreementStatusResponse(
+                result.requiredAgreementsCompleted(),
+                result.missingAgreementTypes().stream()
+                        .map(Enum::name)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/api/memberagreement/dto/RequiredAgreementStatusResponse.java
+++ b/src/main/java/matchuri/backend/api/memberagreement/dto/RequiredAgreementStatusResponse.java
@@ -1,0 +1,9 @@
+package matchuri.backend.api.memberagreement.dto;
+
+import java.util.List;
+
+public record RequiredAgreementStatusResponse(
+        boolean requiredAgreementsCompleted,
+        List<String> missingAgreementTypes
+) {
+}

--- a/src/main/java/matchuri/backend/api/memberagreement/dto/SubmitRequiredAgreementsRequest.java
+++ b/src/main/java/matchuri/backend/api/memberagreement/dto/SubmitRequiredAgreementsRequest.java
@@ -1,0 +1,20 @@
+package matchuri.backend.api.memberagreement.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record SubmitRequiredAgreementsRequest(
+        @NotEmpty(message = "agreements는 비어 있을 수 없습니다.")
+        List<@Valid AgreementConsentRequest> agreements
+) {
+
+    public record AgreementConsentRequest(
+            @NotBlank(message = "agreementType은 비어 있을 수 없습니다.")
+            String agreementType,
+            @NotBlank(message = "agreementVersion은 비어 있을 수 없습니다.")
+            String agreementVersion
+    ) {
+    }
+}

--- a/src/main/java/matchuri/backend/domain/member/MemberAgreementErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/member/MemberAgreementErrorCode.java
@@ -1,0 +1,30 @@
+package matchuri.backend.domain.member;
+
+import java.text.MessageFormat;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import matchuri.backend.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberAgreementErrorCode implements ErrorCode {
+
+    REQUIRED(HttpStatus.FORBIDDEN, "필수 약관 동의가 필요합니다."),
+    INVALID_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 약관 종류입니다. agreementType : {0}"),
+    REQUIRED_TYPES_MISSING(HttpStatus.BAD_REQUEST, "필수 약관 동의 요청이 누락되었습니다. missingTypes : {0}"),
+    VERSION_MISMATCH(HttpStatus.CONFLICT, "최신 필수 약관 버전과 일치하지 않습니다. agreementType : {0}, requestedVersion : {1}");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String format(Object... args) {
+        return MessageFormat.format(message, args);
+    }
+
+    @Override
+    public String getDomainPrefix() {
+        return "MEMBER_AGREEMENT_";
+    }
+}

--- a/src/main/java/matchuri/backend/domain/member/entity/AgreementType.java
+++ b/src/main/java/matchuri/backend/domain/member/entity/AgreementType.java
@@ -1,0 +1,15 @@
+package matchuri.backend.domain.member.entity;
+
+import java.util.Arrays;
+
+public enum AgreementType {
+    TERMS_OF_SERVICE,
+    PRIVACY_POLICY;
+
+    public static AgreementType from(String value) {
+        return Arrays.stream(values())
+                .filter(type -> type.name().equals(value))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/matchuri/backend/domain/member/entity/MemberAgreement.java
+++ b/src/main/java/matchuri/backend/domain/member/entity/MemberAgreement.java
@@ -1,0 +1,72 @@
+package matchuri.backend.domain.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import matchuri.backend.domain.common.BaseEntity;
+
+@Getter
+@Entity
+@Table(
+        name = "member_agreements",
+        comment = "회원 약관 동의 이력",
+        indexes = {
+            @Index(name = "idx_member_agreements_member_id", columnList = "member_id"),
+            @Index(name = "idx_member_agreements_member_type", columnList = "member_id,agreement_type")
+        },
+        uniqueConstraints = {
+            @UniqueConstraint(
+                    name = "uk_member_agreements_member_type_version",
+                    columnNames = {"member_id", "agreement_type", "agreement_version"}
+            )
+        }
+)
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberAgreement extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(comment = "회원 약관 동의 ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "agreement_type", nullable = false, length = 50, comment = "약관 종류")
+    private AgreementType agreementType;
+
+    @Column(name = "agreement_version", nullable = false, length = 50, comment = "약관 버전")
+    private String agreementVersion;
+
+    @Column(name = "agreed_at", nullable = false, comment = "동의 시각")
+    private LocalDateTime agreedAt;
+
+    public static MemberAgreement create(Member member, AgreementType agreementType, String agreementVersion) {
+        return MemberAgreement.builder()
+                .member(member)
+                .agreementType(agreementType)
+                .agreementVersion(agreementVersion)
+                .agreedAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/matchuri/backend/domain/member/repository/MemberAgreementRepository.java
+++ b/src/main/java/matchuri/backend/domain/member/repository/MemberAgreementRepository.java
@@ -1,0 +1,14 @@
+package matchuri.backend.domain.member.repository;
+
+import java.util.Collection;
+import java.util.List;
+import matchuri.backend.domain.member.entity.AgreementType;
+import matchuri.backend.domain.member.entity.MemberAgreement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberAgreementRepository extends JpaRepository<MemberAgreement, Long> {
+
+    List<MemberAgreement> findByMemberIdAndAgreementTypeIn(Long memberId, Collection<AgreementType> agreementTypes);
+
+    boolean existsByMemberIdAndAgreementTypeAndAgreementVersion(Long memberId, AgreementType agreementType, String agreementVersion);
+}

--- a/src/main/java/matchuri/backend/domain/member/service/MemberAgreementService.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberAgreementService.java
@@ -1,0 +1,10 @@
+package matchuri.backend.domain.member.service;
+
+public interface MemberAgreementService {
+
+    RequiredAgreementStatusResult getRequiredAgreementStatus();
+
+    RequiredAgreementStatusResult submitRequiredAgreements(SubmitRequiredAgreementsCommand command);
+
+    boolean hasCompletedRequiredAgreements(Long memberId);
+}

--- a/src/main/java/matchuri/backend/domain/member/service/MemberAgreementServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberAgreementServiceImpl.java
@@ -1,0 +1,131 @@
+package matchuri.backend.domain.member.service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import matchuri.backend.domain.member.MemberAgreementErrorCode;
+import matchuri.backend.domain.member.MemberErrorCode;
+import matchuri.backend.domain.member.entity.AgreementType;
+import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.entity.MemberAgreement;
+import matchuri.backend.domain.member.entity.MemberStatus;
+import matchuri.backend.domain.member.repository.MemberAgreementRepository;
+import matchuri.backend.domain.member.repository.MemberRepository;
+import matchuri.backend.global.exception.BusinessException;
+import matchuri.backend.global.security.AuthenticatedMember;
+import matchuri.backend.global.security.AuthenticationFacade;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberAgreementServiceImpl implements MemberAgreementService {
+
+    private final MemberAgreementRepository memberAgreementRepository;
+    private final MemberRepository memberRepository;
+    private final AuthenticationFacade authenticationFacade;
+
+    @Override
+    public RequiredAgreementStatusResult getRequiredAgreementStatus() {
+        Member member = getCurrentActiveMember();
+        return calculateStatus(member.getId());
+    }
+
+    @Override
+    @Transactional
+    public RequiredAgreementStatusResult submitRequiredAgreements(SubmitRequiredAgreementsCommand command) {
+        Member member = getCurrentActiveMember();
+
+        Map<AgreementType, String> requestedVersions = validateAndIndex(command.agreements());
+        for (AgreementType requiredType : RequiredAgreementVersions.requiredTypes()) {
+            String requiredVersion = RequiredAgreementVersions.getRequiredVersion(requiredType);
+            if (!memberAgreementRepository.existsByMemberIdAndAgreementTypeAndAgreementVersion(
+                    member.getId(),
+                    requiredType,
+                    requiredVersion
+            )) {
+                memberAgreementRepository.save(MemberAgreement.create(member, requiredType, requestedVersions.get(requiredType)));
+            }
+        }
+
+        return calculateStatus(member.getId());
+    }
+
+    @Override
+    public boolean hasCompletedRequiredAgreements(Long memberId) {
+        return calculateStatus(memberId).requiredAgreementsCompleted();
+    }
+
+    private RequiredAgreementStatusResult calculateStatus(Long memberId) {
+        Map<AgreementType, String> agreedVersions = new EnumMap<>(AgreementType.class);
+        memberAgreementRepository.findByMemberIdAndAgreementTypeIn(memberId, RequiredAgreementVersions.requiredTypes())
+                .forEach(agreement -> agreedVersions.put(agreement.getAgreementType(), agreement.getAgreementVersion()));
+
+        List<AgreementType> missingTypes = RequiredAgreementVersions.requiredTypes().stream()
+                .filter(type -> !RequiredAgreementVersions.getRequiredVersion(type).equals(agreedVersions.get(type)))
+                .sorted(Comparator.comparing(Enum::name))
+                .toList();
+
+        return new RequiredAgreementStatusResult(missingTypes.isEmpty(), missingTypes);
+    }
+
+    private Map<AgreementType, String> validateAndIndex(List<SubmitRequiredAgreementsCommand.AgreementConsentCommand> agreements) {
+        Map<AgreementType, String> indexed = new EnumMap<>(AgreementType.class);
+        if (agreements != null) {
+            for (SubmitRequiredAgreementsCommand.AgreementConsentCommand agreement : agreements) {
+                AgreementType agreementType = AgreementType.from(agreement.agreementType());
+                if (agreementType == null) {
+                    throw new BusinessException(
+                            MemberAgreementErrorCode.INVALID_TYPE,
+                            MemberAgreementErrorCode.INVALID_TYPE.format(agreement.agreementType())
+                    );
+                }
+
+                String requiredVersion = RequiredAgreementVersions.getRequiredVersion(agreementType);
+                if (!requiredVersion.equals(agreement.agreementVersion())) {
+                    throw new BusinessException(
+                            MemberAgreementErrorCode.VERSION_MISMATCH,
+                            MemberAgreementErrorCode.VERSION_MISMATCH.format(agreementType.name(), agreement.agreementVersion())
+                    );
+                }
+
+                indexed.put(agreementType, agreement.agreementVersion());
+            }
+        }
+
+        Set<AgreementType> requiredTypes = RequiredAgreementVersions.requiredTypes();
+        List<AgreementType> missingTypes = new ArrayList<>(requiredTypes.stream()
+                .filter(type -> !indexed.containsKey(type))
+                .sorted(Comparator.comparing(Enum::name))
+                .toList());
+        if (!missingTypes.isEmpty()) {
+            throw new BusinessException(
+                    MemberAgreementErrorCode.REQUIRED_TYPES_MISSING,
+                    MemberAgreementErrorCode.REQUIRED_TYPES_MISSING.format(missingTypes)
+            );
+        }
+
+        return indexed;
+    }
+
+    private Member getCurrentActiveMember() {
+        AuthenticatedMember authenticatedMember = authenticationFacade.getCurrentMember();
+        Member member = memberRepository.findById(authenticatedMember.memberId())
+                .orElseThrow(() -> new BusinessException(
+                        MemberErrorCode.NOT_FOUND,
+                        MemberErrorCode.NOT_FOUND.format(authenticatedMember.memberId())
+                ));
+        if (member.getStatus() != MemberStatus.ACTIVE) {
+            throw new BusinessException(
+                    MemberErrorCode.INACTIVE_MEMBER,
+                    MemberErrorCode.INACTIVE_MEMBER.format(member.getId())
+            );
+        }
+        return member;
+    }
+}

--- a/src/main/java/matchuri/backend/domain/member/service/RequiredAgreementStatusResult.java
+++ b/src/main/java/matchuri/backend/domain/member/service/RequiredAgreementStatusResult.java
@@ -1,0 +1,10 @@
+package matchuri.backend.domain.member.service;
+
+import java.util.List;
+import matchuri.backend.domain.member.entity.AgreementType;
+
+public record RequiredAgreementStatusResult(
+        boolean requiredAgreementsCompleted,
+        List<AgreementType> missingAgreementTypes
+) {
+}

--- a/src/main/java/matchuri/backend/domain/member/service/RequiredAgreementVersions.java
+++ b/src/main/java/matchuri/backend/domain/member/service/RequiredAgreementVersions.java
@@ -1,0 +1,30 @@
+package matchuri.backend.domain.member.service;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Set;
+import matchuri.backend.domain.member.entity.AgreementType;
+
+public final class RequiredAgreementVersions {
+
+    public static final String TERMS_OF_SERVICE_REQUIRED_VERSION = "2026-04-10";
+    public static final String PRIVACY_POLICY_REQUIRED_VERSION = "2026-04-10";
+
+    private static final Map<AgreementType, String> REQUIRED_VERSIONS = new EnumMap<>(AgreementType.class);
+
+    static {
+        REQUIRED_VERSIONS.put(AgreementType.TERMS_OF_SERVICE, TERMS_OF_SERVICE_REQUIRED_VERSION);
+        REQUIRED_VERSIONS.put(AgreementType.PRIVACY_POLICY, PRIVACY_POLICY_REQUIRED_VERSION);
+    }
+
+    private RequiredAgreementVersions() {
+    }
+
+    public static Set<AgreementType> requiredTypes() {
+        return REQUIRED_VERSIONS.keySet();
+    }
+
+    public static String getRequiredVersion(AgreementType agreementType) {
+        return REQUIRED_VERSIONS.get(agreementType);
+    }
+}

--- a/src/main/java/matchuri/backend/domain/member/service/SubmitRequiredAgreementsCommand.java
+++ b/src/main/java/matchuri/backend/domain/member/service/SubmitRequiredAgreementsCommand.java
@@ -1,0 +1,14 @@
+package matchuri.backend.domain.member.service;
+
+import java.util.List;
+
+public record SubmitRequiredAgreementsCommand(
+        List<AgreementConsentCommand> agreements
+) {
+
+    public record AgreementConsentCommand(
+            String agreementType,
+            String agreementVersion
+    ) {
+    }
+}

--- a/src/main/java/matchuri/backend/global/config/SecurityConfig.java
+++ b/src/main/java/matchuri/backend/global/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import matchuri.backend.global.security.MatchuriAccessDeniedHandler;
 import matchuri.backend.global.security.MatchuriAuthenticationEntryPoint;
 import matchuri.backend.global.security.OAuth2AuthenticationFailureHandler;
 import matchuri.backend.global.security.OAuth2AuthenticationSuccessHandler;
+import matchuri.backend.global.security.RequiredAgreementAccessFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -34,6 +35,7 @@ public class SecurityConfig {
     private final HttpCookieOAuth2AuthorizationRequestRepository authorizationRequestRepository;
     private final OAuth2AuthenticationSuccessHandler oauth2AuthenticationSuccessHandler;
     private final OAuth2AuthenticationFailureHandler oauth2AuthenticationFailureHandler;
+    private final RequiredAgreementAccessFilter requiredAgreementAccessFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -62,7 +64,8 @@ public class SecurityConfig {
                         .successHandler(oauth2AuthenticationSuccessHandler)
                         .failureHandler(oauth2AuthenticationFailureHandler)
                 )
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(requiredAgreementAccessFilter, JwtAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/matchuri/backend/global/security/MatchuriAccessDeniedHandler.java
+++ b/src/main/java/matchuri/backend/global/security/MatchuriAccessDeniedHandler.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.domain.auth.AuthErrorCode;
 import matchuri.backend.global.api.ApiResponse;
+import matchuri.backend.global.exception.ErrorCode;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
@@ -24,9 +25,14 @@ public class MatchuriAccessDeniedHandler implements AccessDeniedHandler {
             HttpServletResponse response,
             AccessDeniedException accessDeniedException
     ) throws IOException {
-        response.setStatus(AuthErrorCode.FORBIDDEN.getHttpStatus().value());
+        Object errorCodeAttribute = request.getAttribute(RequiredAgreementAccessFilter.AUTHORIZATION_ERROR_CODE_ATTRIBUTE);
+        ErrorCode errorCode = errorCodeAttribute instanceof ErrorCode customErrorCode
+                ? customErrorCode
+                : AuthErrorCode.FORBIDDEN;
+
+        response.setStatus(errorCode.getHttpStatus().value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
-        objectMapper.writeValue(response.getWriter(), ApiResponse.failure(AuthErrorCode.FORBIDDEN));
+        objectMapper.writeValue(response.getWriter(), ApiResponse.failure(errorCode));
     }
 }

--- a/src/main/java/matchuri/backend/global/security/RequiredAgreementAccessFilter.java
+++ b/src/main/java/matchuri/backend/global/security/RequiredAgreementAccessFilter.java
@@ -1,0 +1,89 @@
+package matchuri.backend.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import matchuri.backend.domain.member.MemberAgreementErrorCode;
+import matchuri.backend.domain.member.service.MemberAgreementService;
+import matchuri.backend.global.config.MatchuriProperties;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class RequiredAgreementAccessFilter extends OncePerRequestFilter {
+
+    public static final String AUTHORIZATION_ERROR_CODE_ATTRIBUTE = "matchuri.authorization.error-code";
+
+    private final MemberAgreementService memberAgreementService;
+    private final MatchuriProperties matchuriProperties;
+    private final MatchuriAccessDeniedHandler accessDeniedHandler;
+    private final AntPathMatcher antPathMatcher = new AntPathMatcher();
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        if (shouldSkip(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof AuthenticatedMember authenticatedMember)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (!memberAgreementService.hasCompletedRequiredAgreements(authenticatedMember.memberId())) {
+            request.setAttribute(AUTHORIZATION_ERROR_CODE_ATTRIBUTE, MemberAgreementErrorCode.REQUIRED);
+            accessDeniedHandler.handle(request, response, new AccessDeniedException(MemberAgreementErrorCode.REQUIRED.getMessage()));
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean shouldSkip(HttpServletRequest request) {
+        if (HttpMethod.OPTIONS.matches(request.getMethod())) {
+            return true;
+        }
+
+        return buildAllowedMatchers().stream().anyMatch(matcher -> matcher.matches(request, antPathMatcher));
+    }
+
+    private List<AllowedRequest> buildAllowedMatchers() {
+        List<AllowedRequest> matchers = new ArrayList<>();
+        MatchuriProperties.Auth auth = matchuriProperties.getAuth();
+
+        auth.getPublicApiPatterns().forEach(pattern -> matchers.add(new AllowedRequest(null, pattern)));
+        auth.getPublicGetApiPatterns().forEach(pattern -> matchers.add(new AllowedRequest(HttpMethod.GET, pattern)));
+        auth.getPublicPostApiPatterns().forEach(pattern -> matchers.add(new AllowedRequest(HttpMethod.POST, pattern)));
+        auth.getPublicOptionsApiPatterns().forEach(pattern -> matchers.add(new AllowedRequest(HttpMethod.OPTIONS, pattern)));
+
+        matchers.add(new AllowedRequest(HttpMethod.POST, "/api/v1/auth/logout"));
+        matchers.add(new AllowedRequest(HttpMethod.GET, "/api/v1/member-agreements/required-status"));
+        matchers.add(new AllowedRequest(HttpMethod.POST, "/api/v1/member-agreements/consents"));
+        return matchers;
+    }
+
+    private record AllowedRequest(HttpMethod method, String pattern) {
+
+        private boolean matches(HttpServletRequest request, AntPathMatcher antPathMatcher) {
+            boolean methodMatches = method == null || method.matches(request.getMethod());
+            return methodMatches && antPathMatcher.match(pattern, request.getRequestURI());
+        }
+    }
+}

--- a/src/test/java/matchuri/backend/api/member/MemberAgreementIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/member/MemberAgreementIntegrationTest.java
@@ -1,0 +1,277 @@
+package matchuri.backend.api.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import matchuri.backend.domain.auth.repository.AuthExchangeCodeRepository;
+import matchuri.backend.domain.auth.repository.AuthRefreshTokenRepository;
+import matchuri.backend.domain.member.repository.MemberAgreementRepository;
+import matchuri.backend.domain.member.repository.MemberRepository;
+import matchuri.backend.domain.member.repository.MemberTasteProfileRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MemberAgreementIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private MemberAgreementRepository memberAgreementRepository;
+
+    @Autowired
+    private MemberTasteProfileRepository memberTasteProfileRepository;
+
+    @Autowired
+    private AuthRefreshTokenRepository authRefreshTokenRepository;
+
+    @Autowired
+    private AuthExchangeCodeRepository authExchangeCodeRepository;
+
+    @BeforeEach
+    void setUp() {
+        authExchangeCodeRepository.deleteAll();
+        authRefreshTokenRepository.deleteAll();
+        memberAgreementRepository.deleteAll();
+        memberTasteProfileRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("미동의 회원은 필수 약관 상태를 조회할 수 있다")
+    void getRequiredStatusWhenAgreementsMissing() throws Exception {
+        createMemberThroughApi("agreement-user", "P@ssw0rd!");
+        AuthSession authSession = login("agreement-user", "P@ssw0rd!");
+
+        mockMvc.perform(get("/api/v1/member-agreements/required-status")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(authSession.accessToken())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.requiredAgreementsCompleted").value(false))
+                .andExpect(jsonPath("$.data.missingAgreementTypes", containsInAnyOrder("TERMS_OF_SERVICE", "PRIVACY_POLICY")));
+    }
+
+    @Test
+    @DisplayName("필수 약관 동의 제출 후 완료 상태를 반환하고 핵심 API 접근이 가능해진다")
+    void submitRequiredAgreementsAndAllowProtectedApi() throws Exception {
+        createMemberThroughApi("agreement-user-2", "P@ssw0rd!");
+        AuthSession authSession = login("agreement-user-2", "P@ssw0rd!");
+
+        mockMvc.perform(post("/api/v1/member-agreements/consents")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(authSession.accessToken()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validAgreementRequest()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.requiredAgreementsCompleted").value(true))
+                .andExpect(jsonPath("$.data.missingAgreementTypes").isEmpty());
+
+        assertThat(memberAgreementRepository.count()).isEqualTo(2);
+
+        mockMvc.perform(get("/api/v1/members/me")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(authSession.accessToken())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").isNumber());
+    }
+
+    @Test
+    @DisplayName("같은 타입과 버전으로 중복 제출해도 멱등하게 성공한다")
+    void submitRequiredAgreementsIsIdempotent() throws Exception {
+        createMemberThroughApi("agreement-user-3", "P@ssw0rd!");
+        AuthSession authSession = login("agreement-user-3", "P@ssw0rd!");
+
+        mockMvc.perform(post("/api/v1/member-agreements/consents")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(authSession.accessToken()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validAgreementRequest()))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/member-agreements/consents")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(authSession.accessToken()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validAgreementRequest()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.requiredAgreementsCompleted").value(true));
+
+        assertThat(memberAgreementRepository.count()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("필수 약관 타입이 누락되면 MEMBER_AGREEMENT_REQUIRED_TYPES_MISSING을 반환한다")
+    void submitRequiredAgreementsFailsWhenRequiredTypeMissing() throws Exception {
+        createMemberThroughApi("agreement-user-4", "P@ssw0rd!");
+        AuthSession authSession = login("agreement-user-4", "P@ssw0rd!");
+
+        mockMvc.perform(post("/api/v1/member-agreements/consents")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(authSession.accessToken()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "agreements": [
+                                    {
+                                      "agreementType": "TERMS_OF_SERVICE",
+                                      "agreementVersion": "2026-04-10"
+                                    }
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("MEMBER_AGREEMENT_REQUIRED_TYPES_MISSING"));
+    }
+
+    @Test
+    @DisplayName("잘못된 약관 타입은 MEMBER_AGREEMENT_INVALID_TYPE을 반환한다")
+    void submitRequiredAgreementsFailsWhenTypeInvalid() throws Exception {
+        createMemberThroughApi("agreement-user-5", "P@ssw0rd!");
+        AuthSession authSession = login("agreement-user-5", "P@ssw0rd!");
+
+        mockMvc.perform(post("/api/v1/member-agreements/consents")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(authSession.accessToken()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "agreements": [
+                                    {
+                                      "agreementType": "INVALID_TYPE",
+                                      "agreementVersion": "2026-04-10"
+                                    },
+                                    {
+                                      "agreementType": "PRIVACY_POLICY",
+                                      "agreementVersion": "2026-04-10"
+                                    }
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("MEMBER_AGREEMENT_INVALID_TYPE"));
+    }
+
+    @Test
+    @DisplayName("버전이 다르면 MEMBER_AGREEMENT_VERSION_MISMATCH를 반환한다")
+    void submitRequiredAgreementsFailsWhenVersionMismatch() throws Exception {
+        createMemberThroughApi("agreement-user-6", "P@ssw0rd!");
+        AuthSession authSession = login("agreement-user-6", "P@ssw0rd!");
+
+        mockMvc.perform(post("/api/v1/member-agreements/consents")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(authSession.accessToken()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "agreements": [
+                                    {
+                                      "agreementType": "TERMS_OF_SERVICE",
+                                      "agreementVersion": "2026-03-01"
+                                    },
+                                    {
+                                      "agreementType": "PRIVACY_POLICY",
+                                      "agreementVersion": "2026-04-10"
+                                    }
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("MEMBER_AGREEMENT_VERSION_MISMATCH"));
+    }
+
+    @Test
+    @DisplayName("미동의 회원은 핵심 API에서 MEMBER_AGREEMENT_REQUIRED로 차단되고 로그아웃은 허용된다")
+    void blockProtectedApiBeforeAgreementCompletion() throws Exception {
+        createMemberThroughApi("agreement-user-7", "P@ssw0rd!");
+        AuthSession authSession = login("agreement-user-7", "P@ssw0rd!");
+
+        mockMvc.perform(get("/api/v1/members/me")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(authSession.accessToken())))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("MEMBER_AGREEMENT_REQUIRED"));
+
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(authSession.accessToken()))
+                        .cookie(authSession.refreshTokenCookie()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.loggedOut").value(true));
+    }
+
+    private void createMemberThroughApi(String loginId, String password) throws Exception {
+        mockMvc.perform(post("/api/v1/members")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "loginId": "%s",
+                                  "password": "%s"
+                                }
+                                """.formatted(loginId, password)))
+                .andExpect(status().isOk());
+    }
+
+    private AuthSession login(String loginId, String password) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "loginId": "%s",
+                                  "password": "%s"
+                                }
+                                """.formatted(loginId, password)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").isString())
+                .andExpect(jsonPath("$.data.refreshToken").value(nullValue()))
+                .andReturn();
+
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        return new AuthSession(
+                body.path("data").path("accessToken").asText(),
+                result.getResponse().getCookie("matchuri_refresh_token")
+        );
+    }
+
+    private String validAgreementRequest() {
+        return """
+                {
+                  "agreements": [
+                    {
+                      "agreementType": "TERMS_OF_SERVICE",
+                      "agreementVersion": "2026-04-10"
+                    },
+                    {
+                      "agreementType": "PRIVACY_POLICY",
+                      "agreementVersion": "2026-04-10"
+                    }
+                  ]
+                }
+                """;
+    }
+
+    private String bearer(String accessToken) {
+        return "Bearer " + accessToken;
+    }
+
+    private record AuthSession(
+            String accessToken,
+            Cookie refreshTokenCookie
+    ) {
+    }
+}

--- a/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
@@ -27,6 +27,7 @@ import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.entity.MemberRole;
 import matchuri.backend.domain.member.entity.MemberStatus;
 import matchuri.backend.domain.member.entity.SocialProviderType;
+import matchuri.backend.domain.member.repository.MemberAgreementRepository;
 import matchuri.backend.domain.member.repository.MemberRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileRepository;
 import matchuri.backend.global.config.MatchuriProperties;
@@ -67,12 +68,16 @@ class MemberAuthIntegrationTest {
     private MemberTasteProfileRepository memberTasteProfileRepository;
 
     @Autowired
+    private MemberAgreementRepository memberAgreementRepository;
+
+    @Autowired
     private MatchuriProperties matchuriProperties;
 
     @BeforeEach
     void setUp() {
         authExchangeCodeRepository.deleteAll();
         authRefreshTokenRepository.deleteAll();
+        memberAgreementRepository.deleteAll();
         memberTasteProfileRepository.deleteAll();
         memberRepository.deleteAll();
     }
@@ -131,6 +136,8 @@ class MemberAuthIntegrationTest {
         createMemberThroughApi("tester01", "P@ssw0rd!");
         AuthSession authSession = login("tester01", "P@ssw0rd!");
         String accessToken = authSession.accessToken();
+
+        submitRequiredAgreements(accessToken);
 
         mockMvc.perform(get("/api/v1/members/me")
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken)))
@@ -357,6 +364,7 @@ class MemberAuthIntegrationTest {
     void withdrawnMemberCannotLoginAgain() throws Exception {
         createMemberThroughApi("withdrawn-user", "P@ssw0rd!");
         AuthSession authSession = login("withdrawn-user", "P@ssw0rd!");
+        submitRequiredAgreements(authSession.accessToken());
 
         mockMvc.perform(delete("/api/v1/members/me")
                         .header(HttpHeaders.AUTHORIZATION, bearer(authSession.accessToken())))
@@ -419,6 +427,27 @@ class MemberAuthIntegrationTest {
                 body.path("data").path("accessToken").asText(),
                 result.getResponse().getCookie("matchuri_refresh_token")
         );
+    }
+
+    private void submitRequiredAgreements(String accessToken) throws Exception {
+        mockMvc.perform(post("/api/v1/member-agreements/consents")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "agreements": [
+                                    {
+                                      "agreementType": "TERMS_OF_SERVICE",
+                                      "agreementVersion": "2026-04-10"
+                                    },
+                                    {
+                                      "agreementType": "PRIVACY_POLICY",
+                                      "agreementVersion": "2026-04-10"
+                                    }
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isOk());
     }
 
     private String bearer(String accessToken) {

--- a/src/test/java/matchuri/backend/domain/member/MemberAgreementRepositoryTest.java
+++ b/src/test/java/matchuri/backend/domain/member/MemberAgreementRepositoryTest.java
@@ -1,0 +1,76 @@
+package matchuri.backend.domain.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import matchuri.backend.domain.member.entity.AgreementType;
+import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.entity.MemberAgreement;
+import matchuri.backend.domain.member.entity.MemberRole;
+import matchuri.backend.domain.member.entity.MemberStatus;
+import matchuri.backend.domain.member.repository.MemberAgreementRepository;
+import matchuri.backend.domain.member.repository.MemberRepository;
+import matchuri.backend.global.config.JpaConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import(JpaConfig.class)
+@ActiveProfiles("test")
+class MemberAgreementRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private MemberAgreementRepository memberAgreementRepository;
+
+    @Test
+    @DisplayName("회원별 약관 동의 이력을 타입 기준으로 조회할 수 있다")
+    void findByMemberIdAndAgreementTypeIn() {
+        Member member = memberRepository.save(new Member(
+                "agreement-user",
+                "hashed-password",
+                null,
+                false,
+                null,
+                null,
+                MemberRole.MEMBER,
+                MemberStatus.ACTIVE
+        ));
+        memberAgreementRepository.save(MemberAgreement.create(member, AgreementType.TERMS_OF_SERVICE, "2026-04-10"));
+        memberAgreementRepository.save(MemberAgreement.create(member, AgreementType.PRIVACY_POLICY, "2026-04-10"));
+
+        List<MemberAgreement> agreements = memberAgreementRepository.findByMemberIdAndAgreementTypeIn(
+                member.getId(),
+                List.of(AgreementType.TERMS_OF_SERVICE, AgreementType.PRIVACY_POLICY)
+        );
+
+        assertThat(agreements).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("같은 회원의 같은 약관 타입과 버전 조합은 유일해야 한다")
+    void memberAgreementMustBeUniquePerMemberTypeAndVersion() {
+        Member member = memberRepository.save(new Member(
+                "agreement-user-2",
+                "hashed-password",
+                null,
+                false,
+                null,
+                null,
+                MemberRole.MEMBER,
+                MemberStatus.ACTIVE
+        ));
+        memberAgreementRepository.saveAndFlush(MemberAgreement.create(member, AgreementType.TERMS_OF_SERVICE, "2026-04-10"));
+
+        assertThatThrownBy(() -> memberAgreementRepository.saveAndFlush(
+                MemberAgreement.create(member, AgreementType.TERMS_OF_SERVICE, "2026-04-10")
+        )).isInstanceOf(Exception.class);
+    }
+}

--- a/src/test/java/matchuri/backend/domain/member/service/MemberAgreementServiceImplTest.java
+++ b/src/test/java/matchuri/backend/domain/member/service/MemberAgreementServiceImplTest.java
@@ -1,0 +1,111 @@
+package matchuri.backend.domain.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import matchuri.backend.domain.member.MemberAgreementErrorCode;
+import matchuri.backend.domain.member.entity.AgreementType;
+import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.entity.MemberAgreement;
+import matchuri.backend.domain.member.entity.MemberRole;
+import matchuri.backend.domain.member.entity.MemberStatus;
+import matchuri.backend.domain.member.repository.MemberAgreementRepository;
+import matchuri.backend.domain.member.repository.MemberRepository;
+import matchuri.backend.global.exception.BusinessException;
+import matchuri.backend.global.security.AuthenticatedMember;
+import matchuri.backend.global.security.AuthenticationFacade;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MemberAgreementServiceImplTest {
+
+    @Mock
+    private MemberAgreementRepository memberAgreementRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private AuthenticationFacade authenticationFacade;
+
+    @InjectMocks
+    private MemberAgreementServiceImpl memberAgreementService;
+
+    @Test
+    @DisplayName("필수 약관 중 일부가 빠지면 MEMBER_AGREEMENT_REQUIRED_TYPES_MISSING을 반환한다")
+    void submitRequiredAgreementsFailsWhenRequiredTypesMissing() {
+        Member member = activeMember(1L);
+        when(authenticationFacade.getCurrentMember()).thenReturn(new AuthenticatedMember(1L, "tester01", MemberRole.MEMBER));
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+
+        SubmitRequiredAgreementsCommand command = new SubmitRequiredAgreementsCommand(List.of(
+                new SubmitRequiredAgreementsCommand.AgreementConsentCommand("TERMS_OF_SERVICE", "2026-04-10")
+        ));
+
+        assertThatThrownBy(() -> memberAgreementService.submitRequiredAgreements(command))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(MemberAgreementErrorCode.REQUIRED_TYPES_MISSING);
+    }
+
+    @Test
+    @DisplayName("최신 필수 버전과 다르면 MEMBER_AGREEMENT_VERSION_MISMATCH를 반환한다")
+    void submitRequiredAgreementsFailsWhenVersionMismatch() {
+        Member member = activeMember(1L);
+        when(authenticationFacade.getCurrentMember()).thenReturn(new AuthenticatedMember(1L, "tester01", MemberRole.MEMBER));
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+
+        SubmitRequiredAgreementsCommand command = new SubmitRequiredAgreementsCommand(List.of(
+                new SubmitRequiredAgreementsCommand.AgreementConsentCommand("TERMS_OF_SERVICE", "2026-03-01"),
+                new SubmitRequiredAgreementsCommand.AgreementConsentCommand("PRIVACY_POLICY", "2026-04-10")
+        ));
+
+        assertThatThrownBy(() -> memberAgreementService.submitRequiredAgreements(command))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(MemberAgreementErrorCode.VERSION_MISMATCH);
+    }
+
+    @Test
+    @DisplayName("최신 필수 버전 이력이 모두 있으면 필수 약관 완료 상태를 반환한다")
+    void hasCompletedRequiredAgreementsReturnsTrueWhenAllRequiredVersionsExist() {
+        when(memberAgreementRepository.findByMemberIdAndAgreementTypeIn(1L, RequiredAgreementVersions.requiredTypes()))
+                .thenReturn(List.of(
+                        MemberAgreement.create(activeMember(1L), AgreementType.TERMS_OF_SERVICE, "2026-04-10"),
+                        MemberAgreement.create(activeMember(1L), AgreementType.PRIVACY_POLICY, "2026-04-10")
+                ));
+
+        assertThat(memberAgreementService.hasCompletedRequiredAgreements(1L)).isTrue();
+    }
+
+    @Test
+    @DisplayName("이전 버전만 동의한 경우 필수 약관 완료가 아니다")
+    void hasCompletedRequiredAgreementsReturnsFalseForOlderVersions() {
+        when(memberAgreementRepository.findByMemberIdAndAgreementTypeIn(1L, RequiredAgreementVersions.requiredTypes()))
+                .thenReturn(List.of(
+                        MemberAgreement.create(activeMember(1L), AgreementType.TERMS_OF_SERVICE, "2026-03-01"),
+                        MemberAgreement.create(activeMember(1L), AgreementType.PRIVACY_POLICY, "2026-03-01")
+                ));
+
+        assertThat(memberAgreementService.hasCompletedRequiredAgreements(1L)).isFalse();
+    }
+
+    private Member activeMember(Long memberId) {
+        return Member.builder()
+                .id(memberId)
+                .loginId("tester01")
+                .passwordHash("hashed-password")
+                .social(false)
+                .memberRole(MemberRole.MEMBER)
+                .status(MemberStatus.ACTIVE)
+                .build();
+    }
+}

--- a/src/test/java/matchuri/backend/global/docs/ApiDocumentationSampleTest.java
+++ b/src/test/java/matchuri/backend/global/docs/ApiDocumentationSampleTest.java
@@ -55,6 +55,9 @@ class ApiDocumentationSampleTest {
     @MockitoBean
     private matchuri.backend.global.security.JwtAuthenticationFilter jwtAuthenticationFilter;
 
+    @MockitoBean
+    private matchuri.backend.global.security.RequiredAgreementAccessFilter requiredAgreementAccessFilter;
+
     @Autowired
     private WebApplicationContext context;
 

--- a/src/test/java/matchuri/backend/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/matchuri/backend/global/exception/GlobalExceptionHandlerTest.java
@@ -41,6 +41,9 @@ class GlobalExceptionHandlerTest {
     @MockitoBean
     private matchuri.backend.global.security.JwtAuthenticationFilter jwtAuthenticationFilter;
 
+    @MockitoBean
+    private matchuri.backend.global.security.RequiredAgreementAccessFilter requiredAgreementAccessFilter;
+
     @Autowired
     private MockMvc mockMvc;
 


### PR DESCRIPTION
## 관련 이슈
Closes #56 

## 📝 작업 내용
- 약관 동의 상태 조회 API 추가
- 약관 동의 등록 API 추가
- 약관 미동의 유저에 대한 접근 제한 API 제어

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 약관 동의 자체에 변화, 추가에 대해 유연한 구조로 구현했습니다 (추후 마케팅 수집과 같은 선택 동의를 고려하여)
