### PR TITLE
[Refactor] 소셜 회원가입시 임시 닉네임 네이밍

### DIFF
--- a/src/main/java/matchuri/backend/api/member/MemberApi.java
+++ b/src/main/java/matchuri/backend/api/member/MemberApi.java
@@ -11,6 +11,7 @@ import matchuri.backend.api.member.dto.CreateMemberRequest;
 import matchuri.backend.api.member.dto.CreateMemberResponse;
 import matchuri.backend.api.member.dto.LoginIdExistsResponse;
 import matchuri.backend.api.member.dto.MemberProfileResponse;
+import matchuri.backend.api.member.dto.NicknameExistsResponse;
 import matchuri.backend.api.member.dto.UpdateMemberBasicInfoRequest;
 import matchuri.backend.api.member.dto.UpdateMemberResponse;
 import matchuri.backend.api.member.dto.UpdateMemberTasteProfileRequest;
@@ -154,6 +155,80 @@ public interface MemberApi {
                     example = "tester01"
             )
             String loginId
+    );
+
+    @Operation(
+            summary = "닉네임 중복 확인",
+            description = """
+                    프로필 설정 시 사용할 닉네임이 이미 사용 중인지 확인합니다.
+                    이 API는 인증 없이 호출할 수 있습니다.
+                    """,
+            security = {}
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "정상 조회",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = NicknameExistsResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "data": {
+                                                "nickname": "example_google",
+                                                "exists": true
+                                              },
+                                              "error": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "닉네임 형식이 올바르지 않은 경우",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "invalidNickname",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "data": null,
+                                              "error": {
+                                                "status": 400,
+                                                "code": "COMMON_INVALID_PATH_VARIABLE",
+                                                "message": "경로 변수 형식이 올바르지 않습니다",
+                                                "details": [
+                                                  {
+                                                    "source": "PATH",
+                                                    "field": "nickname",
+                                                    "reason": "닉네임은 비어 있을 수 없습니다."
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ApiResponse<NicknameExistsResponse> checkNicknameExists(
+            @Parameter(
+                    description = """
+                            프로필 설정 시 사용할 닉네임입니다.
+
+                            제약:
+                            - 공백만으로 구성될 수 없음
+                            - 최대 100자
+                            - 예시: 점심탐험가, example_google
+                            """,
+                    example = "example_google"
+            )
+            String nickname
     );
 
     @Operation(

--- a/src/main/java/matchuri/backend/api/member/MemberController.java
+++ b/src/main/java/matchuri/backend/api/member/MemberController.java
@@ -6,6 +6,7 @@ import matchuri.backend.api.member.dto.CreateMemberRequest;
 import matchuri.backend.api.member.dto.CreateMemberResponse;
 import matchuri.backend.api.member.dto.LoginIdExistsResponse;
 import matchuri.backend.api.member.dto.MemberProfileResponse;
+import matchuri.backend.api.member.dto.NicknameExistsResponse;
 import matchuri.backend.api.member.dto.UpdateMemberBasicInfoRequest;
 import matchuri.backend.api.member.dto.UpdateMemberResponse;
 import matchuri.backend.api.member.dto.UpdateMemberTasteProfileRequest;
@@ -50,6 +51,14 @@ public class MemberController implements MemberApi {
         validateLoginId(loginId);
         boolean exists = memberService.existsByLoginId(loginId);
         return ApiResponse.success(memberMapper.toLoginIdExistsResponse(loginId, exists));
+    }
+
+    @Override
+    @GetMapping("/exists/nickname/{nickname}")
+    public ApiResponse<NicknameExistsResponse> checkNicknameExists(@PathVariable String nickname) {
+        validateNickname(nickname);
+        boolean exists = memberService.existsByNickname(nickname);
+        return ApiResponse.success(memberMapper.toNicknameExistsResponse(nickname, exists));
     }
 
     @Override
@@ -100,6 +109,19 @@ public class MemberController implements MemberApi {
             throw RequestValidationException.invalidPathVariable(
                     "loginId",
                     "로그인 아이디는 영문, 숫자, 점(.), 밑줄(_), 하이픈(-)만 사용할 수 있습니다."
+            );
+        }
+    }
+
+    private void validateNickname(String nickname) {
+        if (nickname == null || nickname.isBlank()) {
+            throw RequestValidationException.invalidPathVariable("nickname", "닉네임은 비어 있을 수 없습니다.");
+        }
+
+        if (nickname.length() > Member.NICKNAME_MAX_SIZE) {
+            throw RequestValidationException.invalidPathVariable(
+                    "nickname",
+                    "닉네임은 " + Member.NICKNAME_MAX_SIZE + "자를 초과할 수 없습니다."
             );
         }
     }

--- a/src/main/java/matchuri/backend/api/member/dto/NicknameExistsResponse.java
+++ b/src/main/java/matchuri/backend/api/member/dto/NicknameExistsResponse.java
@@ -1,0 +1,12 @@
+package matchuri.backend.api.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record NicknameExistsResponse(
+        @Schema(description = "중복 확인한 닉네임입니다.", example = "example_google")
+        String nickname,
+
+        @Schema(description = "이미 존재하는 닉네임인지 여부입니다. true면 이미 사용 중입니다.", example = "true")
+        boolean exists
+) {
+}

--- a/src/main/java/matchuri/backend/api/member/mapper/MemberMapper.java
+++ b/src/main/java/matchuri/backend/api/member/mapper/MemberMapper.java
@@ -5,6 +5,7 @@ import matchuri.backend.api.auth.dto.LoginResponse;
 import matchuri.backend.api.member.dto.CreateMemberResponse;
 import matchuri.backend.api.member.dto.LoginIdExistsResponse;
 import matchuri.backend.api.member.dto.MemberProfileResponse;
+import matchuri.backend.api.member.dto.NicknameExistsResponse;
 import matchuri.backend.api.member.dto.MemberTasteProfileSummaryResponse;
 import matchuri.backend.api.member.dto.UpdateMemberResponse;
 import matchuri.backend.api.member.dto.WithdrawMemberResponse;
@@ -28,6 +29,10 @@ public class MemberMapper {
 
     public LoginIdExistsResponse toLoginIdExistsResponse(String loginId, boolean exists) {
         return new LoginIdExistsResponse(loginId, exists);
+    }
+
+    public NicknameExistsResponse toNicknameExistsResponse(String nickname, boolean exists) {
+        return new NicknameExistsResponse(nickname, exists);
     }
 
     public CreateMemberCommand toCreateMemberCommand(String loginId, String password) {

--- a/src/main/java/matchuri/backend/domain/auth/service/OAuth2LoginService.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/OAuth2LoginService.java
@@ -30,8 +30,7 @@ public class OAuth2LoginService {
         var member = oAuth2MemberService.findOrCreateMember(
                 provider,
                 userInfo.providerUserId(),
-                userInfo.email(),
-                userInfo.nickname()
+                userInfo.email()
         );
         TokenPair tokenPair = sessionTokenService.issueLoginTokenPair(member);
         String exchangeCode = sessionTokenService.createExchangeCode(member, provider);

--- a/src/main/java/matchuri/backend/domain/auth/service/OAuth2MemberService.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/OAuth2MemberService.java
@@ -1,5 +1,6 @@
 package matchuri.backend.domain.auth.service;
 
+import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.domain.auth.AuthErrorCode;
 import matchuri.backend.domain.member.MemberErrorCode;
@@ -21,13 +22,13 @@ public class OAuth2MemberService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public Member findOrCreateMember(SocialProviderType provider, String providerUserId, String email, String nickname) {
+    public Member findOrCreateMember(SocialProviderType provider, String providerUserId, String email) {
         if (providerUserId == null || providerUserId.isBlank()) {
             throw new AuthenticationException(AuthErrorCode.OAUTH2_PROVIDER_USERINFO_MISSING);
         }
 
         Member member = memberRepository.findBySocialProviderTypeAndSocialProviderUserId(provider, providerUserId)
-                .orElseGet(() -> createSocialMember(provider, providerUserId, email, nickname));
+                .orElseGet(() -> createSocialMember(provider, providerUserId, email));
 
         if (member.getStatus() != MemberStatus.ACTIVE) {
             throw new BusinessException(MemberErrorCode.INACTIVE_MEMBER, MemberErrorCode.INACTIVE_MEMBER.format(member.getId()));
@@ -36,12 +37,59 @@ public class OAuth2MemberService {
         return member;
     }
 
-    private Member createSocialMember(SocialProviderType provider, String providerUserId, String email, String nickname) {
+    private Member createSocialMember(SocialProviderType provider, String providerUserId, String email) {
+        String temporaryNickname = generateUniqueTemporaryNickname(provider, email);
+
         try {
-            return memberRepository.saveAndFlush(Member.createSocialMember(provider, providerUserId, email, nickname));
+            return memberRepository.saveAndFlush(Member.createSocialMember(provider, providerUserId, email, temporaryNickname));
         } catch (DataIntegrityViolationException exception) {
             return memberRepository.findBySocialProviderTypeAndSocialProviderUserId(provider, providerUserId)
                     .orElseThrow(() -> exception);
         }
+    }
+
+    private String generateUniqueTemporaryNickname(SocialProviderType provider, String email) {
+        String baseNickname = buildBaseTemporaryNickname(provider, email);
+        String candidate = baseNickname;
+        int suffix = 1;
+
+        while (memberRepository.existsByNickname(candidate)) {
+            candidate = appendSuffix(baseNickname, suffix++);
+        }
+
+        return candidate;
+    }
+
+    private String buildBaseTemporaryNickname(SocialProviderType provider, String email) {
+        String emailLocalPart = extractEmailLocalPart(email);
+        String providerName = provider.toRegistrationId();
+        String rawBase = emailLocalPart + "_" + providerName;
+
+        if (rawBase.length() <= Member.NICKNAME_MAX_SIZE) {
+            return rawBase;
+        }
+
+        int maxLocalPartLength = Math.max(1, Member.NICKNAME_MAX_SIZE - providerName.length() - 1);
+        return emailLocalPart.substring(0, Math.min(emailLocalPart.length(), maxLocalPartLength)) + "_" + providerName;
+    }
+
+    private String appendSuffix(String baseNickname, int suffix) {
+        String suffixValue = "_" + suffix;
+        int maxBaseLength = Math.max(1, Member.NICKNAME_MAX_SIZE - suffixValue.length());
+        String truncatedBase = baseNickname.substring(0, Math.min(baseNickname.length(), maxBaseLength));
+        return truncatedBase + suffixValue;
+    }
+
+    private String extractEmailLocalPart(String email) {
+        if (email == null || email.isBlank()) {
+            return "user";
+        }
+
+        int separatorIndex = email.indexOf('@');
+        if (separatorIndex <= 0) {
+            return email.toLowerCase(Locale.ROOT);
+        }
+
+        return email.substring(0, separatorIndex).toLowerCase(Locale.ROOT);
     }
 }

--- a/src/main/java/matchuri/backend/domain/member/MemberErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/member/MemberErrorCode.java
@@ -13,6 +13,7 @@ public enum MemberErrorCode implements ErrorCode {
     NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다. memberId : {0}"),
     NOT_FOUND_LOGIN_ID(HttpStatus.NOT_FOUND, "해당 로그인 아이디의 회원을 찾을 수 없습니다. loginId : {0}"),
     DUPLICATE_LOGIN_ID(HttpStatus.CONFLICT, "이미 사용 중인 로그인 아이디입니다. loginId : {0}"),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다. nickname : {0}"),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
     INACTIVE_MEMBER(HttpStatus.FORBIDDEN, "비활성화된 회원입니다. memberId : {0}");
 

--- a/src/main/java/matchuri/backend/domain/member/entity/Member.java
+++ b/src/main/java/matchuri/backend/domain/member/entity/Member.java
@@ -25,10 +25,12 @@ import matchuri.backend.domain.common.BaseEntity;
     comment = "회원",
     indexes = {
         @Index(name = "idx_members_email", columnList = "email"),
-        @Index(name = "idx_members_social_provider", columnList = "is_social,social_provider_type")
+        @Index(name = "idx_members_social_provider", columnList = "is_social,social_provider_type"),
+        @Index(name = "idx_members_nickname", columnList = "nickname")
     },
     uniqueConstraints = {
         @UniqueConstraint(name = "uk_members_login_id", columnNames = "login_id"),
+        @UniqueConstraint(name = "uk_members_nickname", columnNames = "nickname"),
         @UniqueConstraint(
                 name = "uk_members_social_provider_user",
                 columnNames = {"social_provider_type", "social_provider_user_id"}

--- a/src/main/java/matchuri/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/matchuri/backend/domain/member/repository/MemberRepository.java
@@ -9,6 +9,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByLoginId(String loginId);
 
+    boolean existsByNickname(String nickname);
+
     Optional<Member> findByLoginId(String loginId);
 
     Optional<Member> findBySocialProviderTypeAndSocialProviderUserId(

--- a/src/main/java/matchuri/backend/domain/member/service/MemberService.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberService.java
@@ -4,6 +4,8 @@ public interface MemberService {
 
     boolean existsByLoginId(String loginId);
 
+    boolean existsByNickname(String nickname);
+
     CreateMemberResult createMember(CreateMemberCommand command);
 
     MemberProfileResult getMyProfile();

--- a/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
@@ -31,6 +31,11 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    public boolean existsByNickname(String nickname) {
+        return memberRepository.existsByNickname(nickname);
+    }
+
+    @Override
     @Transactional
     public CreateMemberResult createMember(CreateMemberCommand command) {
         if (memberRepository.existsByLoginId(command.loginId())) {
@@ -58,7 +63,18 @@ public class MemberServiceImpl implements MemberService {
         Member member = getCurrentActiveMember();
 
         if (command.nickname() != null) {
-            member.updateNickname(command.nickname().isBlank() ? null : command.nickname());
+            String nickname = command.nickname().isBlank() ? null : command.nickname();
+            validateNicknameDuplication(member, nickname);
+
+            try {
+                member.updateNickname(nickname);
+                memberRepository.flush();
+            } catch (DataIntegrityViolationException exception) {
+                throw new BusinessException(
+                        MemberErrorCode.DUPLICATE_NICKNAME,
+                        MemberErrorCode.DUPLICATE_NICKNAME.format(nickname)
+                );
+            }
         }
 
         return new UpdateMemberResult(member.getId(), member.getUpdatedAt());
@@ -114,6 +130,19 @@ public class MemberServiceImpl implements MemberService {
             throw new BusinessException(
                     MemberErrorCode.DUPLICATE_LOGIN_ID,
                     MemberErrorCode.DUPLICATE_LOGIN_ID.format(loginId)
+            );
+        }
+    }
+
+    private void validateNicknameDuplication(Member member, String nickname) {
+        if (nickname == null || nickname.equals(member.getNickname())) {
+            return;
+        }
+
+        if (memberRepository.existsByNickname(nickname)) {
+            throw new BusinessException(
+                    MemberErrorCode.DUPLICATE_NICKNAME,
+                    MemberErrorCode.DUPLICATE_NICKNAME.format(nickname)
             );
         }
     }

--- a/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
@@ -216,6 +216,32 @@ class MemberAuthIntegrationTest {
     }
 
     @Test
+    @DisplayName("내 닉네임 수정 시 이미 존재하는 닉네임이면 MEMBER_DUPLICATE_NICKNAME을 반환한다")
+    void updateMyProfileFailsWhenNicknameAlreadyExists() throws Exception {
+        createMemberThroughApi("tester01", "P@ssw0rd!");
+        createMemberThroughApi("tester02", "P@ssw0rd!");
+
+        AuthSession authSession = login("tester01", "P@ssw0rd!");
+        String accessToken = authSession.accessToken();
+        submitRequiredAgreements(accessToken);
+
+        Member duplicateNicknameOwner = memberRepository.findByLoginId("tester02").orElseThrow();
+        duplicateNicknameOwner.updateNickname("점심탐험가");
+        memberRepository.saveAndFlush(duplicateNicknameOwner);
+
+        mockMvc.perform(patch("/api/v1/members/me")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "nickname": "점심탐험가"
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("MEMBER_DUPLICATE_NICKNAME"));
+    }
+
+    @Test
     @DisplayName("보호 API는 토큰 없이 접근하면 AUTH_TOKEN_MISSING을 반환한다")
     void protectedApiRequiresAuthentication() throws Exception {
         mockMvc.perform(get("/api/v1/members/me"))
@@ -339,7 +365,7 @@ class MemberAuthIntegrationTest {
     @Test
     @DisplayName("유효한 소셜 교환 코드는 액세스 토큰으로 교환된다")
     void exchangeOAuth2Code() throws Exception {
-        Member member = memberRepository.save(Member.createSocialMember(SocialProviderType.GOOGLE, "google-user-1", "google@example.com", "구글사용자"));
+        Member member = memberRepository.save(Member.createSocialMember(SocialProviderType.GOOGLE, "google-user-1", "google@example.com", "example_google"));
         authExchangeCodeRepository.save(AuthExchangeCode.issue(
                 member,
                 SocialProviderType.GOOGLE,
@@ -364,7 +390,7 @@ class MemberAuthIntegrationTest {
     @Test
     @DisplayName("소셜 교환 코드는 한 번 사용 후 재사용할 수 없다")
     void exchangeOAuth2CodeCannotBeReused() throws Exception {
-        Member member = memberRepository.save(Member.createSocialMember(SocialProviderType.GOOGLE, "google-user-2", "google2@example.com", "구글사용자2"));
+        Member member = memberRepository.save(Member.createSocialMember(SocialProviderType.GOOGLE, "google-user-2", "google2@example.com", "google2_google"));
         authExchangeCodeRepository.save(AuthExchangeCode.issue(
                 member,
                 SocialProviderType.GOOGLE,
@@ -398,7 +424,7 @@ class MemberAuthIntegrationTest {
     @Test
     @DisplayName("만료된 소셜 교환 코드는 AUTH_OAUTH2_EXCHANGE_CODE_INVALID를 반환한다")
     void exchangeOAuth2CodeFailsWhenCodeIsExpired() throws Exception {
-        Member member = memberRepository.save(Member.createSocialMember(SocialProviderType.GOOGLE, "google-user-3", "google3@example.com", "구글사용자3"));
+        Member member = memberRepository.save(Member.createSocialMember(SocialProviderType.GOOGLE, "google-user-3", "google3@example.com", "google3_google"));
         authExchangeCodeRepository.save(AuthExchangeCode.issue(
                 member,
                 SocialProviderType.GOOGLE,

--- a/src/test/java/matchuri/backend/api/member/MemberControllerIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/member/MemberControllerIntegrationTest.java
@@ -127,6 +127,59 @@ class MemberControllerIntegrationTest {
     }
 
     @Test
+    @DisplayName("이미 존재하는 nickname은 exists=true로 반환한다")
+    void returnsTrueWhenNicknameExists() throws Exception {
+        Member member = Member.builder()
+                .loginId("tester01")
+                .passwordHash("hashed-password")
+                .nickname("example_google")
+                .email("tester01@example.com")
+                .social(false)
+                .memberRole(MemberRole.MEMBER)
+                .status(MemberStatus.ACTIVE)
+                .build();
+        memberRepository.save(member);
+
+        mockMvc.perform(get("/api/v1/members/exists/nickname/{nickname}", "example_google")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.nickname").value("example_google"))
+                .andExpect(jsonPath("$.data.exists").value(true))
+                .andDo(document("members/check-nickname",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("nickname").description(
+                                        """
+                                        프로필 설정 시 사용할 닉네임입니다.
+                                        제약:
+                                        - 공백만으로 구성될 수 없음
+                                        - 최대 100자
+                                        허용 예시: 점심탐험가, example_google
+                                        """
+                                )
+                        ),
+                        RestDocsSupport.successResponse(
+                                fieldWithPath("data.nickname")
+                                        .description("중복 확인한 닉네임입니다. 요청 path variable과 동일한 값을 반환합니다."),
+                                fieldWithPath("data.exists")
+                                        .description("이미 존재하는 닉네임인지 여부입니다. true면 이미 사용 중이고, false면 사용할 수 있습니다.")
+                        )));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 nickname은 exists=false로 반환한다")
+    void returnsFalseWhenNicknameDoesNotExist() throws Exception {
+        mockMvc.perform(get("/api/v1/members/exists/nickname/{nickname}", "example_google")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.nickname").value("example_google"))
+                .andExpect(jsonPath("$.data.exists").value(false));
+    }
+
+    @Test
     @DisplayName("형식이 잘못된 loginId는 공통 경로 변수 오류 응답을 반환한다")
     void returnsPathValidationErrorForInvalidLoginId() throws Exception {
         mockMvc.perform(get("/api/v1/members/exists/{loginId}", "invalid login id")
@@ -147,6 +200,32 @@ class MemberControllerIntegrationTest {
                                         - 공백 포함
                                         - 허용되지 않은 문자 포함
                                         - 50자 초과
+                                        """
+                                )
+                        ),
+                        RestDocsSupport.errorResponse()));
+    }
+
+    @Test
+    @DisplayName("형식이 잘못된 nickname은 공통 경로 변수 오류 응답을 반환한다")
+    void returnsPathValidationErrorForInvalidNickname() throws Exception {
+        mockMvc.perform(get("/api/v1/members/exists/nickname/{nickname}", " ")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("COMMON_INVALID_PATH_VARIABLE"))
+                .andExpect(jsonPath("$.error.details[0].source").value("PATH"))
+                .andExpect(jsonPath("$.error.details[0].field").value("nickname"))
+                .andDo(document("members/check-nickname-invalid",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("nickname").description(
+                                        """
+                                        형식 검증 대상 닉네임입니다.
+                                        대표 실패 케이스:
+                                        - 공백만 포함
+                                        - 100자 초과
                                         """
                                 )
                         ),

--- a/src/test/java/matchuri/backend/domain/auth/service/OAuth2LoginServiceTest.java
+++ b/src/test/java/matchuri/backend/domain/auth/service/OAuth2LoginServiceTest.java
@@ -51,14 +51,14 @@ class OAuth2LoginServiceTest {
                 LocalDateTime.of(2026, 4, 9, 12, 0)
         );
 
-        when(oAuth2MemberService.findOrCreateMember(SocialProviderType.GOOGLE, "google-user-1", "google@example.com", "구글사용자"))
+        when(oAuth2MemberService.findOrCreateMember(SocialProviderType.GOOGLE, "google-user-1", "google@example.com"))
                 .thenReturn(member);
         when(sessionTokenService.issueLoginTokenPair(member)).thenReturn(tokenPair);
         when(sessionTokenService.createExchangeCode(member, SocialProviderType.GOOGLE)).thenReturn("exchange-code");
 
         OAuth2LoginResult result = service.login(SocialProviderType.GOOGLE, oauth2User, "127.0.0.1");
 
-        verify(oAuth2MemberService).findOrCreateMember(SocialProviderType.GOOGLE, "google-user-1", "google@example.com", "구글사용자");
+        verify(oAuth2MemberService).findOrCreateMember(SocialProviderType.GOOGLE, "google-user-1", "google@example.com");
         verify(sessionTokenService).issueLoginTokenPair(member);
         verify(sessionTokenService).createExchangeCode(member, SocialProviderType.GOOGLE);
         assertThat(result.refreshToken()).isEqualTo("refresh-token");

--- a/src/test/java/matchuri/backend/domain/auth/service/OAuth2MemberServiceTest.java
+++ b/src/test/java/matchuri/backend/domain/auth/service/OAuth2MemberServiceTest.java
@@ -1,6 +1,7 @@
 package matchuri.backend.domain.auth.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -13,6 +14,7 @@ import matchuri.backend.domain.member.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -45,17 +47,64 @@ class OAuth2MemberServiceTest {
         when(memberRepository.findBySocialProviderTypeAndSocialProviderUserId(SocialProviderType.GOOGLE, providerUserId))
                 .thenReturn(Optional.empty())
                 .thenReturn(Optional.of(existingMember));
-        when(memberRepository.saveAndFlush(org.mockito.ArgumentMatchers.any(Member.class)))
+        when(memberRepository.existsByNickname("google_google")).thenReturn(false);
+        when(memberRepository.saveAndFlush(any(Member.class)))
                 .thenThrow(new DataIntegrityViolationException("duplicate social member"));
 
         Member resolvedMember = oAuth2MemberService.findOrCreateMember(
                 SocialProviderType.GOOGLE,
                 providerUserId,
-                "google@example.com",
-                "구글사용자"
+                "google@example.com"
         );
 
         assertThat(resolvedMember).isSameAs(existingMember);
-        verify(memberRepository).saveAndFlush(org.mockito.ArgumentMatchers.any(Member.class));
+        verify(memberRepository).saveAndFlush(any(Member.class));
+    }
+
+    @Test
+    @DisplayName("신규 소셜 회원은 이메일 로컬파트와 provider로 임시 닉네임을 생성한다")
+    void createsSocialMemberWithTemporaryNickname() {
+        String providerUserId = "google-user-1";
+        ArgumentCaptor<Member> memberCaptor = ArgumentCaptor.forClass(Member.class);
+
+        when(memberRepository.findBySocialProviderTypeAndSocialProviderUserId(SocialProviderType.GOOGLE, providerUserId))
+                .thenReturn(Optional.empty());
+        when(memberRepository.existsByNickname("example_google")).thenReturn(false);
+        when(memberRepository.saveAndFlush(any(Member.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        Member createdMember = oAuth2MemberService.findOrCreateMember(
+                SocialProviderType.GOOGLE,
+                providerUserId,
+                "example@google.com"
+        );
+
+        verify(memberRepository).saveAndFlush(memberCaptor.capture());
+        assertThat(memberCaptor.getValue().getNickname()).isEqualTo("example_google");
+        assertThat(createdMember.getNickname()).isEqualTo("example_google");
+    }
+
+    @Test
+    @DisplayName("임시 닉네임이 이미 존재하면 숫자 suffix를 붙여 유니크하게 저장한다")
+    void createsUniqueTemporaryNicknameWhenBaseNicknameAlreadyExists() {
+        String providerUserId = "google-user-2";
+        ArgumentCaptor<Member> memberCaptor = ArgumentCaptor.forClass(Member.class);
+
+        when(memberRepository.findBySocialProviderTypeAndSocialProviderUserId(SocialProviderType.GOOGLE, providerUserId))
+                .thenReturn(Optional.empty());
+        when(memberRepository.existsByNickname("example_google")).thenReturn(true);
+        when(memberRepository.existsByNickname("example_google_1")).thenReturn(false);
+        when(memberRepository.saveAndFlush(any(Member.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        Member createdMember = oAuth2MemberService.findOrCreateMember(
+                SocialProviderType.GOOGLE,
+                providerUserId,
+                "example@google.com"
+        );
+
+        verify(memberRepository).saveAndFlush(memberCaptor.capture());
+        assertThat(memberCaptor.getValue().getNickname()).isEqualTo("example_google_1");
+        assertThat(createdMember.getNickname()).isEqualTo("example_google_1");
     }
 }

--- a/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
+++ b/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
@@ -1,14 +1,19 @@
 package matchuri.backend.domain.member.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import matchuri.backend.domain.member.MemberErrorCode;
 import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.entity.MemberRole;
+import matchuri.backend.domain.member.entity.MemberStatus;
 import matchuri.backend.domain.member.repository.MemberRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileRepository;
 import matchuri.backend.global.exception.BusinessException;
+import matchuri.backend.global.security.AuthenticatedMember;
 import matchuri.backend.global.security.AuthenticationFacade;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -51,5 +56,53 @@ class MemberServiceImplTest {
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(MemberErrorCode.DUPLICATE_LOGIN_ID);
+    }
+
+    @Test
+    @DisplayName("내 닉네임 수정 시 이미 사용 중인 닉네임이면 MEMBER_DUPLICATE_NICKNAME을 반환한다")
+    void updateMyProfileRejectsDuplicateNickname() {
+        Member member = Member.builder()
+                .id(1L)
+                .loginId("tester01")
+                .nickname("현재닉네임")
+                .memberRole(MemberRole.MEMBER)
+                .status(MemberStatus.ACTIVE)
+                .social(false)
+                .build();
+
+        when(authenticationFacade.getCurrentMember()).thenReturn(
+                new AuthenticatedMember(1L, "tester01", MemberRole.MEMBER)
+        );
+        when(memberRepository.findById(1L)).thenReturn(java.util.Optional.of(member));
+        when(memberRepository.existsByNickname("중복닉네임")).thenReturn(true);
+
+        assertThatThrownBy(() -> memberService.updateMyProfile(new UpdateMemberBasicInfoCommand("중복닉네임")))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(MemberErrorCode.DUPLICATE_NICKNAME);
+    }
+
+    @Test
+    @DisplayName("내 닉네임 수정 시 같은 닉네임이면 중복 검사 없이 유지한다")
+    void updateMyProfileAllowsSameNickname() {
+        Member member = Member.builder()
+                .id(1L)
+                .loginId("tester01")
+                .nickname("현재닉네임")
+                .memberRole(MemberRole.MEMBER)
+                .status(MemberStatus.ACTIVE)
+                .social(false)
+                .build();
+
+        when(authenticationFacade.getCurrentMember()).thenReturn(
+                new AuthenticatedMember(1L, "tester01", MemberRole.MEMBER)
+        );
+        when(memberRepository.findById(1L)).thenReturn(java.util.Optional.of(member));
+
+        UpdateMemberResult result = memberService.updateMyProfile(new UpdateMemberBasicInfoCommand("현재닉네임"));
+
+        assertThat(result.id()).isEqualTo(1L);
+        assertThat(member.getNickname()).isEqualTo("현재닉네임");
+        verify(memberRepository).flush();
     }
 }


### PR DESCRIPTION
## 관련 이슈
Closes #61 

## 📝 작업 내용
- 소셜 회원가입시 임시 닉네임 네이밍
- 닉네임 중복 검사 api 추가
- members.nickname에 unique 설정

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [x] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
