### PR TITLE
[Chore] 배포 후 헬스체크를 루프로 돌도록 수정

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -156,6 +156,13 @@ jobs:
           set -euo pipefail
           ssh -p "${EC2_PORT}" -i ~/.ssh/matchuri_ec2 "${EC2_USER}@${EC2_HOST}" <<EOF
           set -euo pipefail
-          curl --fail --silent --show-error http://127.0.0.1:8080/actuator/health >/tmp/matchuri-health.json
-          cat /tmp/matchuri-health.json
+          for attempt in {1..12}; do
+            if curl --fail --silent --show-error http://127.0.0.1:8080/api/v1/health >/tmp/matchuri-health.json; then
+              cat /tmp/matchuri-health.json
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "Matchuri health check failed after waiting 60 seconds." >&2
+          exit 1
           EOF


### PR DESCRIPTION
## 관련 이슈
#51 

## 📝 작업 내용
- 서버 배포 후 health check API 발송 루프 추가
- 배포 직후 API를 전송하여 정상적으로 배포됐으나 API가 실패함

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
