### PR TITLE
[Refactor] 자체 회원가입 API 구현

### DIFF
--- a/src/main/java/matchuri/backend/api/member/MemberApi.java
+++ b/src/main/java/matchuri/backend/api/member/MemberApi.java
@@ -60,6 +60,30 @@ public interface MemberApi {
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "필수 약관 동의 요청 누락 또는 형식 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "requiredAgreementTypesMissing",
+                                            value = """
+                                                    {
+                                                      "success": false,
+                                                      "data": null,
+                                                      "error": {
+                                                        "status": 400,
+                                                        "code": "MEMBER_AGREEMENT_REQUIRED_TYPES_MISSING",
+                                                        "message": "필수 약관 동의 요청이 누락되었습니다. missingTypes : [PRIVACY_POLICY]",
+                                                        "details": []
+                                                      }
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "409",
                     description = "이미 사용 중인 loginId 또는 nickname",
                     content = @Content(

--- a/src/main/java/matchuri/backend/api/member/MemberApi.java
+++ b/src/main/java/matchuri/backend/api/member/MemberApi.java
@@ -12,6 +12,8 @@ import matchuri.backend.api.member.dto.CreateMemberResponse;
 import matchuri.backend.api.member.dto.LoginIdExistsResponse;
 import matchuri.backend.api.member.dto.MemberProfileResponse;
 import matchuri.backend.api.member.dto.NicknameExistsResponse;
+import matchuri.backend.api.member.dto.RegisterLocalMemberRequest;
+import matchuri.backend.api.member.dto.RegisterLocalMemberResponse;
 import matchuri.backend.api.member.dto.UpdateMemberBasicInfoRequest;
 import matchuri.backend.api.member.dto.UpdateMemberResponse;
 import matchuri.backend.api.member.dto.UpdateMemberTasteProfileRequest;
@@ -22,11 +24,91 @@ import matchuri.backend.global.api.ApiResponse;
 public interface MemberApi {
 
     @Operation(
-            summary = "회원 가입",
+            summary = "자체 회원가입 통합",
             description = """
-                    일반 회원 계정을 생성합니다.
+                    자체 회원가입에서 `loginId`, `password`, 필수 약관 동의, `nickname`을 하나의 요청으로 원자적으로 처리합니다.
 
                     - 가입 성공 시 자동 로그인되지 않습니다.
+                    - 필수 약관 2종과 최신 버전이 모두 포함되어야 합니다.
+                    - 닉네임은 기본값 없이 필수 입력입니다.
+                    - 처리 중 하나라도 실패하면 회원과 약관 동의 기록은 저장되지 않습니다.
+                    """,
+            security = {}
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "통합 회원가입 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = RegisterLocalMemberResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "data": {
+                                                "memberId": 1,
+                                                "loginId": "tester01",
+                                                "nickname": "점심탐험가",
+                                                "createdAt": "2026-04-14T20:15:30"
+                                              },
+                                              "error": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "이미 사용 중인 loginId 또는 nickname",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "duplicateLoginId",
+                                            value = """
+                                                    {
+                                                      "success": false,
+                                                      "data": null,
+                                                      "error": {
+                                                        "status": 409,
+                                                        "code": "MEMBER_DUPLICATE_LOGIN_ID",
+                                                        "message": "이미 사용 중인 로그인 아이디입니다. loginId : tester01",
+                                                        "details": []
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "duplicateNickname",
+                                            value = """
+                                                    {
+                                                      "success": false,
+                                                      "data": null,
+                                                      "error": {
+                                                        "status": 409,
+                                                        "code": "MEMBER_DUPLICATE_NICKNAME",
+                                                        "message": "이미 사용 중인 닉네임입니다. nickname : 점심탐험가",
+                                                        "details": []
+                                                      }
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+    })
+    ApiResponse<RegisterLocalMemberResponse> registerLocalMember(RegisterLocalMemberRequest request);
+
+    @Operation(
+            summary = "회원 가입 레거시 생성",
+            description = """
+                    일반 회원 계정을 최소 정보(`loginId`, `password`)만으로 생성합니다.
+
+                    - 가입 성공 시 자동 로그인되지 않습니다.
+                    - 필수 약관 동의와 닉네임 입력은 포함되지 않습니다.
+                    - 신규 구현은 `POST /api/v1/members/signup` 사용을 우선 권장합니다.
                     - 응답에는 생성된 회원의 `memberId`, `loginId`, `createdAt`이 포함됩니다.
                     - 가입 직후 로그인 화면으로 이동하거나, 같은 `loginId`로 로그인 API를 이어 호출하면 됩니다.
                     """,

--- a/src/main/java/matchuri/backend/api/member/MemberController.java
+++ b/src/main/java/matchuri/backend/api/member/MemberController.java
@@ -7,6 +7,8 @@ import matchuri.backend.api.member.dto.CreateMemberResponse;
 import matchuri.backend.api.member.dto.LoginIdExistsResponse;
 import matchuri.backend.api.member.dto.MemberProfileResponse;
 import matchuri.backend.api.member.dto.NicknameExistsResponse;
+import matchuri.backend.api.member.dto.RegisterLocalMemberRequest;
+import matchuri.backend.api.member.dto.RegisterLocalMemberResponse;
 import matchuri.backend.api.member.dto.UpdateMemberBasicInfoRequest;
 import matchuri.backend.api.member.dto.UpdateMemberResponse;
 import matchuri.backend.api.member.dto.UpdateMemberTasteProfileRequest;
@@ -32,6 +34,18 @@ public class MemberController implements MemberApi {
 
     private final MemberService memberService;
     private final MemberMapper memberMapper;
+
+    @Override
+    @PostMapping("/signup")
+    public ApiResponse<RegisterLocalMemberResponse> registerLocalMember(
+            @Valid @RequestBody RegisterLocalMemberRequest request
+    ) {
+        var command = memberMapper.toRegisterLocalMemberCommand(request);
+        var result = memberService.registerLocalMember(command);
+        RegisterLocalMemberResponse response = memberMapper.toRegisterLocalMemberResponse(result);
+
+        return ApiResponse.success(response);
+    }
 
     @Override
     @PostMapping

--- a/src/main/java/matchuri/backend/api/member/dto/RegisterLocalMemberRequest.java
+++ b/src/main/java/matchuri/backend/api/member/dto/RegisterLocalMemberRequest.java
@@ -9,6 +9,26 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 import matchuri.backend.domain.member.entity.Member;
 
+@Schema(
+        name = "RegisterLocalMemberRequest",
+        example = """
+                {
+                  "loginId": "tester2372",
+                  "password": "P@ssw0rd!",
+                  "nickname": "점심탐험가123",
+                  "agreements": [
+                    {
+                      "agreementType": "TERMS_OF_SERVICE",
+                      "agreementVersion": "2026-04-10"
+                    },
+                    {
+                      "agreementType": "PRIVACY_POLICY",
+                      "agreementVersion": "2026-04-10"
+                    }
+                  ]
+                }
+                """
+)
 public record RegisterLocalMemberRequest(
         @Schema(
                 description = "회원 가입에 사용할 loginId입니다. 영문, 숫자, 점(.), 밑줄(_), 하이픈(-)만 사용할 수 있습니다.",
@@ -44,13 +64,36 @@ public record RegisterLocalMemberRequest(
         @Size(max = Member.NICKNAME_MAX_SIZE, message = "nickname은 " + Member.NICKNAME_MAX_SIZE + "자를 초과할 수 없습니다.")
         String nickname,
 
+        @Schema(
+                description = "필수 약관 동의 목록입니다. 현재는 서비스 이용약관과 개인정보 처리방침 2종을 모두 포함해야 합니다.",
+                example = """
+                        [
+                          {
+                            "agreementType": "TERMS_OF_SERVICE",
+                            "agreementVersion": "2026-04-10"
+                          },
+                          {
+                            "agreementType": "PRIVACY_POLICY",
+                            "agreementVersion": "2026-04-10"
+                          }
+                        ]
+                        """
+        )
         @NotEmpty(message = "agreements는 비어 있을 수 없습니다.")
         List<@Valid AgreementConsentRequest> agreements
 ) {
 
     public record AgreementConsentRequest(
+            @Schema(
+                    description = "약관 종류입니다.",
+                    example = "TERMS_OF_SERVICE"
+            )
             @NotBlank(message = "agreementType은 비어 있을 수 없습니다.")
             String agreementType,
+            @Schema(
+                    description = "동의한 약관 버전입니다.",
+                    example = "2026-04-10"
+            )
             @NotBlank(message = "agreementVersion은 비어 있을 수 없습니다.")
             String agreementVersion
     ) {

--- a/src/main/java/matchuri/backend/api/member/dto/RegisterLocalMemberRequest.java
+++ b/src/main/java/matchuri/backend/api/member/dto/RegisterLocalMemberRequest.java
@@ -1,0 +1,58 @@
+package matchuri.backend.api.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import matchuri.backend.domain.member.entity.Member;
+
+public record RegisterLocalMemberRequest(
+        @Schema(
+                description = "회원 가입에 사용할 loginId입니다. 영문, 숫자, 점(.), 밑줄(_), 하이픈(-)만 사용할 수 있습니다.",
+                example = "tester2372",
+                maxLength = Member.LOGIN_ID_MAX_SIZE
+        )
+        @NotBlank(message = "loginId는 비어 있을 수 없습니다.")
+        @Size(max = Member.LOGIN_ID_MAX_SIZE, message = "loginId는 " + Member.LOGIN_ID_MAX_SIZE + "자를 초과할 수 없습니다.")
+        @Pattern(regexp = Member.LOGIN_ID_PATTERN, message = "loginId는 영문, 숫자, 점(.), 밑줄(_), 하이픈(-)만 사용할 수 있습니다.")
+        String loginId,
+
+        @Schema(
+                description = "회원 가입 비밀번호입니다. " + Member.PASSWORD_MIN_SIZE + "자 이상 " + Member.PASSWORD_MAX_SIZE + "자 이하를 사용합니다.",
+                example = "P@ssw0rd!",
+                minLength = Member.PASSWORD_MIN_SIZE,
+                maxLength = Member.PASSWORD_MAX_SIZE
+        )
+        @NotBlank(message = "password는 비어 있을 수 없습니다.")
+        @Size(
+                min = Member.PASSWORD_MIN_SIZE,
+                max = Member.PASSWORD_MAX_SIZE,
+                message = "password는 " + Member.PASSWORD_MIN_SIZE + "자 이상 " + Member.PASSWORD_MAX_SIZE + "자 이하여야 합니다."
+        )
+        String password,
+
+        @Schema(
+                description = "가입 완료 전에 반드시 설정해야 하는 닉네임입니다.",
+                example = "점심탐험가123",
+                maxLength = Member.NICKNAME_MAX_SIZE
+        )
+        @NotBlank(message = "nickname은 비어 있을 수 없습니다.")
+        @Pattern(regexp = "^(?!\\s*$).+", message = "nickname은 비어 있을 수 없습니다.")
+        @Size(max = Member.NICKNAME_MAX_SIZE, message = "nickname은 " + Member.NICKNAME_MAX_SIZE + "자를 초과할 수 없습니다.")
+        String nickname,
+
+        @NotEmpty(message = "agreements는 비어 있을 수 없습니다.")
+        List<@Valid AgreementConsentRequest> agreements
+) {
+
+    public record AgreementConsentRequest(
+            @NotBlank(message = "agreementType은 비어 있을 수 없습니다.")
+            String agreementType,
+            @NotBlank(message = "agreementVersion은 비어 있을 수 없습니다.")
+            String agreementVersion
+    ) {
+    }
+}

--- a/src/main/java/matchuri/backend/api/member/dto/RegisterLocalMemberResponse.java
+++ b/src/main/java/matchuri/backend/api/member/dto/RegisterLocalMemberResponse.java
@@ -1,0 +1,19 @@
+package matchuri.backend.api.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record RegisterLocalMemberResponse(
+        @Schema(description = "생성된 회원 ID입니다.", example = "1")
+        Long memberId,
+
+        @Schema(description = "가입 완료된 loginId입니다.", example = "tester01")
+        String loginId,
+
+        @Schema(description = "가입 시 확정된 닉네임입니다.", example = "점심탐험가")
+        String nickname,
+
+        @Schema(description = "회원 가입 완료 시각입니다.", example = "2026-04-14T20:15:30")
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/matchuri/backend/api/member/mapper/MemberMapper.java
+++ b/src/main/java/matchuri/backend/api/member/mapper/MemberMapper.java
@@ -7,6 +7,8 @@ import matchuri.backend.api.member.dto.LoginIdExistsResponse;
 import matchuri.backend.api.member.dto.MemberProfileResponse;
 import matchuri.backend.api.member.dto.NicknameExistsResponse;
 import matchuri.backend.api.member.dto.MemberTasteProfileSummaryResponse;
+import matchuri.backend.api.member.dto.RegisterLocalMemberRequest;
+import matchuri.backend.api.member.dto.RegisterLocalMemberResponse;
 import matchuri.backend.api.member.dto.UpdateMemberResponse;
 import matchuri.backend.api.member.dto.WithdrawMemberResponse;
 import matchuri.backend.domain.auth.service.LoginCommand;
@@ -16,6 +18,9 @@ import matchuri.backend.domain.auth.service.OAuth2ExchangeCommand;
 import matchuri.backend.domain.member.service.CreateMemberCommand;
 import matchuri.backend.domain.member.service.CreateMemberResult;
 import matchuri.backend.domain.member.service.MemberProfileResult;
+import matchuri.backend.domain.member.service.RegisterLocalMemberCommand;
+import matchuri.backend.domain.member.service.RegisterLocalMemberResult;
+import matchuri.backend.domain.member.service.SubmitRequiredAgreementsCommand;
 import matchuri.backend.domain.member.service.UpdateMemberBasicInfoCommand;
 import matchuri.backend.domain.member.service.UpdateMemberResult;
 import matchuri.backend.domain.member.service.UpdateMemberTasteProfileCommand;
@@ -41,6 +46,29 @@ public class MemberMapper {
 
     public CreateMemberResponse toCreateMemberResponse(CreateMemberResult result) {
         return new CreateMemberResponse(result.memberId(), result.loginId(), result.createdAt());
+    }
+
+    public RegisterLocalMemberCommand toRegisterLocalMemberCommand(RegisterLocalMemberRequest request) {
+        return new RegisterLocalMemberCommand(
+                request.loginId(),
+                request.password(),
+                request.nickname(),
+                request.agreements().stream()
+                        .map(agreement -> new SubmitRequiredAgreementsCommand.AgreementConsentCommand(
+                                agreement.agreementType(),
+                                agreement.agreementVersion()
+                        ))
+                        .toList()
+        );
+    }
+
+    public RegisterLocalMemberResponse toRegisterLocalMemberResponse(RegisterLocalMemberResult result) {
+        return new RegisterLocalMemberResponse(
+                result.memberId(),
+                result.loginId(),
+                result.nickname(),
+                result.createdAt()
+        );
     }
 
     public LoginCommand toLoginCommand(String loginId, String password) {

--- a/src/main/java/matchuri/backend/domain/member/entity/Member.java
+++ b/src/main/java/matchuri/backend/domain/member/entity/Member.java
@@ -108,9 +108,14 @@ public class Member extends BaseEntity {
     }
 
     public static Member createWithEncodedPassword(String loginId, String passwordHash) {
+        return createWithEncodedPassword(loginId, passwordHash, null);
+    }
+
+    public static Member createWithEncodedPassword(String loginId, String passwordHash, String nickname) {
         return Member.builder()
                 .loginId(loginId)
                 .passwordHash(passwordHash)
+                .nickname(nickname)
                 .social(false)
                 .socialProviderType(null)
                 .socialProviderUserId(null)

--- a/src/main/java/matchuri/backend/domain/member/service/MemberAgreementServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberAgreementServiceImpl.java
@@ -1,13 +1,10 @@
 package matchuri.backend.domain.member.service;
 
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
-import matchuri.backend.domain.member.MemberAgreementErrorCode;
 import matchuri.backend.domain.member.MemberErrorCode;
 import matchuri.backend.domain.member.entity.AgreementType;
 import matchuri.backend.domain.member.entity.Member;
@@ -28,6 +25,7 @@ public class MemberAgreementServiceImpl implements MemberAgreementService {
 
     private final MemberAgreementRepository memberAgreementRepository;
     private final MemberRepository memberRepository;
+    private final RequiredAgreementRequestValidator requiredAgreementRequestValidator;
     private final AuthenticationFacade authenticationFacade;
 
     @Override
@@ -41,7 +39,7 @@ public class MemberAgreementServiceImpl implements MemberAgreementService {
     public RequiredAgreementStatusResult submitRequiredAgreements(SubmitRequiredAgreementsCommand command) {
         Member member = getCurrentActiveMember();
 
-        Map<AgreementType, String> requestedVersions = validateAndIndex(command.agreements());
+        Map<AgreementType, String> requestedVersions = requiredAgreementRequestValidator.validateAndIndex(command.agreements());
         for (AgreementType requiredType : RequiredAgreementVersions.requiredTypes()) {
             String requiredVersion = RequiredAgreementVersions.getRequiredVersion(requiredType);
             if (!memberAgreementRepository.existsByMemberIdAndAgreementTypeAndAgreementVersion(
@@ -72,45 +70,6 @@ public class MemberAgreementServiceImpl implements MemberAgreementService {
                 .toList();
 
         return new RequiredAgreementStatusResult(missingTypes.isEmpty(), missingTypes);
-    }
-
-    private Map<AgreementType, String> validateAndIndex(List<SubmitRequiredAgreementsCommand.AgreementConsentCommand> agreements) {
-        Map<AgreementType, String> indexed = new EnumMap<>(AgreementType.class);
-        if (agreements != null) {
-            for (SubmitRequiredAgreementsCommand.AgreementConsentCommand agreement : agreements) {
-                AgreementType agreementType = AgreementType.from(agreement.agreementType());
-                if (agreementType == null) {
-                    throw new BusinessException(
-                            MemberAgreementErrorCode.INVALID_TYPE,
-                            MemberAgreementErrorCode.INVALID_TYPE.format(agreement.agreementType())
-                    );
-                }
-
-                String requiredVersion = RequiredAgreementVersions.getRequiredVersion(agreementType);
-                if (!requiredVersion.equals(agreement.agreementVersion())) {
-                    throw new BusinessException(
-                            MemberAgreementErrorCode.VERSION_MISMATCH,
-                            MemberAgreementErrorCode.VERSION_MISMATCH.format(agreementType.name(), agreement.agreementVersion())
-                    );
-                }
-
-                indexed.put(agreementType, agreement.agreementVersion());
-            }
-        }
-
-        Set<AgreementType> requiredTypes = RequiredAgreementVersions.requiredTypes();
-        List<AgreementType> missingTypes = new ArrayList<>(requiredTypes.stream()
-                .filter(type -> !indexed.containsKey(type))
-                .sorted(Comparator.comparing(Enum::name))
-                .toList());
-        if (!missingTypes.isEmpty()) {
-            throw new BusinessException(
-                    MemberAgreementErrorCode.REQUIRED_TYPES_MISSING,
-                    MemberAgreementErrorCode.REQUIRED_TYPES_MISSING.format(missingTypes)
-            );
-        }
-
-        return indexed;
     }
 
     private Member getCurrentActiveMember() {

--- a/src/main/java/matchuri/backend/domain/member/service/MemberService.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberService.java
@@ -6,6 +6,8 @@ public interface MemberService {
 
     boolean existsByNickname(String nickname);
 
+    RegisterLocalMemberResult registerLocalMember(RegisterLocalMemberCommand command);
+
     CreateMemberResult createMember(CreateMemberCommand command);
 
     MemberProfileResult getMyProfile();

--- a/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
@@ -3,8 +3,10 @@ package matchuri.backend.domain.member.service;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.domain.member.MemberErrorCode;
 import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.entity.MemberAgreement;
 import matchuri.backend.domain.member.entity.MemberStatus;
 import matchuri.backend.domain.member.entity.MemberTasteProfile;
+import matchuri.backend.domain.member.repository.MemberAgreementRepository;
 import matchuri.backend.domain.member.repository.MemberRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileRepository;
 import matchuri.backend.global.exception.BusinessException;
@@ -21,7 +23,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
+    private final MemberAgreementRepository memberAgreementRepository;
     private final MemberTasteProfileRepository memberTasteProfileRepository;
+    private final RequiredAgreementRequestValidator requiredAgreementRequestValidator;
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationFacade authenticationFacade;
 
@@ -37,6 +41,25 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional
+    public RegisterLocalMemberResult registerLocalMember(RegisterLocalMemberCommand command) {
+        String passwordHash = passwordEncoder.encode(command.password());
+        Member member = createLocalMember(command.loginId(), passwordHash, command.nickname());
+
+        requiredAgreementRequestValidator.validateAndIndex(command.agreements())
+                .forEach((agreementType, agreementVersion) ->
+                        memberAgreementRepository.save(MemberAgreement.create(member, agreementType, agreementVersion))
+                );
+
+        return new RegisterLocalMemberResult(
+                member.getId(),
+                member.getLoginId(),
+                member.getNickname(),
+                member.getCreatedAt()
+        );
+    }
+
+    @Override
+    @Transactional
     public CreateMemberResult createMember(CreateMemberCommand command) {
         if (memberRepository.existsByLoginId(command.loginId())) {
             throw new BusinessException(
@@ -46,7 +69,7 @@ public class MemberServiceImpl implements MemberService {
         }
 
         String passwordHash = passwordEncoder.encode(command.password());
-        Member member = createLocalMember(command.loginId(), passwordHash);
+        Member member = createLocalMember(command.loginId(), passwordHash, null);
 
         return new CreateMemberResult(member.getId(), member.getLoginId(), member.getCreatedAt());
     }
@@ -122,11 +145,18 @@ public class MemberServiceImpl implements MemberService {
         }
     }
 
-    private Member createLocalMember(String loginId, String passwordHash) {
+    private Member createLocalMember(String loginId, String passwordHash, String nickname) {
+        validateNicknameDuplication(null, nickname);
         try {
-            Member newMember = Member.createWithEncodedPassword(loginId, passwordHash);
+            Member newMember = Member.createWithEncodedPassword(loginId, passwordHash, nickname);
             return memberRepository.saveAndFlush(newMember);
         } catch (DataIntegrityViolationException exception) {
+            if (nickname != null && memberRepository.existsByNickname(nickname)) {
+                throw new BusinessException(
+                        MemberErrorCode.DUPLICATE_NICKNAME,
+                        MemberErrorCode.DUPLICATE_NICKNAME.format(nickname)
+                );
+            }
             throw new BusinessException(
                     MemberErrorCode.DUPLICATE_LOGIN_ID,
                     MemberErrorCode.DUPLICATE_LOGIN_ID.format(loginId)
@@ -135,7 +165,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     private void validateNicknameDuplication(Member member, String nickname) {
-        if (nickname == null || nickname.equals(member.getNickname())) {
+        if (nickname == null || (member != null && nickname.equals(member.getNickname()))) {
             return;
         }
 

--- a/src/main/java/matchuri/backend/domain/member/service/RegisterLocalMemberCommand.java
+++ b/src/main/java/matchuri/backend/domain/member/service/RegisterLocalMemberCommand.java
@@ -1,0 +1,11 @@
+package matchuri.backend.domain.member.service;
+
+import java.util.List;
+
+public record RegisterLocalMemberCommand(
+        String loginId,
+        String password,
+        String nickname,
+        List<SubmitRequiredAgreementsCommand.AgreementConsentCommand> agreements
+) {
+}

--- a/src/main/java/matchuri/backend/domain/member/service/RegisterLocalMemberResult.java
+++ b/src/main/java/matchuri/backend/domain/member/service/RegisterLocalMemberResult.java
@@ -1,0 +1,11 @@
+package matchuri.backend.domain.member.service;
+
+import java.time.LocalDateTime;
+
+public record RegisterLocalMemberResult(
+        Long memberId,
+        String loginId,
+        String nickname,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/matchuri/backend/domain/member/service/RequiredAgreementRequestValidator.java
+++ b/src/main/java/matchuri/backend/domain/member/service/RequiredAgreementRequestValidator.java
@@ -1,0 +1,55 @@
+package matchuri.backend.domain.member.service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import matchuri.backend.domain.member.MemberAgreementErrorCode;
+import matchuri.backend.domain.member.entity.AgreementType;
+import matchuri.backend.global.exception.BusinessException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RequiredAgreementRequestValidator {
+
+    public Map<AgreementType, String> validateAndIndex(List<SubmitRequiredAgreementsCommand.AgreementConsentCommand> agreements) {
+        Map<AgreementType, String> indexed = new EnumMap<>(AgreementType.class);
+        if (agreements != null) {
+            for (SubmitRequiredAgreementsCommand.AgreementConsentCommand agreement : agreements) {
+                AgreementType agreementType = AgreementType.from(agreement.agreementType());
+                if (agreementType == null) {
+                    throw new BusinessException(
+                            MemberAgreementErrorCode.INVALID_TYPE,
+                            MemberAgreementErrorCode.INVALID_TYPE.format(agreement.agreementType())
+                    );
+                }
+
+                String requiredVersion = RequiredAgreementVersions.getRequiredVersion(agreementType);
+                if (!requiredVersion.equals(agreement.agreementVersion())) {
+                    throw new BusinessException(
+                            MemberAgreementErrorCode.VERSION_MISMATCH,
+                            MemberAgreementErrorCode.VERSION_MISMATCH.format(agreementType.name(), agreement.agreementVersion())
+                    );
+                }
+
+                indexed.put(agreementType, agreement.agreementVersion());
+            }
+        }
+
+        Set<AgreementType> requiredTypes = RequiredAgreementVersions.requiredTypes();
+        List<AgreementType> missingTypes = new ArrayList<>(requiredTypes.stream()
+                .filter(type -> !indexed.containsKey(type))
+                .sorted(Comparator.comparing(Enum::name))
+                .toList());
+        if (!missingTypes.isEmpty()) {
+            throw new BusinessException(
+                    MemberAgreementErrorCode.REQUIRED_TYPES_MISSING,
+                    MemberAgreementErrorCode.REQUIRED_TYPES_MISSING.format(missingTypes)
+            );
+        }
+
+        return indexed;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -45,6 +45,7 @@ matchuri:
       - /docs/**
       - /api/v1/health
     public-post-api-patterns:
+      - /api/v1/members/signup
       - /api/v1/members
       - /api/v1/auth/login
       - /api/v1/auth/refresh

--- a/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
@@ -85,6 +85,80 @@ class MemberAuthIntegrationTest {
     }
 
     @Test
+    @DisplayName("자체 회원가입 통합 API는 약관과 닉네임을 함께 저장하지만 로그인 상태는 만들지 않는다")
+    void registerLocalMember() throws Exception {
+        mockMvc.perform(post("/api/v1/members/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "loginId": "signup-user",
+                                  "password": "P@ssw0rd!",
+                                  "nickname": "점심탐험가",
+                                  "agreements": [
+                                    {
+                                      "agreementType": "TERMS_OF_SERVICE",
+                                      "agreementVersion": "2026-04-10"
+                                    },
+                                    {
+                                      "agreementType": "PRIVACY_POLICY",
+                                      "agreementVersion": "2026-04-10"
+                                    }
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.loginId").value("signup-user"))
+                .andExpect(jsonPath("$.data.nickname").value("점심탐험가"))
+                .andExpect(jsonPath("$.data.memberId").isNumber())
+                .andExpect(header().doesNotExist(HttpHeaders.SET_COOKIE));
+
+        Member member = memberRepository.findByLoginId("signup-user").orElseThrow();
+        assertThat(member.getPasswordHash()).isNotEqualTo("P@ssw0rd!");
+        assertThat(member.getNickname()).isEqualTo("점심탐험가");
+        assertThat(memberAgreementRepository.count()).isEqualTo(2);
+
+        mockMvc.perform(get("/api/v1/members/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("AUTH_TOKEN_MISSING"));
+
+        AuthSession authSession = login("signup-user", "P@ssw0rd!");
+        mockMvc.perform(get("/api/v1/members/me")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(authSession.accessToken())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nickname").value("점심탐험가"));
+    }
+
+    @Test
+    @DisplayName("자체 회원가입 통합 API에서 약관 검증이 실패하면 회원과 약관 기록이 남지 않는다")
+    void registerLocalMemberRollsBackWhenAgreementValidationFails() throws Exception {
+        mockMvc.perform(post("/api/v1/members/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "loginId": "rollback-user",
+                                  "password": "P@ssw0rd!",
+                                  "nickname": "롤백검증",
+                                  "agreements": [
+                                    {
+                                      "agreementType": "TERMS_OF_SERVICE",
+                                      "agreementVersion": "2026-03-01"
+                                    },
+                                    {
+                                      "agreementType": "PRIVACY_POLICY",
+                                      "agreementVersion": "2026-04-10"
+                                    }
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("MEMBER_AGREEMENT_VERSION_MISMATCH"));
+
+        assertThat(memberRepository.findByLoginId("rollback-user")).isEmpty();
+        assertThat(memberAgreementRepository.count()).isZero();
+    }
+
+    @Test
     @DisplayName("회원 가입 시 비밀번호는 해시로 저장되고 생성 응답을 반환한다")
     void createMember() throws Exception {
         mockMvc.perform(post("/api/v1/members")

--- a/src/test/java/matchuri/backend/domain/member/service/MemberAgreementServiceImplTest.java
+++ b/src/test/java/matchuri/backend/domain/member/service/MemberAgreementServiceImplTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,6 +36,9 @@ class MemberAgreementServiceImplTest {
 
     @Mock
     private AuthenticationFacade authenticationFacade;
+
+    @Spy
+    private RequiredAgreementRequestValidator requiredAgreementRequestValidator;
 
     @InjectMocks
     private MemberAgreementServiceImpl memberAgreementService;

--- a/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
+++ b/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
@@ -2,14 +2,20 @@ package matchuri.backend.domain.member.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.verify;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+import java.util.Map;
 import matchuri.backend.domain.member.MemberErrorCode;
+import matchuri.backend.domain.member.entity.AgreementType;
 import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.entity.MemberAgreement;
 import matchuri.backend.domain.member.entity.MemberRole;
 import matchuri.backend.domain.member.entity.MemberStatus;
+import matchuri.backend.domain.member.repository.MemberAgreementRepository;
 import matchuri.backend.domain.member.repository.MemberRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileRepository;
 import matchuri.backend.global.exception.BusinessException;
@@ -31,7 +37,13 @@ class MemberServiceImplTest {
     private MemberRepository memberRepository;
 
     @Mock
+    private MemberAgreementRepository memberAgreementRepository;
+
+    @Mock
     private MemberTasteProfileRepository memberTasteProfileRepository;
+
+    @Mock
+    private RequiredAgreementRequestValidator requiredAgreementRequestValidator;
 
     @Mock
     private PasswordEncoder passwordEncoder;
@@ -41,6 +53,47 @@ class MemberServiceImplTest {
 
     @InjectMocks
     private MemberServiceImpl memberService;
+
+    @Test
+    @DisplayName("자체 회원가입 통합은 회원과 필수 약관을 함께 저장한다")
+    void registerLocalMemberSavesMemberAndRequiredAgreements() {
+        RegisterLocalMemberCommand command = new RegisterLocalMemberCommand(
+                "tester01",
+                "P@ssw0rd!",
+                "점심탐험가",
+                List.of(
+                        new SubmitRequiredAgreementsCommand.AgreementConsentCommand("TERMS_OF_SERVICE", "2026-04-10"),
+                        new SubmitRequiredAgreementsCommand.AgreementConsentCommand("PRIVACY_POLICY", "2026-04-10")
+                )
+        );
+
+        Member savedMember = Member.builder()
+                .id(1L)
+                .loginId("tester01")
+                .passwordHash("encoded-password")
+                .nickname("점심탐험가")
+                .memberRole(MemberRole.MEMBER)
+                .status(MemberStatus.ACTIVE)
+                .social(false)
+                .build();
+
+        when(memberRepository.existsByNickname("점심탐험가")).thenReturn(false);
+        when(passwordEncoder.encode("P@ssw0rd!")).thenReturn("encoded-password");
+        when(memberRepository.saveAndFlush(any(Member.class))).thenReturn(savedMember);
+        when(requiredAgreementRequestValidator.validateAndIndex(any())).thenReturn(Map.of(
+                AgreementType.TERMS_OF_SERVICE, "2026-04-10",
+                AgreementType.PRIVACY_POLICY, "2026-04-10"
+        ));
+
+        RegisterLocalMemberResult result = memberService.registerLocalMember(command);
+
+        assertThat(result.memberId()).isEqualTo(1L);
+        assertThat(result.loginId()).isEqualTo("tester01");
+        assertThat(result.nickname()).isEqualTo("점심탐험가");
+        verify(memberRepository).saveAndFlush(any(Member.class));
+        verify(requiredAgreementRequestValidator).validateAndIndex(command.agreements());
+        verify(memberAgreementRepository, times(2)).save(any(MemberAgreement.class));
+    }
 
     @Test
     @DisplayName("회원 가입 저장 충돌은 MEMBER_DUPLICATE_LOGIN_ID로 번역한다")

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -42,6 +42,7 @@ matchuri:
       - /login/oauth2/code/**
       - /docs/**
     public-post-api-patterns:
+      - /api/v1/members/signup
       - /api/v1/members
       - /api/v1/auth/login
       - /api/v1/auth/refresh


### PR DESCRIPTION
## 관련 이슈
#69 

## 📝 작업 내용
- `POST api/v1/members/signup` 추가
- 기존의 회원가입과 호환성을 위해 새로운 API url로 생성
  - 이에 대해 추가적으로 의논 

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
