### PR TITLE
[Chore] Backend CI을 SSM 방식으로 전환

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -16,19 +16,22 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     env:
-      INFISICAL_API_URL: ${{ secrets.INFISICAL_API_URL || 'https://app.infisical.com' }}
+      INFISICAL_API_URL: ${{ secrets.INFISICAL_API_URL }}
       INFISICAL_PROJECT_SLUG: ${{ secrets.INFISICAL_PROJECT_SLUG }}
-      INFISICAL_ENV_SLUG: ${{ secrets.INFISICAL_ENV_SLUG || 'staging' }}
+      INFISICAL_ENV_SLUG: ${{ secrets.INFISICAL_ENV_SLUG }}
       INFISICAL_IDENTITY_ID: ${{ secrets.INFISICAL_IDENTITY_ID }}
-      EC2_HOST: ${{ secrets.EC2_HOST }}
-      EC2_PORT: ${{ secrets.EC2_PORT || '22' }}
-      EC2_USER: ${{ secrets.EC2_USER }}
       MATCHURI_SPRING_PROFILE: ${{ secrets.MATCHURI_SPRING_PROFILE }}
-      DEPLOY_RELEASE_PREFIX: ${{ secrets.DEPLOY_RELEASE_PREFIX || 'backend-staging' }}
-      REMOTE_RELEASES_DIR: ${{ secrets.REMOTE_RELEASES_DIR || '/opt/matchuri/backend/releases' }}
-      REMOTE_DEPLOY_SCRIPT: ${{ secrets.REMOTE_DEPLOY_SCRIPT || '/opt/matchuri/backend/scripts/deploy.sh' }}
-      REMOTE_ENV_FILE: ${{ secrets.REMOTE_ENV_FILE || '/etc/matchuri/backend.env' }}
-      REMOTE_SERVICE_NAME: ${{ secrets.REMOTE_SERVICE_NAME || 'matchuri-backend' }}
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      AWS_ROLE_TO_ASSUME: ${{ vars.AWS_ROLE_TO_ASSUME }}
+      AWS_ROLE_SESSION_NAME: ${{ vars.AWS_ROLE_SESSION_NAME }}
+      AWS_SSM_TARGET_INSTANCE_ID: ${{ vars.AWS_SSM_TARGET_INSTANCE_ID }}
+      DEPLOY_S3_BUCKET: ${{ vars.DEPLOY_S3_BUCKET }}
+      DEPLOY_S3_PREFIX: ${{ vars.DEPLOY_S3_PREFIX }}
+      DEPLOY_RELEASE_PREFIX: ${{ vars.DEPLOY_RELEASE_PREFIX }}
+      REMOTE_RELEASES_DIR: ${{ vars.REMOTE_RELEASES_DIR }}
+      REMOTE_DEPLOY_SCRIPT: ${{ vars.REMOTE_DEPLOY_SCRIPT }}
+      REMOTE_ENV_FILE: ${{ vars.REMOTE_ENV_FILE }}
+      REMOTE_SERVICE_NAME: ${{ vars.REMOTE_SERVICE_NAME }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,9 +42,10 @@ jobs:
           required_vars=(
             INFISICAL_PROJECT_SLUG
             INFISICAL_IDENTITY_ID
-            EC2_HOST
-            EC2_USER
             MATCHURI_SPRING_PROFILE
+            AWS_ROLE_TO_ASSUME
+            AWS_SSM_TARGET_INSTANCE_ID
+            DEPLOY_S3_BUCKET
           )
 
           for var_name in "${required_vars[@]}"; do
@@ -64,7 +68,6 @@ jobs:
         run: |
           set -euo pipefail
           required_secrets=(
-            EC2_SSH_PRIVATE_KEY
             MATCHURI_FRONTEND_ORIGIN
             MATCHURI_DB_PW
             MATCHURI_JWT_SECRET
@@ -123,51 +126,115 @@ jobs:
             printenv | grep '^MATCHURI_' | grep -v '^MATCHURI_SPRING_PROFILE=' | sort
           } > backend.env
 
-      - name: Prepare SSH key
-        run: |
-          set -euo pipefail
-          mkdir -p ~/.ssh
-          chmod 700 ~/.ssh
-          printf '%s\n' "${EC2_SSH_PRIVATE_KEY}" > ~/.ssh/matchuri_ec2
-          chmod 600 ~/.ssh/matchuri_ec2
-          ssh-keyscan -p "${EC2_PORT}" "${EC2_HOST}" >> ~/.ssh/known_hosts
-          chmod 644 ~/.ssh/known_hosts
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ env.AWS_ROLE_SESSION_NAME }}
 
-      - name: Upload release artifact and env file
+      - name: Upload deploy assets to S3
         run: |
           set -euo pipefail
-          scp -P "${EC2_PORT}" -i ~/.ssh/matchuri_ec2 "${JAR_PATH}" "${EC2_USER}@${EC2_HOST}:/tmp/${RELEASE_FILE}"
-          scp -P "${EC2_PORT}" -i ~/.ssh/matchuri_ec2 backend.env "${EC2_USER}@${EC2_HOST}:/tmp/backend.env"
+          aws s3 cp "${JAR_PATH}" "s3://${DEPLOY_S3_BUCKET}/${DEPLOY_S3_PREFIX}/${RELEASE_FILE}"
+          aws s3 cp backend.env "s3://${DEPLOY_S3_BUCKET}/${DEPLOY_S3_PREFIX}/backend.env"
 
-      - name: Deploy on EC2
+      - name: Render SSM command payload
         run: |
           set -euo pipefail
-          ssh -p "${EC2_PORT}" -i ~/.ssh/matchuri_ec2 "${EC2_USER}@${EC2_HOST}" <<EOF
-          set -euo pipefail
-          sudo install -m 600 /tmp/backend.env "${REMOTE_ENV_FILE}"
-          sudo mv "/tmp/${RELEASE_FILE}" "${REMOTE_RELEASES_DIR}/${RELEASE_FILE}"
-          sudo chown matchuri:matchuri "${REMOTE_RELEASES_DIR}/${RELEASE_FILE}"
-          sudo MATCHURI_RELEASE_FILE="${RELEASE_FILE}" "${REMOTE_DEPLOY_SCRIPT}"
-          sudo systemctl status "${REMOTE_SERVICE_NAME}" --no-pager
-          EOF
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
 
-      - name: Verify service health
+          bucket = os.environ["DEPLOY_S3_BUCKET"]
+          prefix = os.environ["DEPLOY_S3_PREFIX"].strip("/")
+          release = os.environ["RELEASE_FILE"]
+          remote_env_file = os.environ["REMOTE_ENV_FILE"]
+          remote_releases_dir = os.environ["REMOTE_RELEASES_DIR"]
+          remote_deploy_script = os.environ["REMOTE_DEPLOY_SCRIPT"]
+          remote_service_name = os.environ["REMOTE_SERVICE_NAME"]
+
+          commands = [
+              "set -euo pipefail",
+              'TMP_ROOT="/tmp/matchuri-deploy"',
+              f'RELEASE_FILE="{release}"',
+              'mkdir -p "${TMP_ROOT}"',
+              f'aws s3 cp "s3://{bucket}/{prefix}/{release}" "${{TMP_ROOT}}/{release}"',
+              f'aws s3 cp "s3://{bucket}/{prefix}/backend.env" "${{TMP_ROOT}}/backend.env"',
+              f'sudo install -m 600 "${{TMP_ROOT}}/backend.env" "{remote_env_file}"',
+              f'sudo mv "${{TMP_ROOT}}/{release}" "{remote_releases_dir}/{release}"',
+              f'sudo chown matchuri:matchuri "{remote_releases_dir}/{release}"',
+              f'sudo MATCHURI_RELEASE_FILE="{release}" "{remote_deploy_script}"',
+              f'sudo systemctl status "{remote_service_name}" --no-pager',
+              "success=0",
+              "for attempt in {1..12}; do",
+              '  if curl --fail --silent --show-error http://127.0.0.1:8080/api/v1/health; then',
+              '    success=1',
+              '    break',
+              '  fi',
+              '  sleep 5',
+              'done',
+              'if [ "${success}" -ne 1 ]; then',
+              '  echo "Matchuri health check failed after deployment." >&2',
+              '  exit 1',
+              'fi',
+          ]
+
+          Path("ssm-parameters.json").write_text(
+              json.dumps({"commands": commands}),
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Send deploy command
         run: |
           set -euo pipefail
-          ssh -p "${EC2_PORT}" -i ~/.ssh/matchuri_ec2 "${EC2_USER}@${EC2_HOST}" 'bash -se' <<'EOF'
+          command_id="$(
+            aws ssm send-command \
+              --instance-ids "${AWS_SSM_TARGET_INSTANCE_ID}" \
+              --document-name "AWS-RunShellScript" \
+              --comment "Matchuri backend deploy ${GITHUB_SHA}" \
+              --parameters file://ssm-parameters.json \
+              --query "Command.CommandId" \
+              --output text
+          )"
+          echo "SSM_COMMAND_ID=${command_id}" >> "$GITHUB_ENV"
+
+      - name: Poll deploy command result
+        run: |
           set -euo pipefail
-          success=0
-          for attempt in {1..12}; do
-            if curl --fail --silent --show-error http://127.0.0.1:8080/api/v1/health >/tmp/matchuri-health.json; then
-              cat /tmp/matchuri-health.json
-              success=1
-              break
+          for attempt in {1..60}; do
+            status="$(
+              aws ssm get-command-invocation \
+                --command-id "${SSM_COMMAND_ID}" \
+                --instance-id "${AWS_SSM_TARGET_INSTANCE_ID}" \
+                --query "Status" \
+                --output text
+            )"
+            echo "Current SSM status: ${status}"
+            if [ "${status}" = "Success" ]; then
+              aws ssm get-command-invocation \
+                --command-id "${SSM_COMMAND_ID}" \
+                --instance-id "${AWS_SSM_TARGET_INSTANCE_ID}" \
+                --query "{Status:Status,StandardOutput:StandardOutputContent,StandardError:StandardErrorContent}"
+              exit 0
+            fi
+            if [ "${status}" = "Failed" ] || [ "${status}" = "Cancelled" ] || [ "${status}" = "TimedOut" ]; then
+              aws ssm get-command-invocation \
+                --command-id "${SSM_COMMAND_ID}" \
+                --instance-id "${AWS_SSM_TARGET_INSTANCE_ID}" \
+                --query "{Status:Status,StandardOutput:StandardOutputContent,StandardError:StandardErrorContent}"
+              exit 1
             fi
             sleep 5
           done
-          if [ "$success" -eq 1 ]; then
-            exit 0
-          fi
-          echo "Matchuri health check failed after waiting 60 seconds." >&2
+          echo "SSM command polling timed out." >&2
           exit 1
-          EOF
+
+      - name: Delete deploy assets from S3
+        if: success()
+        run: |
+          set -euo pipefail
+          aws s3 rm "s3://${DEPLOY_S3_BUCKET}/${DEPLOY_S3_PREFIX}/${RELEASE_FILE}"
+          aws s3 rm "s3://${DEPLOY_S3_BUCKET}/${DEPLOY_S3_PREFIX}/backend.env"


### PR DESCRIPTION
## 관련 이슈

Closes #74

## 작업 배경

기존 backend CD는 GitHub Actions에서 SSH private key를 준비한 뒤,
`scp`와 `ssh`를 사용해 EC2에 직접 배포했습니다.

이 방식은 GitHub-hosted runner의 접속을 위해 SSH 포트를 넓게 허용해야 하고,
배포용 private key를 별도로 관리해야 한다는 문제가 있습니다.

서버 내부의 release 디렉터리, `deploy.sh`, `systemd`와 health check 구조는
이미 동작하고 있으므로 이를 유지하면서 원격 접근 경로만 SSM으로 전환합니다.

## 작업 내용

- SSH private key, EC2 host·port·user 설정 제거
- GitHub Actions OIDC 기반 AWS IAM role assume 추가
- 빌드 JAR와 `backend.env`를 S3 임시 경로에 업로드
- SSM Run Command용 JSON payload 생성
- EC2에서 S3 배포 파일 다운로드
- 기존 `deploy.sh`와 `systemd`를 이용한 서비스 재기동
- SSM command ID를 기준으로 실행 상태 polling
- 성공 및 실패 시 SSM stdout/stderr 출력
- 내부 `/api/v1/health`를 이용한 배포 검증
- 배포 성공 후 S3 임시 객체 삭제

## 배포 흐름

1. Infisical에서 애플리케이션 시크릿을 가져옵니다.
2. Gradle로 실행 가능한 JAR를 빌드합니다.
3. GitHub Actions가 OIDC로 AWS role을 assume합니다.
4. JAR와 `backend.env`를 S3에 업로드합니다.
5. SSM Run Command가 EC2에서 배포 명령을 실행합니다.
6. EC2가 S3에서 파일을 내려받고 기존 배포 스크립트를 실행합니다.
7. `systemd` 상태와 내부 health endpoint를 확인합니다.
8. GitHub Actions가 SSM 실행 결과를 확인합니다.

## 설계 판단

CodeDeploy도 검토할 수 있지만 현재는 단일 EC2 기반 MVP입니다.
이미 서버 내부 배포 수명주기가 구축되어 있으므로 Agent, Deployment Group,
AppSpec과 lifecycle hook을 추가하기보다 SSM으로 접근 경로만 교체했습니다.

## 주요 변경사항

- [ ] API 요구사항 변경
- [ ] DB 구조 변경
- [x] 배포 인프라 및 권한 경로 변경
- [x] SSH 기반 자동 배포 제거

## 검증

- [x] backend build 및 test 통과
- [x] AWS OIDC role assume 확인
- [x] S3 업로드 및 EC2 다운로드 확인
- [x] SSM command 실행 및 상태 polling 확인
- [x] `systemd` 서비스 재기동 확인
- [x] 내부 `/api/v1/health` 성공 확인
- [x] 민감 정보가 코드에 하드코딩되지 않았는지 확인

## 알려진 제한 사항

- 단일 EC2 배포를 전제로 합니다.
- SSM command output의 장기 보관은 아직 적용하지 않습니다.
- 배포 실패 시 JAR 자동 rollback까지 수행하지는 않습니다.
- SSH는 자동 배포에서 제거하되 break-glass 수동 점검 경로로 제한적으로 유지할 수 있습니다.

## 후속 수정

초기 병합 이후 실제 workflow 실행에서 다음 문제가 발견되어 후속 PR로 보완했습니다.

- #76: `${{ ... }}`와 shell 변수 표현의 충돌 수정
- #77: SSM payload를 `bash -lc` 단일 실행 단위로 변경