### PR TITLE
[Chore] 환경변수에 대한 syntax error 수정

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -154,16 +154,17 @@ jobs:
           remote_releases_dir = os.environ["REMOTE_RELEASES_DIR"]
           remote_deploy_script = os.environ["REMOTE_DEPLOY_SCRIPT"]
           remote_service_name = os.environ["REMOTE_SERVICE_NAME"]
+          tmp_root_ref = "${TMP_ROOT}"
 
           commands = [
               "set -euo pipefail",
               'TMP_ROOT="/tmp/matchuri-deploy"',
               f'RELEASE_FILE="{release}"',
               'mkdir -p "${TMP_ROOT}"',
-              f'aws s3 cp "s3://{bucket}/{prefix}/{release}" "${{TMP_ROOT}}/{release}"',
-              f'aws s3 cp "s3://{bucket}/{prefix}/backend.env" "${{TMP_ROOT}}/backend.env"',
-              f'sudo install -m 600 "${{TMP_ROOT}}/backend.env" "{remote_env_file}"',
-              f'sudo mv "${{TMP_ROOT}}/{release}" "{remote_releases_dir}/{release}"',
+              f'aws s3 cp "s3://{bucket}/{prefix}/{release}" "{tmp_root_ref}/{release}"',
+              f'aws s3 cp "s3://{bucket}/{prefix}/backend.env" "{tmp_root_ref}/backend.env"',
+              f'sudo install -m 600 "{tmp_root_ref}/backend.env" "{remote_env_file}"',
+              f'sudo mv "{tmp_root_ref}/{release}" "{remote_releases_dir}/{release}"',
               f'sudo chown matchuri:matchuri "{remote_releases_dir}/{release}"',
               f'sudo MATCHURI_RELEASE_FILE="{release}" "{remote_deploy_script}"',
               f'sudo systemctl status "{remote_service_name}" --no-pager',


### PR DESCRIPTION
## 관련 이슈

Refs #74  
Follow-up to #75

## 문제

#75 병합 후 workflow를 실행하는 과정에서 SSM command payload를 생성하는
Python 코드의 `${{TMP_ROOT}}` 표현이 GitHub Actions의 expression 문법
`${{ ... }}`로 해석될 수 있어 syntax error가 발생했습니다.

의도한 값은 GitHub Actions expression이 아니라 EC2에서 실행될 shell 변수
`${TMP_ROOT}`였습니다.

## 원인

Python f-string 안에서 shell 변수의 중괄호를 escape하기 위해
`${{TMP_ROOT}}`를 작성했지만, workflow 파일에서는 이 문자열도 GitHub Actions의
expression 평가 대상이 됩니다.

하나의 파일 안에 다음 세 가지 보간 규칙이 겹쳐 있어 문제가 발생했습니다.

- GitHub Actions expression: `${{ ... }}`
- Python f-string: `{...}`
- shell variable: `${...}`

## 변경 내용

shell 변수 문자열을 별도 Python 변수로 분리했습니다.

```python
tmp_root_ref = "${TMP_ROOT}"