### PR TITLE
[Chore] SSM payload를 bash로 실행

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -146,6 +146,7 @@ jobs:
           import json
           import os
           from pathlib import Path
+          import shlex
 
           bucket = os.environ["DEPLOY_S3_BUCKET"]
           prefix = os.environ["DEPLOY_S3_PREFIX"].strip("/")
@@ -156,7 +157,7 @@ jobs:
           remote_service_name = os.environ["REMOTE_SERVICE_NAME"]
           tmp_root_ref = "${TMP_ROOT}"
 
-          commands = [
+          script_lines = [
               "set -euo pipefail",
               'TMP_ROOT="/tmp/matchuri-deploy"',
               f'RELEASE_FILE="{release}"',
@@ -181,6 +182,8 @@ jobs:
               '  exit 1',
               'fi',
           ]
+          script = "\n".join(script_lines)
+          commands = [f"bash -lc {shlex.quote(script)}"]
 
           Path("ssm-parameters.json").write_text(
               json.dumps({"commands": commands}),


### PR DESCRIPTION
## 관련 이슈

Refs #74  
Follow-up to #75 and #76

## 문제

SSM `AWS-RunShellScript`에 여러 command line을 전달하는 방식만으로는
현재 배포 스크립트가 기대하는 Bash 실행 환경을 명확히 보장하기 어렵습니다.

payload에는 다음과 같이 Bash에 의존하는 동작이 포함되어 있습니다.

- `set -euo pipefail`
- `{1..12}` brace expansion
- 여러 줄에 걸친 변수와 상태 값 공유
- health check retry loop

기본 shell 실행 방식에 의존하면 `pipefail`이나 brace expansion이 지원되지 않거나,
명령 실행 컨텍스트가 달라져 배포 결과가 불안정해질 수 있습니다.

## 변경 내용

개별 command 배열을 하나의 script 문자열로 결합한 뒤, 전체 payload를
명시적으로 Bash에서 실행하도록 변경했습니다.

```python
script = "\n".join(script_lines)
commands = [f"bash -lc {shlex.quote(script)}"]
```

또한 `shlex.quote`를 사용해 여러 줄 script가 `bash -lc`의 단일 인자로
안전하게 전달되도록 했습니다.

## 변경 효과

- 전체 배포 과정이 하나의 Bash 실행 컨텍스트에서 동작합니다.
- `set -euo pipefail`이 전체 배포 script에 적용됩니다.
- health check의 `success` 값이 같은 shell에서 유지됩니다.
- `{1..12}` retry loop가 Bash 문법으로 정상 동작합니다.
- script 내부의 따옴표와 특수 문자가 안전하게 전달됩니다.

## 검증

- [x] SSM payload가 `bash -lc` 형태로 생성된다.
- [x] release 및 환경 파일을 S3에서 다운로드한다.
- [x] 기존 `deploy.sh`가 실행된다.
- [x] `systemd` 상태 확인이 수행된다.
- [x] health check retry loop가 정상 동작한다.
- [x] 실패 시 SSM command가 실패 상태를 반환한다.
- [x] API 및 DB 계약 변경이 없다.

## 알려진 제한 사항

- 대상 EC2에 Bash가 설치되어 있음을 전제로 합니다.
- SSM command output의 장기 보관은 별도 범위입니다.
