### PR TITLE
[Fix] 약관 동의 후 기존 토큰 인가 실패에 대한 방어 로직 구현

### DIFF
--- a/src/main/java/matchuri/backend/global/security/RequiredAgreementAccessFilter.java
+++ b/src/main/java/matchuri/backend/global/security/RequiredAgreementAccessFilter.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.domain.member.MemberAgreementErrorCode;
+import matchuri.backend.domain.member.service.RequiredAgreementRevisionResolver;
 import matchuri.backend.domain.member.service.RequiredAgreementVersions;
 import matchuri.backend.global.config.MatchuriProperties;
 import org.springframework.http.HttpMethod;
@@ -27,6 +28,7 @@ public class RequiredAgreementAccessFilter extends OncePerRequestFilter {
 
     private final MatchuriProperties matchuriProperties;
     private final MatchuriAccessDeniedHandler accessDeniedHandler;
+    private final RequiredAgreementRevisionResolver requiredAgreementRevisionResolver;
     private final AntPathMatcher antPathMatcher = new AntPathMatcher();
 
     @Override
@@ -46,13 +48,23 @@ public class RequiredAgreementAccessFilter extends OncePerRequestFilter {
             return;
         }
 
-        if (!RequiredAgreementVersions.currentRevision().equals(authenticatedMember.requiredAgreementRevision())) {
+        if (!hasSatisfiedRequiredAgreements(authenticatedMember)) {
             request.setAttribute(AUTHORIZATION_ERROR_CODE_ATTRIBUTE, MemberAgreementErrorCode.REQUIRED);
             accessDeniedHandler.handle(request, response, new AccessDeniedException(MemberAgreementErrorCode.REQUIRED.getMessage()));
             return;
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private boolean hasSatisfiedRequiredAgreements(AuthenticatedMember authenticatedMember) {
+        if (RequiredAgreementVersions.currentRevision().equals(authenticatedMember.requiredAgreementRevision())) {
+            return true;
+        }
+
+        return RequiredAgreementVersions.currentRevision().equals(
+                requiredAgreementRevisionResolver.resolve(authenticatedMember.memberId())
+        );
     }
 
     private boolean shouldSkip(HttpServletRequest request) {

--- a/src/test/java/matchuri/backend/api/member/MemberAgreementIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/member/MemberAgreementIntegrationTest.java
@@ -103,8 +103,8 @@ class MemberAgreementIntegrationTest {
 
         mockMvc.perform(get("/api/v1/members/me")
                         .header(HttpHeaders.AUTHORIZATION, bearer(authSession.accessToken())))
-                .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.error.code").value("MEMBER_AGREEMENT_REQUIRED"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").isNumber());
 
         mockMvc.perform(get("/api/v1/members/me")
                         .header(HttpHeaders.AUTHORIZATION, bearer(refreshedAccessToken)))

--- a/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
@@ -24,7 +24,9 @@ import matchuri.backend.domain.auth.entity.AuthRefreshToken;
 import matchuri.backend.domain.auth.entity.AuthExchangeCode;
 import matchuri.backend.domain.auth.repository.AuthExchangeCodeRepository;
 import matchuri.backend.domain.auth.repository.AuthRefreshTokenRepository;
+import matchuri.backend.domain.member.entity.AgreementType;
 import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.entity.MemberAgreement;
 import matchuri.backend.domain.member.entity.MemberRole;
 import matchuri.backend.domain.member.entity.MemberStatus;
 import matchuri.backend.domain.member.entity.MemberTasteProfile;
@@ -390,6 +392,30 @@ class MemberAuthIntegrationTest {
     }
 
     @Test
+    @DisplayName("최신 필수 약관 동의 기록이 있으면 구 access token claim도 fallback 검증으로 허용한다")
+    void protectedApiAllowsLegacyTokenWhenRequiredAgreementsAlreadyCompleted() throws Exception {
+        Member member = memberRepository.save(new Member(
+                "legacy-agreement-user",
+                "hashed-password",
+                null,
+                false,
+                null,
+                null,
+                MemberRole.MEMBER,
+                MemberStatus.ACTIVE
+        ));
+        memberAgreementRepository.save(MemberAgreement.create(member, AgreementType.TERMS_OF_SERVICE, "2026-04-10"));
+        memberAgreementRepository.save(MemberAgreement.create(member, AgreementType.PRIVACY_POLICY, "2026-04-10"));
+
+        String legacyAccessToken = accessToken(member, null, Instant.now().plusSeconds(1800));
+
+        mockMvc.perform(get("/api/v1/members/me")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(legacyAccessToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(member.getId()));
+    }
+
+    @Test
     @DisplayName("refresh token 쿠키가 없으면 AUTH_REFRESH_TOKEN_MISSING을 반환한다")
     void refreshFailsWhenRefreshTokenCookieIsMissing() throws Exception {
         mockMvc.perform(post("/api/v1/auth/refresh"))
@@ -651,6 +677,14 @@ class MemberAuthIntegrationTest {
         Instant now = Instant.now();
         Instant issuedAt = now.minusSeconds(3600);
         Instant expiredAt = now.minusSeconds(1800);
+        return accessToken(member, null, expiredAt, issuedAt);
+    }
+
+    private String accessToken(Member member, String requiredAgreementRevision, Instant expiresAt) {
+        return accessToken(member, requiredAgreementRevision, expiresAt, Instant.now());
+    }
+
+    private String accessToken(Member member, String requiredAgreementRevision, Instant expiresAt, Instant issuedAt) {
         SecretKey signingKey = Keys.hmacShaKeyFor(
                 matchuriProperties.getAuth().getJwt().getSecret().getBytes(StandardCharsets.UTF_8)
         );
@@ -660,9 +694,9 @@ class MemberAuthIntegrationTest {
                 .subject(String.valueOf(member.getId()))
                 .claim("role", member.getMemberRole().name())
                 .claim("loginId", member.getLoginId())
-                .claim("requiredAgreementRevision", null)
+                .claim("requiredAgreementRevision", requiredAgreementRevision)
                 .issuedAt(Date.from(issuedAt))
-                .expiration(Date.from(expiredAt))
+                .expiration(Date.from(expiresAt))
                 .signWith(signingKey)
                 .compact();
     }


### PR DESCRIPTION
## 관련 이슈
Closes #83 

## 📝 작업 내용
- 새로 발급된 accesstoken으로 다시 요청을 보내면 문제가 없지만 이에 대한 방어로직을 구현
- 팀원에게는 토큰 재발급을 권장

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
