### PR TITLE
[Feat] 취향 프로필 조회 API 구현

### DIFF
--- a/src/main/java/matchuri/backend/api/member/MemberApi.java
+++ b/src/main/java/matchuri/backend/api/member/MemberApi.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import matchuri.backend.api.member.dto.docs.CreateMemberApiResponse;
 import matchuri.backend.api.member.dto.docs.LoginIdExistsApiResponse;
+import matchuri.backend.api.member.dto.docs.MemberTasteProfileSummaryApiResponse;
 import matchuri.backend.api.member.dto.docs.NicknameExistsApiResponse;
 import matchuri.backend.api.member.dto.docs.RegisterLocalMemberApiResponse;
 import matchuri.backend.api.member.dto.request.CreateMemberRequest;
@@ -19,6 +20,7 @@ import matchuri.backend.api.member.dto.request.UpdateMemberTasteProfileRequest;
 import matchuri.backend.api.member.dto.response.CreateMemberResponse;
 import matchuri.backend.api.member.dto.response.LoginIdExistsResponse;
 import matchuri.backend.api.member.dto.response.MemberProfileResponse;
+import matchuri.backend.api.member.dto.response.MemberTasteProfileSummaryResponse;
 import matchuri.backend.api.member.dto.response.NicknameExistsResponse;
 import matchuri.backend.api.member.dto.response.RegisterLocalMemberResponse;
 import matchuri.backend.api.member.dto.response.UpdateMemberResponse;
@@ -352,6 +354,80 @@ public interface MemberApi {
                     - `loginId`, `email`, 취향 프로필 상세 필드는 이 응답에 포함되지 않습니다.
                     """)
     ApiResponse<MemberProfileResponse> getMyProfile();
+
+    @Operation(
+            summary = "내 취향 프로필 조회",
+            description = """
+                    현재 로그인한 회원의 취향 프로필을 조회합니다.
+
+                    - `Authorization: Bearer <accessToken>` 헤더가 필요합니다.
+                    - 프로필이 아직 없어도 빈 배열 기반의 정상 응답을 반환합니다.
+                    - 선택된 `attribute category`, `restriction ingredient`는 표시용 최소 메타데이터와 함께 반환합니다.
+                    - `profileVersion`은 현재 서버가 관리하는 버전 문자열입니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = MemberTasteProfileSummaryApiResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "profileExists",
+                                            value = """
+                                                    {
+                                                      "success": true,
+                                                      "data": {
+                                                        "memberId": 1,
+                                                        "profileVersion": "v1",
+                                                        "attributeCategories": [
+                                                          {
+                                                            "id": 1,
+                                                            "categoryType": "FLAVOR",
+                                                            "code": "SPICY",
+                                                            "name": "매운맛",
+                                                            "sortOrder": 10
+                                                          }
+                                                        ],
+                                                        "restrictionIngredients": [
+                                                          {
+                                                            "id": 101,
+                                                            "code": "PEANUT",
+                                                            "name": "땅콩",
+                                                            "allergen": true,
+                                                            "sortOrder": 10
+                                                          }
+                                                        ],
+                                                        "updatedAt": "2026-04-17T12:30:45"
+                                                      },
+                                                      "error": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "emptyProfile",
+                                            value = """
+                                                    {
+                                                      "success": true,
+                                                      "data": {
+                                                        "memberId": 1,
+                                                        "profileVersion": "v1",
+                                                        "attributeCategories": [],
+                                                        "restrictionIngredients": [],
+                                                        "updatedAt": null
+                                                      },
+                                                      "error": null
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")
+    })
+    ApiResponse<MemberTasteProfileSummaryResponse> getMyTasteProfile();
 
     @Operation(
             summary = "내 기본 정보 수정",

--- a/src/main/java/matchuri/backend/api/member/MemberController.java
+++ b/src/main/java/matchuri/backend/api/member/MemberController.java
@@ -9,6 +9,7 @@ import matchuri.backend.api.member.dto.request.UpdateMemberTasteProfileRequest;
 import matchuri.backend.api.member.dto.response.CreateMemberResponse;
 import matchuri.backend.api.member.dto.response.LoginIdExistsResponse;
 import matchuri.backend.api.member.dto.response.MemberProfileResponse;
+import matchuri.backend.api.member.dto.response.MemberTasteProfileSummaryResponse;
 import matchuri.backend.api.member.dto.response.NicknameExistsResponse;
 import matchuri.backend.api.member.dto.response.RegisterLocalMemberResponse;
 import matchuri.backend.api.member.dto.response.UpdateMemberResponse;
@@ -84,6 +85,15 @@ public class MemberController implements MemberApi {
     public ApiResponse<MemberProfileResponse> getMyProfile() {
         var myProfile = memberService.getMyProfile();
         MemberProfileResponse response = memberMapper.toMemberProfileResponse(myProfile);
+
+        return ApiResponse.success(response);
+    }
+
+    @Override
+    @GetMapping("/me/taste-profile")
+    public ApiResponse<MemberTasteProfileSummaryResponse> getMyTasteProfile() {
+        var myTasteProfile = memberService.getMyTasteProfile();
+        MemberTasteProfileSummaryResponse response = memberMapper.toMemberTasteProfileSummaryResponse(myTasteProfile);
 
         return ApiResponse.success(response);
     }

--- a/src/main/java/matchuri/backend/api/member/dto/docs/MemberTasteProfileSummaryApiResponse.java
+++ b/src/main/java/matchuri/backend/api/member/dto/docs/MemberTasteProfileSummaryApiResponse.java
@@ -1,0 +1,18 @@
+package matchuri.backend.api.member.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.member.dto.response.MemberTasteProfileSummaryResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "내 취향 프로필 조회 API의 공통 응답 envelope입니다.")
+public record MemberTasteProfileSummaryApiResponse(
+        @Schema(description = "요청 성공 여부입니다.", example = "true")
+        boolean success,
+
+        @Schema(description = "성공 시 반환되는 내 취향 프로필 payload입니다.")
+        MemberTasteProfileSummaryResponse data,
+
+        @Schema(description = "실패 시 반환되는 에러 정보입니다.")
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/member/dto/response/MemberTasteAttributeCategoryResponse.java
+++ b/src/main/java/matchuri/backend/api/member/dto/response/MemberTasteAttributeCategoryResponse.java
@@ -1,0 +1,22 @@
+package matchuri.backend.api.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.domain.menu.entity.CategoryType;
+
+public record MemberTasteAttributeCategoryResponse(
+        @Schema(description = "선택된 attribute category ID입니다.", example = "1")
+        Long id,
+
+        @Schema(description = "선택된 attribute category의 상위 유형입니다.", example = "FLAVOR")
+        CategoryType categoryType,
+
+        @Schema(description = "선택된 attribute category 코드입니다.", example = "SPICY")
+        String code,
+
+        @Schema(description = "선택된 attribute category 표시 이름입니다.", example = "매운맛")
+        String name,
+
+        @Schema(description = "화면 표시 순서를 위한 정렬 값입니다.", example = "10")
+        int sortOrder
+) {
+}

--- a/src/main/java/matchuri/backend/api/member/dto/response/MemberTasteProfileSummaryResponse.java
+++ b/src/main/java/matchuri/backend/api/member/dto/response/MemberTasteProfileSummaryResponse.java
@@ -1,10 +1,23 @@
 package matchuri.backend.api.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record MemberTasteProfileSummaryResponse(
-        List<Object> attributeCategories,
-        List<Object> restrictionIngredients,
-        String profileVersion
+        @Schema(description = "현재 로그인한 회원 ID입니다.", example = "1")
+        Long memberId,
+
+        @Schema(description = "현재 서버가 관리하는 취향 프로필 버전 문자열입니다.", example = "v1")
+        String profileVersion,
+
+        @Schema(description = "현재 선택된 attribute category 목록입니다.")
+        List<MemberTasteAttributeCategoryResponse> attributeCategories,
+
+        @Schema(description = "현재 선택된 restriction ingredient 목록입니다.")
+        List<MemberTasteRestrictionIngredientResponse> restrictionIngredients,
+
+        @Schema(description = "취향 프로필이 마지막으로 갱신된 시각입니다. 프로필이 없으면 null입니다.", example = "2026-04-17T12:30:45")
+        LocalDateTime updatedAt
 ) {
 }

--- a/src/main/java/matchuri/backend/api/member/dto/response/MemberTasteRestrictionIngredientResponse.java
+++ b/src/main/java/matchuri/backend/api/member/dto/response/MemberTasteRestrictionIngredientResponse.java
@@ -1,0 +1,21 @@
+package matchuri.backend.api.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MemberTasteRestrictionIngredientResponse(
+        @Schema(description = "선택된 restriction ingredient ID입니다.", example = "101")
+        Long id,
+
+        @Schema(description = "선택된 restriction ingredient 코드입니다.", example = "PEANUT")
+        String code,
+
+        @Schema(description = "선택된 restriction ingredient 표시 이름입니다.", example = "땅콩")
+        String name,
+
+        @Schema(description = "알레르기 유발 재료 여부입니다.", example = "true")
+        boolean allergen,
+
+        @Schema(description = "화면 표시 순서를 위한 정렬 값입니다.", example = "10")
+        int sortOrder
+) {
+}

--- a/src/main/java/matchuri/backend/api/member/mapper/MemberMapper.java
+++ b/src/main/java/matchuri/backend/api/member/mapper/MemberMapper.java
@@ -5,7 +5,10 @@ import matchuri.backend.api.auth.dto.response.LogoutResponse;
 import matchuri.backend.api.member.dto.request.RegisterLocalMemberRequest;
 import matchuri.backend.api.member.dto.response.CreateMemberResponse;
 import matchuri.backend.api.member.dto.response.LoginIdExistsResponse;
+import matchuri.backend.api.member.dto.response.MemberTasteAttributeCategoryResponse;
 import matchuri.backend.api.member.dto.response.MemberProfileResponse;
+import matchuri.backend.api.member.dto.response.MemberTasteProfileSummaryResponse;
+import matchuri.backend.api.member.dto.response.MemberTasteRestrictionIngredientResponse;
 import matchuri.backend.api.member.dto.response.NicknameExistsResponse;
 import matchuri.backend.api.member.dto.response.RegisterLocalMemberResponse;
 import matchuri.backend.api.member.dto.response.UpdateMemberResponse;
@@ -22,6 +25,7 @@ import matchuri.backend.domain.member.command.UpdateMemberTasteProfileCommand;
 import matchuri.backend.domain.member.entity.SocialProviderType;
 import matchuri.backend.domain.member.result.CreateMemberResult;
 import matchuri.backend.domain.member.result.MemberProfileResult;
+import matchuri.backend.domain.member.result.MemberTasteProfileSummaryResult;
 import matchuri.backend.domain.member.result.RegisterLocalMemberResult;
 import matchuri.backend.domain.member.result.UpdateMemberResult;
 import matchuri.backend.domain.member.result.WithdrawMemberResult;
@@ -92,6 +96,32 @@ public class MemberMapper {
 
     public MemberProfileResponse toMemberProfileResponse(MemberProfileResult result) {
         return new MemberProfileResponse(result.id(), result.nickname());
+    }
+
+    public MemberTasteProfileSummaryResponse toMemberTasteProfileSummaryResponse(MemberTasteProfileSummaryResult result) {
+        return new MemberTasteProfileSummaryResponse(
+                result.memberId(),
+                result.profileVersion(),
+                result.attributeCategories().stream()
+                        .map(item -> new MemberTasteAttributeCategoryResponse(
+                                item.id(),
+                                item.categoryType(),
+                                item.code(),
+                                item.name(),
+                                item.sortOrder()
+                        ))
+                        .toList(),
+                result.restrictionIngredients().stream()
+                        .map(item -> new MemberTasteRestrictionIngredientResponse(
+                                item.id(),
+                                item.code(),
+                                item.name(),
+                                item.allergen(),
+                                item.sortOrder()
+                        ))
+                        .toList(),
+                result.updatedAt()
+        );
     }
 
     public UpdateMemberBasicInfoCommand toUpdateMemberBasicInfoCommand(String nickname) {

--- a/src/main/java/matchuri/backend/domain/member/repository/MemberTasteProfileCategoryRepository.java
+++ b/src/main/java/matchuri/backend/domain/member/repository/MemberTasteProfileCategoryRepository.java
@@ -1,0 +1,19 @@
+package matchuri.backend.domain.member.repository;
+
+import java.util.List;
+import matchuri.backend.domain.member.entity.MemberTasteProfileCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface MemberTasteProfileCategoryRepository extends JpaRepository<MemberTasteProfileCategory, Long> {
+
+    @Query("""
+            select mapping
+            from MemberTasteProfileCategory mapping
+            join fetch mapping.attributeCategory attributeCategory
+            where mapping.profile.id = :profileId
+            order by attributeCategory.categoryType asc, attributeCategory.sortOrder asc, attributeCategory.id asc
+            """)
+    List<MemberTasteProfileCategory> findAllByProfileIdOrderByDisplay(@Param("profileId") Long profileId);
+}

--- a/src/main/java/matchuri/backend/domain/member/repository/MemberTasteProfileRestrictionIngredientRepository.java
+++ b/src/main/java/matchuri/backend/domain/member/repository/MemberTasteProfileRestrictionIngredientRepository.java
@@ -1,0 +1,19 @@
+package matchuri.backend.domain.member.repository;
+
+import java.util.List;
+import matchuri.backend.domain.member.entity.MemberTasteProfileRestrictionIngredient;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface MemberTasteProfileRestrictionIngredientRepository extends JpaRepository<MemberTasteProfileRestrictionIngredient, Long> {
+
+    @Query("""
+            select mapping
+            from MemberTasteProfileRestrictionIngredient mapping
+            join fetch mapping.ingredient ingredient
+            where mapping.profile.id = :profileId
+            order by ingredient.sortOrder asc, ingredient.id asc
+            """)
+    List<MemberTasteProfileRestrictionIngredient> findAllByProfileIdOrderByDisplay(@Param("profileId") Long profileId);
+}

--- a/src/main/java/matchuri/backend/domain/member/result/MemberTasteProfileSummaryResult.java
+++ b/src/main/java/matchuri/backend/domain/member/result/MemberTasteProfileSummaryResult.java
@@ -1,0 +1,88 @@
+package matchuri.backend.domain.member.result;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import matchuri.backend.domain.member.entity.MemberTasteProfile;
+import matchuri.backend.domain.member.entity.MemberTasteProfileCategory;
+import matchuri.backend.domain.member.entity.MemberTasteProfileRestrictionIngredient;
+import matchuri.backend.domain.menu.entity.CategoryType;
+
+public record MemberTasteProfileSummaryResult(
+        Long memberId,
+        String profileVersion,
+        List<AttributeCategoryItem> attributeCategories,
+        List<RestrictionIngredientItem> restrictionIngredients,
+        LocalDateTime updatedAt
+) {
+
+    public static final String DEFAULT_PROFILE_VERSION = "v1";
+
+    public static MemberTasteProfileSummaryResult empty(Long memberId) {
+        return new MemberTasteProfileSummaryResult(
+                memberId,
+                DEFAULT_PROFILE_VERSION,
+                List.of(),
+                List.of(),
+                null
+        );
+    }
+
+    public static MemberTasteProfileSummaryResult of(
+            Long memberId,
+            MemberTasteProfile profile,
+            List<MemberTasteProfileCategory> attributeCategories,
+            List<MemberTasteProfileRestrictionIngredient> restrictionIngredients
+    ) {
+        return new MemberTasteProfileSummaryResult(
+                memberId,
+                profile.getProfileVersion(),
+                attributeCategories.stream()
+                        .map(AttributeCategoryItem::from)
+                        .toList(),
+                restrictionIngredients.stream()
+                        .map(RestrictionIngredientItem::from)
+                        .toList(),
+                profile.getUpdatedAt()
+        );
+    }
+
+    public record AttributeCategoryItem(
+            Long id,
+            CategoryType categoryType,
+            String code,
+            String name,
+            int sortOrder
+    ) {
+
+        public static AttributeCategoryItem from(MemberTasteProfileCategory mapping) {
+            var attributeCategory = mapping.getAttributeCategory();
+            return new AttributeCategoryItem(
+                    attributeCategory.getId(),
+                    attributeCategory.getCategoryType(),
+                    attributeCategory.getCode(),
+                    attributeCategory.getName(),
+                    attributeCategory.getSortOrder()
+            );
+        }
+    }
+
+    public record RestrictionIngredientItem(
+            Long id,
+            String code,
+            String name,
+            boolean allergen,
+            int sortOrder
+    ) {
+
+        public static RestrictionIngredientItem from(MemberTasteProfileRestrictionIngredient mapping) {
+            var ingredient = mapping.getIngredient();
+            return new RestrictionIngredientItem(
+                    ingredient.getId(),
+                    ingredient.getCode(),
+                    ingredient.getName(),
+                    ingredient.isAllergen(),
+                    ingredient.getSortOrder()
+            );
+        }
+    }
+}

--- a/src/main/java/matchuri/backend/domain/member/service/MemberService.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberService.java
@@ -6,6 +6,7 @@ import matchuri.backend.domain.member.command.UpdateMemberBasicInfoCommand;
 import matchuri.backend.domain.member.command.UpdateMemberTasteProfileCommand;
 import matchuri.backend.domain.member.result.CreateMemberResult;
 import matchuri.backend.domain.member.result.MemberProfileResult;
+import matchuri.backend.domain.member.result.MemberTasteProfileSummaryResult;
 import matchuri.backend.domain.member.result.RegisterLocalMemberResult;
 import matchuri.backend.domain.member.result.UpdateMemberResult;
 import matchuri.backend.domain.member.result.WithdrawMemberResult;
@@ -21,6 +22,8 @@ public interface MemberService {
     CreateMemberResult createMember(CreateMemberCommand command);
 
     MemberProfileResult getMyProfile();
+
+    MemberTasteProfileSummaryResult getMyTasteProfile();
 
     UpdateMemberResult updateMyProfile(UpdateMemberBasicInfoCommand command);
 

--- a/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
@@ -8,15 +8,18 @@ import matchuri.backend.domain.member.command.UpdateMemberTasteProfileCommand;
 import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.entity.MemberAgreement;
 import matchuri.backend.domain.member.entity.MemberTasteProfile;
+import matchuri.backend.domain.member.repository.MemberTasteProfileCategoryRepository;
 import matchuri.backend.domain.member.exception.MemberErrorCode;
 import matchuri.backend.domain.member.repository.MemberAgreementRepository;
 import matchuri.backend.domain.member.repository.MemberRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileRepository;
 import matchuri.backend.domain.member.result.CreateMemberResult;
 import matchuri.backend.domain.member.result.MemberProfileResult;
+import matchuri.backend.domain.member.result.MemberTasteProfileSummaryResult;
 import matchuri.backend.domain.member.result.RegisterLocalMemberResult;
 import matchuri.backend.domain.member.result.UpdateMemberResult;
 import matchuri.backend.domain.member.result.WithdrawMemberResult;
+import matchuri.backend.domain.member.repository.MemberTasteProfileRestrictionIngredientRepository;
 import matchuri.backend.domain.member.support.agreement.RequiredAgreementRequestValidator;
 import matchuri.backend.domain.member.support.member.ActiveMemberReader;
 import matchuri.backend.global.exception.BusinessException;
@@ -33,6 +36,8 @@ public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
     private final MemberAgreementRepository memberAgreementRepository;
     private final MemberTasteProfileRepository memberTasteProfileRepository;
+    private final MemberTasteProfileCategoryRepository memberTasteProfileCategoryRepository;
+    private final MemberTasteProfileRestrictionIngredientRepository memberTasteProfileRestrictionIngredientRepository;
     private final RequiredAgreementRequestValidator requiredAgreementRequestValidator;
     private final PasswordEncoder passwordEncoder;
     private final ActiveMemberReader activeMemberReader;
@@ -81,6 +86,20 @@ public class MemberServiceImpl implements MemberService {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
 
         return MemberProfileResult.from(member);
+    }
+
+    @Override
+    public MemberTasteProfileSummaryResult getMyTasteProfile() {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+
+        return memberTasteProfileRepository.findByMemberId(member.getId())
+                .map(tasteProfile -> MemberTasteProfileSummaryResult.of(
+                        member.getId(),
+                        tasteProfile,
+                        memberTasteProfileCategoryRepository.findAllByProfileIdOrderByDisplay(tasteProfile.getId()),
+                        memberTasteProfileRestrictionIngredientRepository.findAllByProfileIdOrderByDisplay(tasteProfile.getId())
+                ))
+                .orElseGet(() -> MemberTasteProfileSummaryResult.empty(member.getId()));
     }
 
     @Override

--- a/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
@@ -30,10 +30,19 @@ import matchuri.backend.domain.member.entity.MemberAgreement;
 import matchuri.backend.domain.member.entity.MemberRole;
 import matchuri.backend.domain.member.entity.MemberStatus;
 import matchuri.backend.domain.member.entity.MemberTasteProfile;
+import matchuri.backend.domain.member.entity.MemberTasteProfileCategory;
+import matchuri.backend.domain.member.entity.MemberTasteProfileRestrictionIngredient;
 import matchuri.backend.domain.member.entity.SocialProviderType;
 import matchuri.backend.domain.member.repository.MemberAgreementRepository;
 import matchuri.backend.domain.member.repository.MemberRepository;
+import matchuri.backend.domain.member.repository.MemberTasteProfileCategoryRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileRepository;
+import matchuri.backend.domain.member.repository.MemberTasteProfileRestrictionIngredientRepository;
+import matchuri.backend.domain.menu.entity.AttributeCategory;
+import matchuri.backend.domain.menu.entity.CategoryType;
+import matchuri.backend.domain.menu.entity.Ingredient;
+import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
+import matchuri.backend.domain.menu.repository.IngredientRepository;
 import matchuri.backend.global.config.MatchuriProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -72,7 +81,19 @@ class MemberAuthIntegrationTest {
     private MemberTasteProfileRepository memberTasteProfileRepository;
 
     @Autowired
+    private MemberTasteProfileCategoryRepository memberTasteProfileCategoryRepository;
+
+    @Autowired
+    private MemberTasteProfileRestrictionIngredientRepository memberTasteProfileRestrictionIngredientRepository;
+
+    @Autowired
     private MemberAgreementRepository memberAgreementRepository;
+
+    @Autowired
+    private AttributeCategoryRepository attributeCategoryRepository;
+
+    @Autowired
+    private IngredientRepository ingredientRepository;
 
     @Autowired
     private MatchuriProperties matchuriProperties;
@@ -82,7 +103,11 @@ class MemberAuthIntegrationTest {
         authExchangeCodeRepository.deleteAll();
         authRefreshTokenRepository.deleteAll();
         memberAgreementRepository.deleteAll();
+        memberTasteProfileCategoryRepository.deleteAll();
+        memberTasteProfileRestrictionIngredientRepository.deleteAll();
         memberTasteProfileRepository.deleteAll();
+        attributeCategoryRepository.deleteAll();
+        ingredientRepository.deleteAll();
         memberRepository.deleteAll();
     }
 
@@ -287,6 +312,60 @@ class MemberAuthIntegrationTest {
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken)))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.error.code").value("MEMBER_INACTIVE_MEMBER"));
+    }
+
+    @Test
+    @DisplayName("내 취향 프로필 조회는 프로필이 없어도 빈 배열 기반 응답을 반환한다")
+    void getMyTasteProfileReturnsEmptyProfile() throws Exception {
+        createMemberThroughApi("taste-user-empty", "P@ssw0rd!");
+        AuthSession authSession = login("taste-user-empty", "P@ssw0rd!");
+        String accessToken = submitRequiredAgreements(authSession.accessToken());
+        Long memberId = memberRepository.findByLoginId("taste-user-empty").orElseThrow().getId();
+
+        mockMvc.perform(get("/api/v1/members/me/taste-profile")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.memberId").value(memberId))
+                .andExpect(jsonPath("$.data.profileVersion").value("v1"))
+                .andExpect(jsonPath("$.data.attributeCategories.length()").value(0))
+                .andExpect(jsonPath("$.data.restrictionIngredients.length()").value(0))
+                .andExpect(jsonPath("$.data.updatedAt").value(nullValue()));
+    }
+
+    @Test
+    @DisplayName("내 취향 프로필 조회는 저장된 선택 항목을 표시용 메타데이터와 함께 반환한다")
+    void getMyTasteProfileReturnsSelectedItems() throws Exception {
+        createMemberThroughApi("taste-user-full", "P@ssw0rd!");
+        AuthSession authSession = login("taste-user-full", "P@ssw0rd!");
+        String accessToken = submitRequiredAgreements(authSession.accessToken());
+        Member member = memberRepository.findByLoginId("taste-user-full").orElseThrow();
+
+        AttributeCategory attributeCategory = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 10)
+        );
+        Ingredient ingredient = ingredientRepository.save(
+                new Ingredient("PEANUT", "땅콩", true, 10)
+        );
+        MemberTasteProfile tasteProfile = memberTasteProfileRepository.save(new MemberTasteProfile(member, "v2"));
+        memberTasteProfileCategoryRepository.save(new MemberTasteProfileCategory(tasteProfile, attributeCategory));
+        memberTasteProfileRestrictionIngredientRepository.save(
+                new MemberTasteProfileRestrictionIngredient(tasteProfile, ingredient)
+        );
+
+        mockMvc.perform(get("/api/v1/members/me/taste-profile")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.memberId").value(member.getId()))
+                .andExpect(jsonPath("$.data.profileVersion").value("v2"))
+                .andExpect(jsonPath("$.data.attributeCategories[0].id").value(attributeCategory.getId()))
+                .andExpect(jsonPath("$.data.attributeCategories[0].categoryType").value("FLAVOR"))
+                .andExpect(jsonPath("$.data.attributeCategories[0].code").value("SPICY"))
+                .andExpect(jsonPath("$.data.restrictionIngredients[0].id").value(ingredient.getId()))
+                .andExpect(jsonPath("$.data.restrictionIngredients[0].code").value("PEANUT"))
+                .andExpect(jsonPath("$.data.restrictionIngredients[0].allergen").value(true))
+                .andExpect(jsonPath("$.data.updatedAt").isNotEmpty());
     }
 
     @Test

--- a/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
+++ b/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
@@ -16,16 +16,25 @@ import matchuri.backend.domain.member.command.UpdateMemberBasicInfoCommand;
 import matchuri.backend.domain.member.entity.AgreementType;
 import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.entity.MemberAgreement;
+import matchuri.backend.domain.member.entity.MemberTasteProfile;
+import matchuri.backend.domain.member.entity.MemberTasteProfileCategory;
+import matchuri.backend.domain.member.entity.MemberTasteProfileRestrictionIngredient;
 import matchuri.backend.domain.member.entity.MemberRole;
 import matchuri.backend.domain.member.entity.MemberStatus;
 import matchuri.backend.domain.member.exception.MemberErrorCode;
 import matchuri.backend.domain.member.repository.MemberAgreementRepository;
 import matchuri.backend.domain.member.repository.MemberRepository;
+import matchuri.backend.domain.member.repository.MemberTasteProfileCategoryRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileRepository;
+import matchuri.backend.domain.member.repository.MemberTasteProfileRestrictionIngredientRepository;
+import matchuri.backend.domain.member.result.MemberTasteProfileSummaryResult;
 import matchuri.backend.domain.member.result.RegisterLocalMemberResult;
 import matchuri.backend.domain.member.result.UpdateMemberResult;
 import matchuri.backend.domain.member.support.agreement.RequiredAgreementRequestValidator;
 import matchuri.backend.domain.member.support.member.ActiveMemberReader;
+import matchuri.backend.domain.menu.entity.AttributeCategory;
+import matchuri.backend.domain.menu.entity.CategoryType;
+import matchuri.backend.domain.menu.entity.Ingredient;
 import matchuri.backend.global.exception.BusinessException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,6 +56,12 @@ class MemberServiceImplTest {
 
     @Mock
     private MemberTasteProfileRepository memberTasteProfileRepository;
+
+    @Mock
+    private MemberTasteProfileCategoryRepository memberTasteProfileCategoryRepository;
+
+    @Mock
+    private MemberTasteProfileRestrictionIngredientRepository memberTasteProfileRestrictionIngredientRepository;
 
     @Mock
     private RequiredAgreementRequestValidator requiredAgreementRequestValidator;
@@ -157,5 +172,69 @@ class MemberServiceImplTest {
         assertThat(result.id()).isEqualTo(1L);
         assertThat(member.getNickname()).isEqualTo("현재닉네임");
         verify(memberRepository).flush();
+    }
+
+    @Test
+    @DisplayName("내 취향 프로필 조회 시 프로필이 없으면 빈 배열 기반 응답을 반환한다")
+    void getMyTasteProfileReturnsEmptyProfileWhenProfileDoesNotExist() {
+        Member member = Member.builder()
+                .id(1L)
+                .loginId("tester01")
+                .memberRole(MemberRole.MEMBER)
+                .status(MemberStatus.ACTIVE)
+                .social(false)
+                .build();
+
+        when(activeMemberReader.getCurrentAuthenticatedActiveMember()).thenReturn(member);
+        when(memberTasteProfileRepository.findByMemberId(1L)).thenReturn(java.util.Optional.empty());
+
+        MemberTasteProfileSummaryResult result = memberService.getMyTasteProfile();
+
+        assertThat(result.memberId()).isEqualTo(1L);
+        assertThat(result.profileVersion()).isEqualTo(MemberTasteProfileSummaryResult.DEFAULT_PROFILE_VERSION);
+        assertThat(result.attributeCategories()).isEmpty();
+        assertThat(result.restrictionIngredients()).isEmpty();
+        assertThat(result.updatedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("내 취향 프로필 조회 시 저장된 선택 항목을 표시용 메타데이터와 함께 반환한다")
+    void getMyTasteProfileReturnsSelectedItems() {
+        Member member = Member.builder()
+                .id(1L)
+                .loginId("tester01")
+                .memberRole(MemberRole.MEMBER)
+                .status(MemberStatus.ACTIVE)
+                .social(false)
+                .build();
+        MemberTasteProfile profile = new MemberTasteProfile(member, "v2");
+        AttributeCategory attributeCategory = new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 10);
+        Ingredient ingredient = new Ingredient("PEANUT", "땅콩", true, 10);
+
+        when(activeMemberReader.getCurrentAuthenticatedActiveMember()).thenReturn(member);
+        when(memberTasteProfileRepository.findByMemberId(1L)).thenReturn(java.util.Optional.of(profile));
+        when(memberTasteProfileCategoryRepository.findAllByProfileIdOrderByDisplay(profile.getId()))
+                .thenReturn(List.of(new MemberTasteProfileCategory(profile, attributeCategory)));
+        when(memberTasteProfileRestrictionIngredientRepository.findAllByProfileIdOrderByDisplay(profile.getId()))
+                .thenReturn(List.of(new MemberTasteProfileRestrictionIngredient(profile, ingredient)));
+
+        MemberTasteProfileSummaryResult result = memberService.getMyTasteProfile();
+
+        assertThat(result.memberId()).isEqualTo(1L);
+        assertThat(result.profileVersion()).isEqualTo("v2");
+        assertThat(result.attributeCategories()).singleElement()
+                .extracting(
+                        MemberTasteProfileSummaryResult.AttributeCategoryItem::categoryType,
+                        MemberTasteProfileSummaryResult.AttributeCategoryItem::code,
+                        MemberTasteProfileSummaryResult.AttributeCategoryItem::name
+                )
+                .containsExactly(CategoryType.FLAVOR, "SPICY", "매운맛");
+        assertThat(result.restrictionIngredients()).singleElement()
+                .extracting(
+                        MemberTasteProfileSummaryResult.RestrictionIngredientItem::code,
+                        MemberTasteProfileSummaryResult.RestrictionIngredientItem::name,
+                        MemberTasteProfileSummaryResult.RestrictionIngredientItem::allergen
+                )
+                .containsExactly("PEANUT", "땅콩", true);
     }
 }

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -81,7 +81,15 @@ class OpenApiDocumentationIntegrationTest {
                         .value("#/components/schemas/LoginIdExistsApiResponse"))
                 .andExpect(jsonPath("$.paths['/api/v1/members/exists/nickname/{nickname}'].get.security").isEmpty())
                 .andExpect(jsonPath("$.paths['/api/v1/members/exists/nickname/{nickname}'].get.responses['200'].content['application/json'].schema.$ref")
-                        .value("#/components/schemas/NicknameExistsApiResponse"));
+                        .value("#/components/schemas/NicknameExistsApiResponse"))
+                .andExpect(jsonPath("$.paths['/api/v1/members/me/taste-profile'].get.responses['200'].content['application/json'].schema.$ref")
+                        .value("#/components/schemas/MemberTasteProfileSummaryApiResponse"))
+                .andExpect(jsonPath("$.components.schemas.MemberTasteProfileSummaryResponse.properties.memberId.description")
+                        .value("현재 로그인한 회원 ID입니다."))
+                .andExpect(jsonPath("$.components.schemas.MemberTasteAttributeCategoryResponse.properties.categoryType.description")
+                        .value("선택된 attribute category의 상위 유형입니다."))
+                .andExpect(jsonPath("$.components.schemas.MemberTasteRestrictionIngredientResponse.properties.allergen.description")
+                        .value("알레르기 유발 재료 여부입니다."));
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
Closes #95 

## 📝 작업 내용
- 무엇을 변경했나요?
- 왜 이 변경이 필요한가요?

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항

취향 프로필은 회원가입 이후 입력하기에 취향 프로필이 없을 때 조회하더라도 400 에러 발생이 아닌 빈 값을 응답하도록 설계했습니다.

```json
{
  "success": true,
  "data": {
    "memberId": 3,
    "profileVersion": "v1",
    "attributeCategories": [],
    "restrictionIngredients": [],
    "updatedAt": "2026-04-20T10:56:46.679711"
  },
  "error": null
}
```
