### PR TITLE
[Feat] 관리용 Attribute categories list API 구현

### DIFF
--- a/src/main/java/matchuri/backend/api/menu/MenuAdminReferenceApi.java
+++ b/src/main/java/matchuri/backend/api/menu/MenuAdminReferenceApi.java
@@ -1,0 +1,90 @@
+package matchuri.backend.api.menu;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import matchuri.backend.api.menu.dto.docs.AdminAttributeCategoryListApiResponse;
+import matchuri.backend.api.menu.dto.response.AdminAttributeCategoryResponse;
+import matchuri.backend.global.api.ApiResponse;
+
+@Tag(name = "Menu Admin Reference", description = "참조 데이터 운영 관리를 위한 관리자 전용 조회 API")
+@SecurityRequirement(name = "bearerAuth")
+public interface MenuAdminReferenceApi {
+
+    @Operation(
+            summary = "관리자 attribute category 목록 조회",
+            description = """
+                    운영 관리용 `attribute category` 목록을 조회합니다.
+
+                    - `ADMIN` 권한이 필요합니다.
+                    - 활성/비활성 데이터를 모두 반환합니다.
+                    - 별도 `includeInactive` 파라미터 없이 전체 운영 상태를 기본 노출합니다.
+                    - 정렬 기준은 `categoryType`, `sortOrder`, `id`입니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = AdminAttributeCategoryListApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "data": [
+                                                {
+                                                  "id": 1,
+                                                  "categoryType": "FLAVOR",
+                                                  "code": "SPICY",
+                                                  "name": "매운맛",
+                                                  "sortOrder": 10,
+                                                  "isActive": true
+                                                },
+                                                {
+                                                  "id": 2,
+                                                  "categoryType": "FLAVOR",
+                                                  "code": "MILD",
+                                                  "name": "순한맛",
+                                                  "sortOrder": 20,
+                                                  "isActive": false
+                                                }
+                                              ],
+                                              "error": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "관리자 권한 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "forbidden",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "data": null,
+                                              "error": {
+                                                "status": 403,
+                                                "code": "AUTH_FORBIDDEN",
+                                                "message": "접근 권한이 없습니다.",
+                                                "details": []
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ApiResponse<List<AdminAttributeCategoryResponse>> getAdminAttributeCategories();
+}

--- a/src/main/java/matchuri/backend/api/menu/MenuAdminReferenceController.java
+++ b/src/main/java/matchuri/backend/api/menu/MenuAdminReferenceController.java
@@ -1,0 +1,30 @@
+package matchuri.backend.api.menu;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import matchuri.backend.api.menu.dto.response.AdminAttributeCategoryResponse;
+import matchuri.backend.api.menu.mapper.MenuReferenceMapper;
+import matchuri.backend.domain.menu.service.MenuAdminReferenceService;
+import matchuri.backend.global.api.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin")
+public class MenuAdminReferenceController implements MenuAdminReferenceApi {
+
+    private final MenuAdminReferenceService menuAdminReferenceService;
+    private final MenuReferenceMapper menuReferenceMapper;
+
+    @Override
+    @GetMapping("/attribute-categories")
+    public ApiResponse<List<AdminAttributeCategoryResponse>> getAdminAttributeCategories() {
+        return ApiResponse.success(
+                menuReferenceMapper.toAdminAttributeCategoryResponses(
+                        menuAdminReferenceService.getAttributeCategories()
+                )
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/api/menu/dto/docs/AdminAttributeCategoryListApiResponse.java
+++ b/src/main/java/matchuri/backend/api/menu/dto/docs/AdminAttributeCategoryListApiResponse.java
@@ -1,0 +1,19 @@
+package matchuri.backend.api.menu.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import matchuri.backend.api.menu.dto.response.AdminAttributeCategoryResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "관리자 attribute category 목록 조회 API의 공통 응답 envelope입니다.")
+public record AdminAttributeCategoryListApiResponse(
+        @Schema(description = "요청 성공 여부입니다.", example = "true")
+        boolean success,
+
+        @Schema(description = "성공 시 반환되는 전체 attribute category 목록입니다. 활성/비활성 데이터를 모두 포함합니다.")
+        List<AdminAttributeCategoryResponse> data,
+
+        @Schema(description = "실패 시 반환되는 에러 정보입니다.")
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/menu/dto/response/AdminAttributeCategoryResponse.java
+++ b/src/main/java/matchuri/backend/api/menu/dto/response/AdminAttributeCategoryResponse.java
@@ -1,0 +1,25 @@
+package matchuri.backend.api.menu.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.domain.menu.entity.CategoryType;
+
+public record AdminAttributeCategoryResponse(
+        @Schema(description = "attribute category ID입니다.", example = "1")
+        Long id,
+
+        @Schema(description = "attribute category의 상위 유형입니다.", example = "FLAVOR")
+        CategoryType categoryType,
+
+        @Schema(description = "attribute category 코드입니다.", example = "SPICY")
+        String code,
+
+        @Schema(description = "attribute category 표시 이름입니다.", example = "매운맛")
+        String name,
+
+        @Schema(description = "화면 표시 순서를 위한 정렬 값입니다.", example = "10")
+        int sortOrder,
+
+        @Schema(description = "운영 기준 활성 여부입니다.", example = "true")
+        boolean isActive
+) {
+}

--- a/src/main/java/matchuri/backend/api/menu/mapper/MenuReferenceMapper.java
+++ b/src/main/java/matchuri/backend/api/menu/mapper/MenuReferenceMapper.java
@@ -1,14 +1,22 @@
 package matchuri.backend.api.menu.mapper;
 
 import java.util.List;
+import matchuri.backend.api.menu.dto.response.AdminAttributeCategoryResponse;
 import matchuri.backend.api.menu.dto.response.AttributeCategoryResponse;
 import matchuri.backend.api.menu.dto.response.RestrictionIngredientResponse;
+import matchuri.backend.domain.menu.result.AdminAttributeCategoryResult;
 import matchuri.backend.domain.menu.result.AttributeCategoryResult;
 import matchuri.backend.domain.menu.result.RestrictionIngredientResult;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MenuReferenceMapper {
+
+    public List<AdminAttributeCategoryResponse> toAdminAttributeCategoryResponses(List<AdminAttributeCategoryResult> results) {
+        return results.stream()
+                .map(this::toAdminAttributeCategoryResponse)
+                .toList();
+    }
 
     public List<AttributeCategoryResponse> toAttributeCategoryResponses(List<AttributeCategoryResult> results) {
         return results.stream()
@@ -29,6 +37,17 @@ public class MenuReferenceMapper {
                 result.code(),
                 result.name(),
                 result.sortOrder()
+        );
+    }
+
+    private AdminAttributeCategoryResponse toAdminAttributeCategoryResponse(AdminAttributeCategoryResult result) {
+        return new AdminAttributeCategoryResponse(
+                result.id(),
+                result.categoryType(),
+                result.code(),
+                result.name(),
+                result.sortOrder(),
+                result.isActive()
         );
     }
 

--- a/src/main/java/matchuri/backend/domain/menu/repository/AttributeCategoryRepository.java
+++ b/src/main/java/matchuri/backend/domain/menu/repository/AttributeCategoryRepository.java
@@ -10,6 +10,8 @@ public interface AttributeCategoryRepository extends JpaRepository<AttributeCate
 
     boolean existsByCategoryTypeAndCode(CategoryType categoryType, String code);
 
+    List<AttributeCategory> findAllByOrderByCategoryTypeAscSortOrderAscIdAsc();
+
     List<AttributeCategory> findAllByActiveTrueOrderByCategoryTypeAscSortOrderAscIdAsc();
 
     List<AttributeCategory> findAllByIdInAndActiveTrue(Collection<Long> ids);

--- a/src/main/java/matchuri/backend/domain/menu/result/AdminAttributeCategoryResult.java
+++ b/src/main/java/matchuri/backend/domain/menu/result/AdminAttributeCategoryResult.java
@@ -1,0 +1,25 @@
+package matchuri.backend.domain.menu.result;
+
+import matchuri.backend.domain.menu.entity.AttributeCategory;
+import matchuri.backend.domain.menu.entity.CategoryType;
+
+public record AdminAttributeCategoryResult(
+        Long id,
+        CategoryType categoryType,
+        String code,
+        String name,
+        int sortOrder,
+        boolean isActive
+) {
+
+    public static AdminAttributeCategoryResult from(AttributeCategory attributeCategory) {
+        return new AdminAttributeCategoryResult(
+                attributeCategory.getId(),
+                attributeCategory.getCategoryType(),
+                attributeCategory.getCode(),
+                attributeCategory.getName(),
+                attributeCategory.getSortOrder(),
+                attributeCategory.isActive()
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/domain/menu/service/MenuAdminReferenceService.java
+++ b/src/main/java/matchuri/backend/domain/menu/service/MenuAdminReferenceService.java
@@ -1,0 +1,9 @@
+package matchuri.backend.domain.menu.service;
+
+import java.util.List;
+import matchuri.backend.domain.menu.result.AdminAttributeCategoryResult;
+
+public interface MenuAdminReferenceService {
+
+    List<AdminAttributeCategoryResult> getAttributeCategories();
+}

--- a/src/main/java/matchuri/backend/domain/menu/service/MenuAdminReferenceServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/menu/service/MenuAdminReferenceServiceImpl.java
@@ -1,0 +1,23 @@
+package matchuri.backend.domain.menu.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
+import matchuri.backend.domain.menu.result.AdminAttributeCategoryResult;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MenuAdminReferenceServiceImpl implements MenuAdminReferenceService {
+
+    private final AttributeCategoryRepository attributeCategoryRepository;
+
+    @Override
+    public List<AdminAttributeCategoryResult> getAttributeCategories() {
+        return attributeCategoryRepository.findAllByOrderByCategoryTypeAscSortOrderAscIdAsc().stream()
+                .map(AdminAttributeCategoryResult::from)
+                .toList();
+    }
+}

--- a/src/main/java/matchuri/backend/global/config/SecurityConfig.java
+++ b/src/main/java/matchuri/backend/global/config/SecurityConfig.java
@@ -56,6 +56,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, authProps.getPublicGetApiPatterns().toArray(String[]::new)).permitAll()
                         .requestMatchers(HttpMethod.POST, authProps.getPublicPostApiPatterns().toArray(String[]::new)).permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, authProps.getPublicOptionsApiPatterns().toArray(String[]::new)).permitAll()
+                        .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/src/test/java/matchuri/backend/api/menu/MenuAdminReferenceIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/menu/MenuAdminReferenceIntegrationTest.java
@@ -1,0 +1,136 @@
+package matchuri.backend.api.menu;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.entity.MemberRole;
+import matchuri.backend.domain.member.entity.MemberStatus;
+import matchuri.backend.domain.member.support.agreement.RequiredAgreementVersions;
+import matchuri.backend.domain.member.repository.MemberRepository;
+import matchuri.backend.domain.menu.entity.AttributeCategory;
+import matchuri.backend.domain.menu.entity.CategoryType;
+import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
+import matchuri.backend.global.config.MatchuriProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MenuAdminReferenceIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private AttributeCategoryRepository attributeCategoryRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private MatchuriProperties matchuriProperties;
+
+    @BeforeEach
+    void setUp() {
+        attributeCategoryRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("관리자 attribute category 목록 조회는 활성과 비활성 데이터를 함께 정렬해서 반환한다")
+    void getAdminAttributeCategoriesReturnsAllRowsInSortedOrder() throws Exception {
+        Member admin = memberRepository.save(new Member(
+                "admin-user",
+                "hashed-password",
+                null,
+                false,
+                null,
+                null,
+                MemberRole.ADMIN,
+                MemberStatus.ACTIVE
+        ));
+        AttributeCategory spicy = attributeCategoryRepository.save(new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 20));
+        AttributeCategory grilled = attributeCategoryRepository.save(new AttributeCategory(CategoryType.COOKING_METHOD, "GRILLED", "구이", 10));
+        AttributeCategory mild = new AttributeCategory(CategoryType.FLAVOR, "MILD", "순한맛", 10);
+        mild.deactivate();
+        mild = attributeCategoryRepository.save(mild);
+
+                mockMvc.perform(get("/api/v1/admin/attribute-categories")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(admin)))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.error").value(nullValue()))
+                .andExpect(jsonPath("$.data.length()").value(3))
+                .andExpect(jsonPath("$.data[0].id").value(grilled.getId()))
+                .andExpect(jsonPath("$.data[0].categoryType").value("COOKING_METHOD"))
+                .andExpect(jsonPath("$.data[0].isActive").value(true))
+                .andExpect(jsonPath("$.data[1].id").value(mild.getId()))
+                .andExpect(jsonPath("$.data[1].code").value("MILD"))
+                .andExpect(jsonPath("$.data[1].isActive").value(false))
+                .andExpect(jsonPath("$.data[2].id").value(spicy.getId()))
+                .andExpect(jsonPath("$.data[2].code").value("SPICY"))
+                .andExpect(jsonPath("$.data[2].isActive").value(true));
+    }
+
+    @Test
+    @DisplayName("일반 회원은 관리자 attribute category 목록 조회에 접근할 수 없다")
+    void getAdminAttributeCategoriesRejectsNonAdminMember() throws Exception {
+        Member member = memberRepository.save(new Member(
+                "member-user",
+                "hashed-password",
+                null,
+                false,
+                null,
+                null,
+                MemberRole.MEMBER,
+                MemberStatus.ACTIVE
+        ));
+
+        mockMvc.perform(get("/api/v1/admin/attribute-categories")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member)))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("AUTH_FORBIDDEN"));
+    }
+
+    private String bearer(String accessToken) {
+        return "Bearer " + accessToken;
+    }
+
+    private String accessToken(Member member) {
+        SecretKey signingKey = Keys.hmacShaKeyFor(
+                matchuriProperties.getAuth().getJwt().getSecret().getBytes(StandardCharsets.UTF_8)
+        );
+
+        return Jwts.builder()
+                .issuer(matchuriProperties.getAuth().getJwt().getIssuer())
+                .subject(String.valueOf(member.getId()))
+                .claim("role", member.getMemberRole().name())
+                .claim("loginId", member.getLoginId())
+                .claim("requiredAgreementRevision", RequiredAgreementVersions.currentRevision())
+                .issuedAt(Date.from(Instant.now()))
+                .expiration(Date.from(Instant.now().plusSeconds(1800)))
+                .signWith(signingKey)
+                .compact();
+    }
+}

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -121,6 +121,21 @@ class OpenApiDocumentationIntegrationTest {
     }
 
     @Test
+    @DisplayName("OpenAPI 문서에 관리자 attribute category 조회 API의 보안 요구와 envelope 응답 스키마가 노출된다")
+    void exposesMenuAdminReferenceApiMetadataInOpenApi() throws Exception {
+        mockMvc.perform(get("/docs/openapi"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("application/json"))
+                .andExpect(jsonPath("$.paths['/api/v1/admin/attribute-categories'].get.summary")
+                        .value("관리자 attribute category 목록 조회"))
+                .andExpect(jsonPath("$.paths['/api/v1/admin/attribute-categories'].get.security[0].bearerAuth").exists())
+                .andExpect(jsonPath("$.paths['/api/v1/admin/attribute-categories'].get.responses['200'].content['application/json'].schema.$ref")
+                        .value("#/components/schemas/AdminAttributeCategoryListApiResponse"))
+                .andExpect(jsonPath("$.components.schemas.AdminAttributeCategoryResponse.properties.isActive.description")
+                        .value("운영 기준 활성 여부입니다."));
+    }
+
+    @Test
     @DisplayName("OpenAPI 문서에 Member Agreement API의 envelope 응답 스키마가 노출된다")
     void exposesMemberAgreementApiMetadataInOpenApi() throws Exception {
         mockMvc.perform(get("/docs/openapi"))


### PR DESCRIPTION
## 관련 이슈
Reference #98 

## 📝 작업 내용
- `GET /api/v1/admin/attribute-categories` 구현

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 관리자용 API 입니다, `MemberRole.ADMIN` 만 접근 가능
