### PR TITLE
[Feat] 관리자용 Ingredient List GET API 구현

### DIFF
--- a/src/main/java/matchuri/backend/api/menu/MenuAdminReferenceApi.java
+++ b/src/main/java/matchuri/backend/api/menu/MenuAdminReferenceApi.java
@@ -10,9 +10,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import matchuri.backend.api.menu.dto.docs.AdminAttributeCategoryApiResponse;
 import matchuri.backend.api.menu.dto.docs.AdminAttributeCategoryListApiResponse;
+import matchuri.backend.api.menu.dto.docs.AdminIngredientListApiResponse;
 import matchuri.backend.api.menu.dto.request.CreateAdminAttributeCategoryRequest;
 import matchuri.backend.api.menu.dto.request.UpdateAdminAttributeCategoryRequest;
 import matchuri.backend.api.menu.dto.response.AdminAttributeCategoryResponse;
+import matchuri.backend.api.menu.dto.response.AdminIngredientResponse;
 import matchuri.backend.global.api.ApiResponse;
 
 @Tag(name = "Menu Admin Reference", description = "참조 데이터 운영 관리를 위한 관리자 전용 API")
@@ -90,6 +92,61 @@ public interface MenuAdminReferenceApi {
             )
     })
     ApiResponse<List<AdminAttributeCategoryResponse>> getAdminAttributeCategories();
+
+    @Operation(
+            summary = "관리자 ingredient 목록 조회",
+            description = """
+                    운영 관리용 `ingredient` 목록을 조회합니다.
+
+                    - `ADMIN` 권한이 필요합니다.
+                    - 활성/비활성 데이터를 모두 반환합니다.
+                    - 별도 `includeInactive` 파라미터 없이 전체 운영 상태를 기본 노출합니다.
+                    - 정렬 기준은 `sortOrder`, `id`입니다.
+                    - 응답에는 `allergen`, `isActive`를 함께 포함합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = AdminIngredientListApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "data": [
+                                                {
+                                                  "id": 101,
+                                                  "code": "PEANUT",
+                                                  "name": "땅콩",
+                                                  "allergen": true,
+                                                  "sortOrder": 10,
+                                                  "isActive": true
+                                                },
+                                                {
+                                                  "id": 102,
+                                                  "code": "PORK",
+                                                  "name": "돼지고기",
+                                                  "allergen": false,
+                                                  "sortOrder": 20,
+                                                  "isActive": false
+                                                }
+                                              ],
+                                              "error": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "관리자 권한 없음"
+            )
+    })
+    ApiResponse<List<AdminIngredientResponse>> getAdminIngredients();
 
     @Operation(
             summary = "관리자 attribute category 생성",

--- a/src/main/java/matchuri/backend/api/menu/MenuAdminReferenceController.java
+++ b/src/main/java/matchuri/backend/api/menu/MenuAdminReferenceController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import matchuri.backend.api.menu.dto.request.CreateAdminAttributeCategoryRequest;
 import matchuri.backend.api.menu.dto.request.UpdateAdminAttributeCategoryRequest;
 import matchuri.backend.api.menu.dto.response.AdminAttributeCategoryResponse;
+import matchuri.backend.api.menu.dto.response.AdminIngredientResponse;
 import matchuri.backend.api.menu.mapper.MenuReferenceMapper;
 import matchuri.backend.domain.menu.service.MenuAdminReferenceService;
 import matchuri.backend.global.api.ApiResponse;
@@ -32,6 +33,16 @@ public class MenuAdminReferenceController implements MenuAdminReferenceApi {
 
         var results = menuAdminReferenceService.getAttributeCategories();
         var responses = menuReferenceMapper.toAdminAttributeCategoryResponses(results);
+
+        return ApiResponse.success(responses);
+    }
+
+    @Override
+    @GetMapping("/ingredients")
+    public ApiResponse<List<AdminIngredientResponse>> getAdminIngredients() {
+
+        var results = menuAdminReferenceService.getIngredients();
+        var responses = menuReferenceMapper.toAdminIngredientResponses(results);
 
         return ApiResponse.success(responses);
     }

--- a/src/main/java/matchuri/backend/api/menu/dto/docs/AdminIngredientListApiResponse.java
+++ b/src/main/java/matchuri/backend/api/menu/dto/docs/AdminIngredientListApiResponse.java
@@ -1,0 +1,19 @@
+package matchuri.backend.api.menu.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import matchuri.backend.api.menu.dto.response.AdminIngredientResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "관리자 ingredient 목록 조회 API의 공통 응답 envelope입니다.")
+public record AdminIngredientListApiResponse(
+        @Schema(description = "요청 성공 여부입니다.", example = "true")
+        boolean success,
+
+        @Schema(description = "성공 시 반환되는 전체 ingredient 목록입니다. 활성/비활성 데이터를 모두 포함합니다.")
+        List<AdminIngredientResponse> data,
+
+        @Schema(description = "실패 시 반환되는 에러 정보입니다.")
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/menu/dto/response/AdminIngredientResponse.java
+++ b/src/main/java/matchuri/backend/api/menu/dto/response/AdminIngredientResponse.java
@@ -1,0 +1,24 @@
+package matchuri.backend.api.menu.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AdminIngredientResponse(
+        @Schema(description = "ingredient ID입니다.", example = "101")
+        Long id,
+
+        @Schema(description = "ingredient 코드입니다.", example = "PEANUT")
+        String code,
+
+        @Schema(description = "ingredient 표시 이름입니다.", example = "땅콩")
+        String name,
+
+        @Schema(description = "알레르기 유발 재료 여부입니다.", example = "true")
+        boolean allergen,
+
+        @Schema(description = "화면 표시 순서를 위한 정렬 값입니다.", example = "10")
+        int sortOrder,
+
+        @Schema(description = "운영 기준 활성 여부입니다.", example = "true")
+        boolean isActive
+) {
+}

--- a/src/main/java/matchuri/backend/api/menu/mapper/MenuReferenceMapper.java
+++ b/src/main/java/matchuri/backend/api/menu/mapper/MenuReferenceMapper.java
@@ -4,12 +4,14 @@ import java.util.List;
 import matchuri.backend.api.menu.dto.request.CreateAdminAttributeCategoryRequest;
 import matchuri.backend.api.menu.dto.request.UpdateAdminAttributeCategoryRequest;
 import matchuri.backend.api.menu.dto.response.AdminAttributeCategoryResponse;
+import matchuri.backend.api.menu.dto.response.AdminIngredientResponse;
 import matchuri.backend.api.menu.dto.response.AttributeCategoryResponse;
 import matchuri.backend.api.menu.dto.response.RestrictionIngredientResponse;
 import matchuri.backend.domain.menu.command.CreateAdminAttributeCategoryCommand;
 import matchuri.backend.domain.menu.command.UpdateAdminAttributeCategoryCommand;
 import matchuri.backend.domain.menu.entity.CategoryType;
 import matchuri.backend.domain.menu.result.AdminAttributeCategoryResult;
+import matchuri.backend.domain.menu.result.AdminIngredientResult;
 import matchuri.backend.domain.menu.result.AttributeCategoryResult;
 import matchuri.backend.domain.menu.result.RestrictionIngredientResult;
 import matchuri.backend.global.exception.RequestValidationException;
@@ -45,6 +47,12 @@ public class MenuReferenceMapper {
                 .toList();
     }
 
+    public List<AdminIngredientResponse> toAdminIngredientResponses(List<AdminIngredientResult> results) {
+        return results.stream()
+                .map(this::toAdminIngredientResponse)
+                .toList();
+    }
+
     public List<AttributeCategoryResponse> toAttributeCategoryResponses(List<AttributeCategoryResult> results) {
         return results.stream()
                 .map(this::toAttributeCategoryResponse)
@@ -73,6 +81,17 @@ public class MenuReferenceMapper {
                 result.categoryType(),
                 result.code(),
                 result.name(),
+                result.sortOrder(),
+                result.isActive()
+        );
+    }
+
+    public AdminIngredientResponse toAdminIngredientResponse(AdminIngredientResult result) {
+        return new AdminIngredientResponse(
+                result.id(),
+                result.code(),
+                result.name(),
+                result.allergen(),
                 result.sortOrder(),
                 result.isActive()
         );

--- a/src/main/java/matchuri/backend/domain/menu/repository/IngredientRepository.java
+++ b/src/main/java/matchuri/backend/domain/menu/repository/IngredientRepository.java
@@ -9,6 +9,8 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
 
     boolean existsByCode(String code);
 
+    List<Ingredient> findAllByOrderBySortOrderAscIdAsc();
+
     List<Ingredient> findAllByActiveTrueOrderBySortOrderAscIdAsc();
 
     List<Ingredient> findAllByIdInAndActiveTrue(Collection<Long> ids);

--- a/src/main/java/matchuri/backend/domain/menu/result/AdminIngredientResult.java
+++ b/src/main/java/matchuri/backend/domain/menu/result/AdminIngredientResult.java
@@ -1,0 +1,24 @@
+package matchuri.backend.domain.menu.result;
+
+import matchuri.backend.domain.menu.entity.Ingredient;
+
+public record AdminIngredientResult(
+        Long id,
+        String code,
+        String name,
+        boolean allergen,
+        int sortOrder,
+        boolean isActive
+) {
+
+    public static AdminIngredientResult from(Ingredient ingredient) {
+        return new AdminIngredientResult(
+                ingredient.getId(),
+                ingredient.getCode(),
+                ingredient.getName(),
+                ingredient.isAllergen(),
+                ingredient.getSortOrder(),
+                ingredient.isActive()
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/domain/menu/service/MenuAdminReferenceService.java
+++ b/src/main/java/matchuri/backend/domain/menu/service/MenuAdminReferenceService.java
@@ -4,10 +4,13 @@ import java.util.List;
 import matchuri.backend.domain.menu.command.CreateAdminAttributeCategoryCommand;
 import matchuri.backend.domain.menu.command.UpdateAdminAttributeCategoryCommand;
 import matchuri.backend.domain.menu.result.AdminAttributeCategoryResult;
+import matchuri.backend.domain.menu.result.AdminIngredientResult;
 
 public interface MenuAdminReferenceService {
 
     List<AdminAttributeCategoryResult> getAttributeCategories();
+
+    List<AdminIngredientResult> getIngredients();
 
     AdminAttributeCategoryResult createAttributeCategory(CreateAdminAttributeCategoryCommand command);
 

--- a/src/main/java/matchuri/backend/domain/menu/service/MenuAdminReferenceServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/menu/service/MenuAdminReferenceServiceImpl.java
@@ -8,6 +8,8 @@ import matchuri.backend.domain.menu.command.UpdateAdminAttributeCategoryCommand;
 import matchuri.backend.domain.menu.entity.AttributeCategory;
 import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
 import matchuri.backend.domain.menu.result.AdminAttributeCategoryResult;
+import matchuri.backend.domain.menu.repository.IngredientRepository;
+import matchuri.backend.domain.menu.result.AdminIngredientResult;
 import matchuri.backend.global.exception.BusinessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,11 +20,19 @@ import org.springframework.transaction.annotation.Transactional;
 public class MenuAdminReferenceServiceImpl implements MenuAdminReferenceService {
 
     private final AttributeCategoryRepository attributeCategoryRepository;
+    private final IngredientRepository ingredientRepository;
 
     @Override
     public List<AdminAttributeCategoryResult> getAttributeCategories() {
         return attributeCategoryRepository.findAllByOrderByCategoryTypeAscSortOrderAscIdAsc().stream()
                 .map(AdminAttributeCategoryResult::from)
+                .toList();
+    }
+
+    @Override
+    public List<AdminIngredientResult> getIngredients() {
+        return ingredientRepository.findAllByOrderBySortOrderAscIdAsc().stream()
+                .map(AdminIngredientResult::from)
                 .toList();
     }
 

--- a/src/test/java/matchuri/backend/api/menu/MenuAdminReferenceIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/menu/MenuAdminReferenceIntegrationTest.java
@@ -22,7 +22,9 @@ import matchuri.backend.domain.member.support.agreement.RequiredAgreementVersion
 import matchuri.backend.domain.member.repository.MemberRepository;
 import matchuri.backend.domain.menu.entity.AttributeCategory;
 import matchuri.backend.domain.menu.entity.CategoryType;
+import matchuri.backend.domain.menu.entity.Ingredient;
 import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
+import matchuri.backend.domain.menu.repository.IngredientRepository;
 import matchuri.backend.global.config.MatchuriProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -47,6 +49,9 @@ class MenuAdminReferenceIntegrationTest {
     private AttributeCategoryRepository attributeCategoryRepository;
 
     @Autowired
+    private IngredientRepository ingredientRepository;
+
+    @Autowired
     private MemberRepository memberRepository;
 
     @Autowired
@@ -55,6 +60,7 @@ class MenuAdminReferenceIntegrationTest {
     @BeforeEach
     void setUp() {
         attributeCategoryRepository.deleteAll();
+        ingredientRepository.deleteAll();
         memberRepository.deleteAll();
     }
 
@@ -96,6 +102,44 @@ class MenuAdminReferenceIntegrationTest {
     }
 
     @Test
+    @DisplayName("관리자 ingredient 목록 조회는 활성과 비활성 데이터를 함께 정렬해서 반환한다")
+    void getAdminIngredientsReturnsAllRowsInSortedOrder() throws Exception {
+        Member admin = memberRepository.save(new Member(
+                "admin-ingredient-user",
+                "hashed-password",
+                null,
+                false,
+                null,
+                null,
+                MemberRole.ADMIN,
+                MemberStatus.ACTIVE
+        ));
+        Ingredient peanut = ingredientRepository.save(new Ingredient("PEANUT", "땅콩", true, 10));
+        Ingredient pork = new Ingredient("PORK", "돼지고기", false, 10);
+        pork.deactivate();
+        pork = ingredientRepository.save(pork);
+        Ingredient milk = ingredientRepository.save(new Ingredient("MILK", "우유", true, 30));
+
+        mockMvc.perform(get("/api/v1/admin/ingredients")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(admin)))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.error").value(nullValue()))
+                .andExpect(jsonPath("$.data.length()").value(3))
+                .andExpect(jsonPath("$.data[0].id").value(peanut.getId()))
+                .andExpect(jsonPath("$.data[0].code").value("PEANUT"))
+                .andExpect(jsonPath("$.data[0].allergen").value(true))
+                .andExpect(jsonPath("$.data[0].isActive").value(true))
+                .andExpect(jsonPath("$.data[1].id").value(pork.getId()))
+                .andExpect(jsonPath("$.data[1].code").value("PORK"))
+                .andExpect(jsonPath("$.data[1].allergen").value(false))
+                .andExpect(jsonPath("$.data[1].isActive").value(false))
+                .andExpect(jsonPath("$.data[2].code").value("MILK"))
+                .andExpect(jsonPath("$.data[2].isActive").value(true));
+    }
+
+    @Test
     @DisplayName("일반 회원은 관리자 attribute category 목록 조회에 접근할 수 없다")
     void getAdminAttributeCategoriesRejectsNonAdminMember() throws Exception {
         Member member = memberRepository.save(new Member(
@@ -110,6 +154,28 @@ class MenuAdminReferenceIntegrationTest {
         ));
 
         mockMvc.perform(get("/api/v1/admin/attribute-categories")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member)))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("AUTH_FORBIDDEN"));
+    }
+
+    @Test
+    @DisplayName("일반 회원은 관리자 ingredient 목록 조회에 접근할 수 없다")
+    void getAdminIngredientsRejectsNonAdminMember() throws Exception {
+        Member member = memberRepository.save(new Member(
+                "member-ingredient-user",
+                "hashed-password",
+                null,
+                false,
+                null,
+                null,
+                MemberRole.MEMBER,
+                MemberStatus.ACTIVE
+        ));
+
+        mockMvc.perform(get("/api/v1/admin/ingredients")
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member)))
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isForbidden())

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -131,6 +131,11 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath("$.paths['/api/v1/admin/attribute-categories'].get.security[0].bearerAuth").exists())
                 .andExpect(jsonPath("$.paths['/api/v1/admin/attribute-categories'].get.responses['200'].content['application/json'].schema.$ref")
                         .value("#/components/schemas/AdminAttributeCategoryListApiResponse"))
+                .andExpect(jsonPath("$.paths['/api/v1/admin/ingredients'].get.summary")
+                        .value("관리자 ingredient 목록 조회"))
+                .andExpect(jsonPath("$.paths['/api/v1/admin/ingredients'].get.security[0].bearerAuth").exists())
+                .andExpect(jsonPath("$.paths['/api/v1/admin/ingredients'].get.responses['200'].content['application/json'].schema.$ref")
+                        .value("#/components/schemas/AdminIngredientListApiResponse"))
                 .andExpect(jsonPath("$.paths['/api/v1/admin/attribute-categories'].post.summary")
                         .value("관리자 attribute category 생성"))
                 .andExpect(jsonPath("$.paths['/api/v1/admin/attribute-categories'].post.security[0].bearerAuth").exists())
@@ -152,6 +157,8 @@ class OpenApiDocumentationIntegrationTest {
                         .value("수정할 활성 여부입니다. null이면 활성 상태를 변경하지 않습니다."))
                 .andExpect(jsonPath("$.components.schemas.CreateAdminAttributeCategoryRequest.properties.categoryType.description")
                         .value(org.hamcrest.Matchers.containsString("허용 값은 FLAVOR")))
+                .andExpect(jsonPath("$.components.schemas.AdminIngredientResponse.properties.isActive.description")
+                        .value("운영 기준 활성 여부입니다."))
                 .andExpect(jsonPath("$.components.schemas.AdminAttributeCategoryResponse.properties.isActive.description")
                         .value("운영 기준 활성 여부입니다."));
     }


### PR DESCRIPTION
## 관련 이슈
#98 

## 📝 작업 내용
- `GET /api/v1/admin/ingredients`

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
