### PR TITLE
[Feat] 사용자 취향 등록에 비선호 메뉴를 추가

### DIFF
--- a/src/main/java/matchuri/backend/api/member/MemberApi.java
+++ b/src/main/java/matchuri/backend/api/member/MemberApi.java
@@ -362,7 +362,7 @@ public interface MemberApi {
 
                     - `Authorization: Bearer <accessToken>` 헤더가 필요합니다.
                     - 프로필이 아직 없어도 빈 배열 기반의 정상 응답을 반환합니다.
-                    - 선택된 `attribute category`, `restriction ingredient`는 표시용 최소 메타데이터와 함께 반환합니다.
+                    - 선택된 `attribute category`, `restriction ingredient`, `disliked menu item`은 표시용 최소 메타데이터와 함께 반환합니다.
                     - `profileVersion`은 현재 프로필 정책/구조가 어떤 버전을 따르는지 나타내는 서버 관리 버전입니다.
                     - 단순 사용자 입력 변경만으로는 `profileVersion`이 바뀌지 않습니다.
                     """
@@ -401,6 +401,13 @@ public interface MemberApi {
                                                             "sortOrder": 10
                                                           }
                                                         ],
+                                                        "dislikedMenuItems": [
+                                                          {
+                                                            "id": 1001,
+                                                            "code": "PORK_CUTLET",
+                                                            "name": "돈까스"
+                                                          }
+                                                        ],
                                                         "updatedAt": "2026-04-17T12:30:45"
                                                       },
                                                       "error": null
@@ -417,6 +424,7 @@ public interface MemberApi {
                                                         "profileVersion": "v1",
                                                         "attributeCategories": [],
                                                         "restrictionIngredients": [],
+                                                        "dislikedMenuItems": [],
                                                         "updatedAt": null
                                                       },
                                                       "error": null
@@ -448,9 +456,10 @@ public interface MemberApi {
             description = """
                     현재 로그인한 회원의 취향 프로필을 전체 교체 방식으로 저장합니다.
 
-                    - `attributeCategoryIds`, `restrictionIngredientIds`는 각각 최신 입력 기준으로 전체 교체됩니다.
+                    - `attributeCategoryIds`, `restrictionIngredientIds`, `dislikedMenuItemIds`는 각각 최신 입력 기준으로 전체 교체됩니다.
                     - 특정 목록을 비우려면 빈 배열을 보내야 합니다.
                     - 존재하지 않거나 비활성화된 참조 데이터 ID는 거절됩니다.
+                    - `dislikedMenuItemIds`는 활성 `MenuItem` 검색/선택 결과의 ID 목록입니다.
                     - 성공 시 조회 API와 동일한 구조를 반환합니다.
                     - `profileVersion`은 수정 시각 대체값이 아니라 프로필 정책/구조 버전이므로, 단순 저장만으로는 바뀌지 않습니다.
                     """)
@@ -485,6 +494,13 @@ public interface MemberApi {
                                                     "name": "땅콩",
                                                     "allergen": true,
                                                     "sortOrder": 10
+                                                  }
+                                                ],
+                                                "dislikedMenuItems": [
+                                                  {
+                                                    "id": 1001,
+                                                    "code": "PORK_CUTLET",
+                                                    "name": "돈까스"
                                                   }
                                                 ],
                                                 "updatedAt": "2026-04-20T18:00:00"
@@ -526,6 +542,36 @@ public interface MemberApi {
                                                         "status": 400,
                                                         "code": "MEMBER_INVALID_TASTE_RESTRICTION_INGREDIENT",
                                                         "message": "유효하지 않거나 비활성화된 restriction ingredient ID가 포함되어 있습니다. restrictionIngredientIds : [999]",
+                                                        "details": []
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "duplicateDislikedMenuItem",
+                                            value = """
+                                                    {
+                                                      "success": false,
+                                                      "data": null,
+                                                      "error": {
+                                                        "status": 400,
+                                                        "code": "MEMBER_DUPLICATE_TASTE_DISLIKED_MENU_ITEM",
+                                                        "message": "중복된 disliked menu item ID가 포함되어 있습니다. dislikedMenuItemIds : [1001, 1001]",
+                                                        "details": []
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "invalidDislikedMenuItem",
+                                            value = """
+                                                    {
+                                                      "success": false,
+                                                      "data": null,
+                                                      "error": {
+                                                        "status": 400,
+                                                        "code": "MEMBER_INVALID_TASTE_DISLIKED_MENU_ITEM",
+                                                        "message": "유효하지 않거나 비활성화된 disliked menu item ID가 포함되어 있습니다. dislikedMenuItemIds : [999]",
                                                         "details": []
                                                       }
                                                     }

--- a/src/main/java/matchuri/backend/api/member/dto/request/UpdateMemberTasteProfileRequest.java
+++ b/src/main/java/matchuri/backend/api/member/dto/request/UpdateMemberTasteProfileRequest.java
@@ -17,6 +17,13 @@ public record UpdateMemberTasteProfileRequest(
                 example = "[101]"
         )
         @NotNull(message = "restrictionIngredientIds는 null일 수 없습니다.")
-        List<@NotNull(message = "restrictionIngredientIds 항목은 null일 수 없습니다.") Long> restrictionIngredientIds
+        List<@NotNull(message = "restrictionIngredientIds 항목은 null일 수 없습니다.") Long> restrictionIngredientIds,
+
+        @Schema(
+                description = "현재 선택한 disliked menu item ID 목록입니다. 전체 교체형 저장이므로 비우려면 빈 배열을 보내야 합니다.",
+                example = "[1001, 1002]"
+        )
+        @NotNull(message = "dislikedMenuItemIds는 null일 수 없습니다.")
+        List<@NotNull(message = "dislikedMenuItemIds 항목은 null일 수 없습니다.") Long> dislikedMenuItemIds
 ) {
 }

--- a/src/main/java/matchuri/backend/api/member/dto/response/MemberTasteDislikedMenuItemResponse.java
+++ b/src/main/java/matchuri/backend/api/member/dto/response/MemberTasteDislikedMenuItemResponse.java
@@ -1,0 +1,15 @@
+package matchuri.backend.api.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MemberTasteDislikedMenuItemResponse(
+        @Schema(description = "선택된 disliked menu item ID입니다.", example = "1001")
+        Long id,
+
+        @Schema(description = "선택된 disliked menu item 코드입니다.", example = "PORK_CUTLET")
+        String code,
+
+        @Schema(description = "선택된 disliked menu item 표시 이름입니다.", example = "돈까스")
+        String name
+) {
+}

--- a/src/main/java/matchuri/backend/api/member/dto/response/MemberTasteProfileSummaryResponse.java
+++ b/src/main/java/matchuri/backend/api/member/dto/response/MemberTasteProfileSummaryResponse.java
@@ -17,6 +17,9 @@ public record MemberTasteProfileSummaryResponse(
         @Schema(description = "현재 선택된 restriction ingredient 목록입니다.")
         List<MemberTasteRestrictionIngredientResponse> restrictionIngredients,
 
+        @Schema(description = "현재 선택된 disliked menu item 목록입니다.")
+        List<MemberTasteDislikedMenuItemResponse> dislikedMenuItems,
+
         @Schema(description = "취향 프로필이 마지막으로 갱신된 시각입니다. 프로필이 없으면 null입니다.", example = "2026-04-17T12:30:45")
         LocalDateTime updatedAt
 ) {

--- a/src/main/java/matchuri/backend/api/member/mapper/MemberMapper.java
+++ b/src/main/java/matchuri/backend/api/member/mapper/MemberMapper.java
@@ -7,6 +7,7 @@ import matchuri.backend.api.member.dto.request.RegisterLocalMemberRequest;
 import matchuri.backend.api.member.dto.request.UpdateMemberTasteProfileRequest;
 import matchuri.backend.api.member.dto.response.CreateMemberResponse;
 import matchuri.backend.api.member.dto.response.LoginIdExistsResponse;
+import matchuri.backend.api.member.dto.response.MemberTasteDislikedMenuItemResponse;
 import matchuri.backend.api.member.dto.response.MemberTasteAttributeCategoryResponse;
 import matchuri.backend.api.member.dto.response.MemberProfileResponse;
 import matchuri.backend.api.member.dto.response.MemberTasteProfileSummaryResponse;
@@ -124,6 +125,13 @@ public class MemberMapper {
                                 item.sortOrder()
                         ))
                         .toList(),
+                result.dislikedMenuItems().stream()
+                        .map(item -> new MemberTasteDislikedMenuItemResponse(
+                                item.id(),
+                                item.code(),
+                                item.name()
+                        ))
+                        .toList(),
                 result.updatedAt()
         );
     }
@@ -135,7 +143,8 @@ public class MemberMapper {
     public UpdateMemberTasteProfileCommand toUpdateMemberTasteProfileCommand(UpdateMemberTasteProfileRequest request) {
         return new UpdateMemberTasteProfileCommand(
                 request.attributeCategoryIds(),
-                request.restrictionIngredientIds()
+                request.restrictionIngredientIds(),
+                request.dislikedMenuItemIds()
         );
     }
 

--- a/src/main/java/matchuri/backend/bootstrap/ReferenceDataInitializer.java
+++ b/src/main/java/matchuri/backend/bootstrap/ReferenceDataInitializer.java
@@ -4,8 +4,10 @@ import lombok.extern.slf4j.Slf4j;
 import matchuri.backend.domain.menu.entity.AttributeCategory;
 import matchuri.backend.domain.menu.entity.CategoryType;
 import matchuri.backend.domain.menu.entity.Ingredient;
+import matchuri.backend.domain.menu.entity.MenuItem;
 import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
 import matchuri.backend.domain.menu.repository.IngredientRepository;
+import matchuri.backend.domain.menu.repository.MenuItemRepository;
 import matchuri.backend.global.config.MatchuriProperties;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -19,15 +21,18 @@ public class ReferenceDataInitializer {
     private final MatchuriProperties matchuriProperties;
     private final AttributeCategoryRepository attributeCategoryRepository;
     private final IngredientRepository ingredientRepository;
+    private final MenuItemRepository menuItemRepository;
 
     public ReferenceDataInitializer(
             MatchuriProperties matchuriProperties,
             AttributeCategoryRepository attributeCategoryRepository,
-            IngredientRepository ingredientRepository
+            IngredientRepository ingredientRepository,
+            MenuItemRepository menuItemRepository
     ) {
         this.matchuriProperties = matchuriProperties;
         this.attributeCategoryRepository = attributeCategoryRepository;
         this.ingredientRepository = ingredientRepository;
+        this.menuItemRepository = menuItemRepository;
     }
 
     @Transactional
@@ -48,6 +53,15 @@ public class ReferenceDataInitializer {
         createdCount += createIngredientIfAbsent("SHRIMP", "새우", true, 20);
         createdCount += createIngredientIfAbsent("MILK", "우유", true, 30);
         createdCount += createIngredientIfAbsent("EGG", "계란", true, 40);
+
+        createdCount += createMenuItemIfAbsent("KIMCHI_STEW", "김치찌개", "김치와 돼지고기를 넣고 끓인 대표적인 한식 찌개입니다.");
+        createdCount += createMenuItemIfAbsent("DOENJANG_STEW", "된장찌개", "된장을 기본으로 두부와 채소를 넣어 끓인 구수한 찌개입니다.");
+        createdCount += createMenuItemIfAbsent("BIBIMBAP", "비빔밥", "밥 위에 여러 나물과 고추장을 올려 비벼 먹는 한식 메뉴입니다.");
+        createdCount += createMenuItemIfAbsent("PORK_CUTLET", "돈까스", "돼지고기를 튀겨 소스와 함께 먹는 바삭한 메뉴입니다.");
+        createdCount += createMenuItemIfAbsent("JJAJANGMYEON", "짜장면", "춘장 소스에 면을 비벼 먹는 중식 면 요리입니다.");
+        createdCount += createMenuItemIfAbsent("JJAMPPONG", "짬뽕", "해산물과 채소를 넣은 매콤한 국물 면 요리입니다.");
+        createdCount += createMenuItemIfAbsent("RAMEN", "라멘", "진한 육수와 면을 함께 즐기는 일본식 면 요리입니다.");
+        createdCount += createMenuItemIfAbsent("SUSHI", "초밥", "초밥용 밥 위에 생선이나 재료를 올린 메뉴입니다.");
 
         log.info("Reference seed initialization completed. createdCount={}", createdCount);
         return createdCount;
@@ -72,6 +86,17 @@ public class ReferenceDataInitializer {
 
         ingredientRepository.save(new Ingredient(code, name, allergen, sortOrder));
         log.info("Ingredient created. code={}", code);
+        return 1;
+    }
+
+    private int createMenuItemIfAbsent(String code, String name, String description) {
+        if (menuItemRepository.existsByCode(code)) {
+            log.info("Menu item already exists. code={}", code);
+            return 0;
+        }
+
+        menuItemRepository.save(new MenuItem(code, name, description));
+        log.info("Menu item created. code={}", code);
         return 1;
     }
 }

--- a/src/main/java/matchuri/backend/domain/member/command/UpdateMemberTasteProfileCommand.java
+++ b/src/main/java/matchuri/backend/domain/member/command/UpdateMemberTasteProfileCommand.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 public record UpdateMemberTasteProfileCommand(
         List<Long> attributeCategoryIds,
-        List<Long> restrictionIngredientIds
+        List<Long> restrictionIngredientIds,
+        List<Long> dislikedMenuItemIds
 ) {
 }

--- a/src/main/java/matchuri/backend/domain/member/entity/MemberTasteProfileDislikedMenuItem.java
+++ b/src/main/java/matchuri/backend/domain/member/entity/MemberTasteProfileDislikedMenuItem.java
@@ -1,0 +1,56 @@
+package matchuri.backend.domain.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import matchuri.backend.domain.common.BaseEntity;
+import matchuri.backend.domain.menu.entity.MenuItem;
+
+@Getter
+@Entity
+@Table(
+    name = "member_taste_profile_disliked_menu_items",
+    comment = "회원 취향 프로필 비선호 메뉴 매핑",
+    indexes = {
+        @Index(name = "idx_member_profile_disliked_menu_profile", columnList = "profile_id"),
+        @Index(name = "idx_member_profile_disliked_menu_menu", columnList = "menu_id")
+    },
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_member_profile_disliked_menu_item",
+            columnNames = {"profile_id", "menu_id"}
+        )
+    }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberTasteProfileDislikedMenuItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(comment = "회원 취향 프로필 비선호 메뉴 매핑 ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "profile_id", nullable = false, comment = "회원 취향 프로필 ID")
+    private MemberTasteProfile profile;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "menu_id", nullable = false, comment = "메뉴 ID")
+    private MenuItem menuItem;
+
+    public MemberTasteProfileDislikedMenuItem(MemberTasteProfile profile, MenuItem menuItem) {
+        this.profile = profile;
+        this.menuItem = menuItem;
+    }
+}

--- a/src/main/java/matchuri/backend/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/member/exception/MemberErrorCode.java
@@ -16,8 +16,10 @@ public enum MemberErrorCode implements ErrorCode {
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다. nickname : {0}"),
     DUPLICATE_TASTE_ATTRIBUTE_CATEGORY(HttpStatus.BAD_REQUEST, "중복된 attribute category ID가 포함되어 있습니다. attributeCategoryIds : {0}"),
     DUPLICATE_TASTE_RESTRICTION_INGREDIENT(HttpStatus.BAD_REQUEST, "중복된 restriction ingredient ID가 포함되어 있습니다. restrictionIngredientIds : {0}"),
+    DUPLICATE_TASTE_DISLIKED_MENU_ITEM(HttpStatus.BAD_REQUEST, "중복된 disliked menu item ID가 포함되어 있습니다. dislikedMenuItemIds : {0}"),
     INVALID_TASTE_ATTRIBUTE_CATEGORY(HttpStatus.BAD_REQUEST, "유효하지 않거나 비활성화된 attribute category ID가 포함되어 있습니다. attributeCategoryIds : {0}"),
     INVALID_TASTE_RESTRICTION_INGREDIENT(HttpStatus.BAD_REQUEST, "유효하지 않거나 비활성화된 restriction ingredient ID가 포함되어 있습니다. restrictionIngredientIds : {0}"),
+    INVALID_TASTE_DISLIKED_MENU_ITEM(HttpStatus.BAD_REQUEST, "유효하지 않거나 비활성화된 disliked menu item ID가 포함되어 있습니다. dislikedMenuItemIds : {0}"),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
     NICKNAME_REQUIRED(HttpStatus.FORBIDDEN, "닉네임 설정이 필요합니다."),
     INACTIVE_MEMBER(HttpStatus.FORBIDDEN, "비활성화된 회원입니다. memberId : {0}");

--- a/src/main/java/matchuri/backend/domain/member/repository/MemberTasteProfileDislikedMenuItemRepository.java
+++ b/src/main/java/matchuri/backend/domain/member/repository/MemberTasteProfileDislikedMenuItemRepository.java
@@ -1,0 +1,21 @@
+package matchuri.backend.domain.member.repository;
+
+import java.util.List;
+import matchuri.backend.domain.member.entity.MemberTasteProfileDislikedMenuItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface MemberTasteProfileDislikedMenuItemRepository extends JpaRepository<MemberTasteProfileDislikedMenuItem, Long> {
+
+    List<MemberTasteProfileDislikedMenuItem> findAllByProfileId(Long profileId);
+
+    @Query("""
+            select mapping
+            from MemberTasteProfileDislikedMenuItem mapping
+            join fetch mapping.menuItem menuItem
+            where mapping.profile.id = :profileId
+            order by menuItem.name asc, menuItem.id asc
+            """)
+    List<MemberTasteProfileDislikedMenuItem> findAllByProfileIdOrderByDisplay(@Param("profileId") Long profileId);
+}

--- a/src/main/java/matchuri/backend/domain/member/result/MemberTasteProfileSummaryResult.java
+++ b/src/main/java/matchuri/backend/domain/member/result/MemberTasteProfileSummaryResult.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import matchuri.backend.domain.member.entity.MemberTasteProfile;
 import matchuri.backend.domain.member.entity.MemberTasteProfileCategory;
+import matchuri.backend.domain.member.entity.MemberTasteProfileDislikedMenuItem;
 import matchuri.backend.domain.member.entity.MemberTasteProfileRestrictionIngredient;
 import matchuri.backend.domain.menu.entity.CategoryType;
 
@@ -12,6 +13,7 @@ public record MemberTasteProfileSummaryResult(
         String profileVersion,
         List<AttributeCategoryItem> attributeCategories,
         List<RestrictionIngredientItem> restrictionIngredients,
+        List<DislikedMenuItem> dislikedMenuItems,
         LocalDateTime updatedAt
 ) {
 
@@ -23,6 +25,7 @@ public record MemberTasteProfileSummaryResult(
                 DEFAULT_PROFILE_VERSION,
                 List.of(),
                 List.of(),
+                List.of(),
                 null
         );
     }
@@ -31,7 +34,8 @@ public record MemberTasteProfileSummaryResult(
             Long memberId,
             MemberTasteProfile profile,
             List<MemberTasteProfileCategory> attributeCategories,
-            List<MemberTasteProfileRestrictionIngredient> restrictionIngredients
+            List<MemberTasteProfileRestrictionIngredient> restrictionIngredients,
+            List<MemberTasteProfileDislikedMenuItem> dislikedMenuItems
     ) {
         return new MemberTasteProfileSummaryResult(
                 memberId,
@@ -41,6 +45,9 @@ public record MemberTasteProfileSummaryResult(
                         .toList(),
                 restrictionIngredients.stream()
                         .map(RestrictionIngredientItem::from)
+                        .toList(),
+                dislikedMenuItems.stream()
+                        .map(DislikedMenuItem::from)
                         .toList(),
                 profile.getUpdatedAt()
         );
@@ -82,6 +89,22 @@ public record MemberTasteProfileSummaryResult(
                     ingredient.getName(),
                     ingredient.isAllergen(),
                     ingredient.getSortOrder()
+            );
+        }
+    }
+
+    public record DislikedMenuItem(
+            Long id,
+            String code,
+            String name
+    ) {
+
+        public static DislikedMenuItem from(MemberTasteProfileDislikedMenuItem mapping) {
+            var menuItem = mapping.getMenuItem();
+            return new DislikedMenuItem(
+                    menuItem.getId(),
+                    menuItem.getCode(),
+                    menuItem.getName()
             );
         }
     }

--- a/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
@@ -14,8 +14,10 @@ import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.entity.MemberAgreement;
 import matchuri.backend.domain.member.entity.MemberTasteProfile;
 import matchuri.backend.domain.member.entity.MemberTasteProfileCategory;
+import matchuri.backend.domain.member.entity.MemberTasteProfileDislikedMenuItem;
 import matchuri.backend.domain.member.entity.MemberTasteProfileRestrictionIngredient;
 import matchuri.backend.domain.member.repository.MemberTasteProfileCategoryRepository;
+import matchuri.backend.domain.member.repository.MemberTasteProfileDislikedMenuItemRepository;
 import matchuri.backend.domain.member.exception.MemberErrorCode;
 import matchuri.backend.domain.member.repository.MemberAgreementRepository;
 import matchuri.backend.domain.member.repository.MemberRepository;
@@ -32,8 +34,10 @@ import matchuri.backend.domain.member.support.member.ActiveMemberReader;
 import matchuri.backend.domain.member.support.onboarding.OnboardingStatusResolver;
 import matchuri.backend.domain.menu.entity.AttributeCategory;
 import matchuri.backend.domain.menu.entity.Ingredient;
+import matchuri.backend.domain.menu.entity.MenuItem;
 import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
 import matchuri.backend.domain.menu.repository.IngredientRepository;
+import matchuri.backend.domain.menu.repository.MenuItemRepository;
 import matchuri.backend.global.exception.BusinessException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -50,8 +54,10 @@ public class MemberServiceImpl implements MemberService {
     private final MemberTasteProfileRepository memberTasteProfileRepository;
     private final MemberTasteProfileCategoryRepository memberTasteProfileCategoryRepository;
     private final MemberTasteProfileRestrictionIngredientRepository memberTasteProfileRestrictionIngredientRepository;
+    private final MemberTasteProfileDislikedMenuItemRepository memberTasteProfileDislikedMenuItemRepository;
     private final AttributeCategoryRepository attributeCategoryRepository;
     private final IngredientRepository ingredientRepository;
+    private final MenuItemRepository menuItemRepository;
     private final RequiredAgreementRequestValidator requiredAgreementRequestValidator;
     private final PasswordEncoder passwordEncoder;
     private final ActiveMemberReader activeMemberReader;
@@ -112,7 +118,8 @@ public class MemberServiceImpl implements MemberService {
                         member.getId(),
                         tasteProfile,
                         memberTasteProfileCategoryRepository.findAllByProfileIdOrderByDisplay(tasteProfile.getId()),
-                        memberTasteProfileRestrictionIngredientRepository.findAllByProfileIdOrderByDisplay(tasteProfile.getId())
+                        memberTasteProfileRestrictionIngredientRepository.findAllByProfileIdOrderByDisplay(tasteProfile.getId()),
+                        memberTasteProfileDislikedMenuItemRepository.findAllByProfileIdOrderByDisplay(tasteProfile.getId())
                 ))
                 .orElseGet(() -> MemberTasteProfileSummaryResult.empty(member.getId()));
     }
@@ -143,6 +150,7 @@ public class MemberServiceImpl implements MemberService {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
         List<Long> attributeCategoryIds = command.attributeCategoryIds();
         List<Long> restrictionIngredientIds = command.restrictionIngredientIds();
+        List<Long> dislikedMenuItemIds = command.dislikedMenuItemIds();
 
         validateNoDuplicateIds(
                 attributeCategoryIds,
@@ -152,9 +160,14 @@ public class MemberServiceImpl implements MemberService {
                 restrictionIngredientIds,
                 MemberErrorCode.DUPLICATE_TASTE_RESTRICTION_INGREDIENT
         );
+        validateNoDuplicateIds(
+                dislikedMenuItemIds,
+                MemberErrorCode.DUPLICATE_TASTE_DISLIKED_MENU_ITEM
+        );
 
         Map<Long, AttributeCategory> attributeCategoriesById = loadActiveAttributeCategories(attributeCategoryIds);
         Map<Long, Ingredient> ingredientsById = loadActiveIngredients(restrictionIngredientIds);
+        Map<Long, MenuItem> menuItemsById = loadActiveMenuItems(dislikedMenuItemIds);
 
         MemberTasteProfile tasteProfile = memberTasteProfileRepository.findByMemberId(member.getId())
                 .orElseGet(() -> memberTasteProfileRepository.saveAndFlush(
@@ -163,12 +176,14 @@ public class MemberServiceImpl implements MemberService {
 
         replaceAttributeCategoryMappings(tasteProfile, attributeCategoryIds, attributeCategoriesById);
         replaceRestrictionIngredientMappings(tasteProfile, restrictionIngredientIds, ingredientsById);
+        replaceDislikedMenuItemMappings(tasteProfile, dislikedMenuItemIds, menuItemsById);
 
         return MemberTasteProfileSummaryResult.of(
                 member.getId(),
                 tasteProfile,
                 memberTasteProfileCategoryRepository.findAllByProfileIdOrderByDisplay(tasteProfile.getId()),
-                memberTasteProfileRestrictionIngredientRepository.findAllByProfileIdOrderByDisplay(tasteProfile.getId())
+                memberTasteProfileRestrictionIngredientRepository.findAllByProfileIdOrderByDisplay(tasteProfile.getId()),
+                memberTasteProfileDislikedMenuItemRepository.findAllByProfileIdOrderByDisplay(tasteProfile.getId())
         );
     }
 
@@ -244,6 +259,16 @@ public class MemberServiceImpl implements MemberService {
                 .collect(Collectors.toMap(Ingredient::getId, Function.identity()));
     }
 
+    private Map<Long, MenuItem> loadActiveMenuItems(List<Long> dislikedMenuItemIds) {
+        List<MenuItem> menuItems = menuItemRepository.findAllByIdInAndActiveTrue(dislikedMenuItemIds);
+        if (menuItems.size() != dislikedMenuItemIds.size()) {
+            throw new BusinessException(MemberErrorCode.INVALID_TASTE_DISLIKED_MENU_ITEM, dislikedMenuItemIds);
+        }
+
+        return menuItems.stream()
+                .collect(Collectors.toMap(MenuItem::getId, Function.identity()));
+    }
+
     private void replaceAttributeCategoryMappings(
             MemberTasteProfile tasteProfile,
             List<Long> attributeCategoryIds,
@@ -285,6 +310,29 @@ public class MemberServiceImpl implements MemberService {
                         .map(restrictionIngredientId -> new MemberTasteProfileRestrictionIngredient(
                                 tasteProfile,
                                 ingredientsById.get(restrictionIngredientId)
+                        ))
+                        .toList()
+        );
+    }
+
+    private void replaceDislikedMenuItemMappings(
+            MemberTasteProfile tasteProfile,
+            List<Long> dislikedMenuItemIds,
+            Map<Long, MenuItem> menuItemsById
+    ) {
+        memberTasteProfileDislikedMenuItemRepository.deleteAllInBatch(
+                memberTasteProfileDislikedMenuItemRepository.findAllByProfileId(tasteProfile.getId())
+        );
+
+        if (dislikedMenuItemIds.isEmpty()) {
+            return;
+        }
+
+        memberTasteProfileDislikedMenuItemRepository.saveAll(
+                dislikedMenuItemIds.stream()
+                        .map(dislikedMenuItemId -> new MemberTasteProfileDislikedMenuItem(
+                                tasteProfile,
+                                menuItemsById.get(dislikedMenuItemId)
                         ))
                         .toList()
         );

--- a/src/main/java/matchuri/backend/domain/menu/repository/MenuItemRepository.java
+++ b/src/main/java/matchuri/backend/domain/menu/repository/MenuItemRepository.java
@@ -1,0 +1,13 @@
+package matchuri.backend.domain.menu.repository;
+
+import java.util.Collection;
+import java.util.List;
+import matchuri.backend.domain.menu.entity.MenuItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuItemRepository extends JpaRepository<MenuItem, Long> {
+
+    boolean existsByCode(String code);
+
+    List<MenuItem> findAllByIdInAndActiveTrue(Collection<Long> ids);
+}

--- a/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
@@ -31,18 +31,22 @@ import matchuri.backend.domain.member.entity.MemberRole;
 import matchuri.backend.domain.member.entity.MemberStatus;
 import matchuri.backend.domain.member.entity.MemberTasteProfile;
 import matchuri.backend.domain.member.entity.MemberTasteProfileCategory;
+import matchuri.backend.domain.member.entity.MemberTasteProfileDislikedMenuItem;
 import matchuri.backend.domain.member.entity.MemberTasteProfileRestrictionIngredient;
 import matchuri.backend.domain.member.entity.SocialProviderType;
 import matchuri.backend.domain.member.repository.MemberAgreementRepository;
 import matchuri.backend.domain.member.repository.MemberRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileCategoryRepository;
+import matchuri.backend.domain.member.repository.MemberTasteProfileDislikedMenuItemRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileRestrictionIngredientRepository;
 import matchuri.backend.domain.menu.entity.AttributeCategory;
 import matchuri.backend.domain.menu.entity.CategoryType;
 import matchuri.backend.domain.menu.entity.Ingredient;
+import matchuri.backend.domain.menu.entity.MenuItem;
 import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
 import matchuri.backend.domain.menu.repository.IngredientRepository;
+import matchuri.backend.domain.menu.repository.MenuItemRepository;
 import matchuri.backend.global.config.MatchuriProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -87,6 +91,9 @@ class MemberAuthIntegrationTest {
     private MemberTasteProfileRestrictionIngredientRepository memberTasteProfileRestrictionIngredientRepository;
 
     @Autowired
+    private MemberTasteProfileDislikedMenuItemRepository memberTasteProfileDislikedMenuItemRepository;
+
+    @Autowired
     private MemberAgreementRepository memberAgreementRepository;
 
     @Autowired
@@ -94,6 +101,9 @@ class MemberAuthIntegrationTest {
 
     @Autowired
     private IngredientRepository ingredientRepository;
+
+    @Autowired
+    private MenuItemRepository menuItemRepository;
 
     @Autowired
     private MatchuriProperties matchuriProperties;
@@ -105,9 +115,11 @@ class MemberAuthIntegrationTest {
         memberAgreementRepository.deleteAll();
         memberTasteProfileCategoryRepository.deleteAll();
         memberTasteProfileRestrictionIngredientRepository.deleteAll();
+        memberTasteProfileDislikedMenuItemRepository.deleteAll();
         memberTasteProfileRepository.deleteAll();
         attributeCategoryRepository.deleteAll();
         ingredientRepository.deleteAll();
+        menuItemRepository.deleteAll();
         memberRepository.deleteAll();
     }
 
@@ -247,6 +259,9 @@ class MemberAuthIntegrationTest {
         Ingredient ingredient = ingredientRepository.save(
                 new Ingredient("PEANUT", "땅콩", true, 10)
         );
+        MenuItem menuItem = menuItemRepository.save(
+                new MenuItem("PORK_CUTLET", "돈까스", "바삭한 돼지고기 튀김")
+        );
 
         mockMvc.perform(get("/api/v1/members/me")
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken)))
@@ -275,14 +290,16 @@ class MemberAuthIntegrationTest {
                         .content("""
                                 {
                                   "attributeCategoryIds": [%d],
-                                  "restrictionIngredientIds": [%d]
+                                  "restrictionIngredientIds": [%d],
+                                  "dislikedMenuItemIds": [%d]
                                 }
-                                """.formatted(attributeCategory.getId(), ingredient.getId())))
+                                """.formatted(attributeCategory.getId(), ingredient.getId(), menuItem.getId())))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.memberId").isNumber())
                 .andExpect(jsonPath("$.data.profileVersion").value("v1"))
                 .andExpect(jsonPath("$.data.attributeCategories[0].code").value("SPICY"))
                 .andExpect(jsonPath("$.data.restrictionIngredients[0].code").value("PEANUT"))
+                .andExpect(jsonPath("$.data.dislikedMenuItems[0].code").value("PORK_CUTLET"))
                 .andExpect(jsonPath("$.data.updatedAt").exists());
 
         mockMvc.perform(get("/api/v1/members/me")
@@ -342,6 +359,7 @@ class MemberAuthIntegrationTest {
                 .andExpect(jsonPath("$.data.profileVersion").value("v1"))
                 .andExpect(jsonPath("$.data.attributeCategories.length()").value(0))
                 .andExpect(jsonPath("$.data.restrictionIngredients.length()").value(0))
+                .andExpect(jsonPath("$.data.dislikedMenuItems.length()").value(0))
                 .andExpect(jsonPath("$.data.updatedAt").value(nullValue()));
     }
 
@@ -359,10 +377,16 @@ class MemberAuthIntegrationTest {
         Ingredient ingredient = ingredientRepository.save(
                 new Ingredient("PEANUT", "땅콩", true, 10)
         );
+        MenuItem menuItem = menuItemRepository.save(
+                new MenuItem("PORK_CUTLET", "돈까스", "바삭한 돼지고기 튀김")
+        );
         MemberTasteProfile tasteProfile = memberTasteProfileRepository.save(new MemberTasteProfile(member, "v2"));
         memberTasteProfileCategoryRepository.save(new MemberTasteProfileCategory(tasteProfile, attributeCategory));
         memberTasteProfileRestrictionIngredientRepository.save(
                 new MemberTasteProfileRestrictionIngredient(tasteProfile, ingredient)
+        );
+        memberTasteProfileDislikedMenuItemRepository.save(
+                new MemberTasteProfileDislikedMenuItem(tasteProfile, menuItem)
         );
 
         mockMvc.perform(get("/api/v1/members/me/taste-profile")
@@ -377,6 +401,9 @@ class MemberAuthIntegrationTest {
                 .andExpect(jsonPath("$.data.restrictionIngredients[0].id").value(ingredient.getId()))
                 .andExpect(jsonPath("$.data.restrictionIngredients[0].code").value("PEANUT"))
                 .andExpect(jsonPath("$.data.restrictionIngredients[0].allergen").value(true))
+                .andExpect(jsonPath("$.data.dislikedMenuItems[0].id").value(menuItem.getId()))
+                .andExpect(jsonPath("$.data.dislikedMenuItems[0].code").value("PORK_CUTLET"))
+                .andExpect(jsonPath("$.data.dislikedMenuItems[0].name").value("돈까스"))
                 .andExpect(jsonPath("$.data.updatedAt").isNotEmpty());
     }
 
@@ -393,7 +420,8 @@ class MemberAuthIntegrationTest {
                         .content("""
                                 {
                                   "attributeCategoryIds": [999],
-                                  "restrictionIngredientIds": []
+                                  "restrictionIngredientIds": [],
+                                  "dislikedMenuItemIds": []
                                 }
                                 """))
                 .andExpect(status().isBadRequest())
@@ -413,11 +441,54 @@ class MemberAuthIntegrationTest {
                         .content("""
                                 {
                                   "attributeCategoryIds": [1, 1],
-                                  "restrictionIngredientIds": []
+                                  "restrictionIngredientIds": [],
+                                  "dislikedMenuItemIds": []
                                 }
                                 """))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error.code").value("MEMBER_DUPLICATE_TASTE_ATTRIBUTE_CATEGORY"));
+    }
+
+    @Test
+    @DisplayName("내 취향 프로필 저장은 잘못된 disliked menu item ID를 거절한다")
+    void updateMyTasteProfileRejectsInvalidDislikedMenuItem() throws Exception {
+        createMemberThroughApi("taste-user-invalid-menu", "P@ssw0rd!");
+        AuthSession authSession = login("taste-user-invalid-menu", "P@ssw0rd!");
+        String accessToken = submitRequiredAgreements(authSession.accessToken());
+
+        mockMvc.perform(patch("/api/v1/members/me/taste-profile")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "attributeCategoryIds": [],
+                                  "restrictionIngredientIds": [],
+                                  "dislikedMenuItemIds": [999]
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("MEMBER_INVALID_TASTE_DISLIKED_MENU_ITEM"));
+    }
+
+    @Test
+    @DisplayName("내 취향 프로필 저장은 중복 disliked menu item ID를 거절한다")
+    void updateMyTasteProfileRejectsDuplicateDislikedMenuItemIds() throws Exception {
+        createMemberThroughApi("taste-user-duplicate-menu", "P@ssw0rd!");
+        AuthSession authSession = login("taste-user-duplicate-menu", "P@ssw0rd!");
+        String accessToken = submitRequiredAgreements(authSession.accessToken());
+
+        mockMvc.perform(patch("/api/v1/members/me/taste-profile")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "attributeCategoryIds": [],
+                                  "restrictionIngredientIds": [],
+                                  "dislikedMenuItemIds": [1001, 1001]
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("MEMBER_DUPLICATE_TASTE_DISLIKED_MENU_ITEM"));
     }
 
     @Test

--- a/src/test/java/matchuri/backend/api/menu/MenuAdminReferenceIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/menu/MenuAdminReferenceIntegrationTest.java
@@ -537,7 +537,8 @@ class MenuAdminReferenceIntegrationTest {
                         .content("""
                                 {
                                   "attributeCategoryIds": [],
-                                  "restrictionIngredientIds": [%d]
+                                  "restrictionIngredientIds": [%d],
+                                  "dislikedMenuItemIds": []
                                 }
                                 """.formatted(ingredient.getId())))
                 .andExpect(status().isBadRequest())
@@ -937,7 +938,8 @@ class MenuAdminReferenceIntegrationTest {
                         .content("""
                                 {
                                   "attributeCategoryIds": [%d],
-                                  "restrictionIngredientIds": []
+                                  "restrictionIngredientIds": [],
+                                  "dislikedMenuItemIds": []
                                 }
                                 """.formatted(attributeCategory.getId())))
                 .andExpect(status().isBadRequest())

--- a/src/test/java/matchuri/backend/bootstrap/SeedDataInitializerTest.java
+++ b/src/test/java/matchuri/backend/bootstrap/SeedDataInitializerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import matchuri.backend.domain.menu.entity.CategoryType;
 import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
 import matchuri.backend.domain.menu.repository.IngredientRepository;
+import matchuri.backend.domain.menu.repository.MenuItemRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,12 +34,16 @@ class SeedDataInitializerTest {
     @Autowired
     private IngredientRepository ingredientRepository;
 
+    @Autowired
+    private MenuItemRepository menuItemRepository;
+
     @Test
     @DisplayName("local 프로필에서는 참조 데이터와 샘플 회원 시드가 멱등하게 초기화된다")
     void initializesReferenceAndSampleDataIdempotently() throws Exception {
         long initialCount = memberRepository.count();
         long initialAttributeCategoryCount = attributeCategoryRepository.count();
         long initialIngredientCount = ingredientRepository.count();
+        long initialMenuItemCount = menuItemRepository.count();
 
         assertThat(memberRepository.existsByLoginId("tester01")).isTrue();
         assertThat(memberRepository.existsByLoginId("tester02")).isTrue();
@@ -46,15 +51,19 @@ class SeedDataInitializerTest {
         assertThat(attributeCategoryRepository.existsByCategoryTypeAndCode(CategoryType.TEMPERATURE, "HOT")).isTrue();
         assertThat(ingredientRepository.existsByCode("PEANUT")).isTrue();
         assertThat(ingredientRepository.existsByCode("EGG")).isTrue();
+        assertThat(menuItemRepository.existsByCode("KIMCHI_STEW")).isTrue();
+        assertThat(menuItemRepository.existsByCode("PORK_CUTLET")).isTrue();
 
         seedDataInitializer.run(new DefaultApplicationArguments(new String[0]));
 
         assertThat(memberRepository.count()).isEqualTo(initialCount);
         assertThat(attributeCategoryRepository.count()).isEqualTo(initialAttributeCategoryCount);
         assertThat(ingredientRepository.count()).isEqualTo(initialIngredientCount);
+        assertThat(menuItemRepository.count()).isEqualTo(initialMenuItemCount);
         assertThat(memberRepository.existsByLoginId("tester01")).isTrue();
         assertThat(memberRepository.existsByLoginId("tester02")).isTrue();
         assertThat(attributeCategoryRepository.existsByCategoryTypeAndCode(CategoryType.FLAVOR, "SPICY")).isTrue();
         assertThat(ingredientRepository.existsByCode("PEANUT")).isTrue();
+        assertThat(menuItemRepository.existsByCode("KIMCHI_STEW")).isTrue();
     }
 }

--- a/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
+++ b/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
@@ -21,6 +21,7 @@ import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.entity.MemberAgreement;
 import matchuri.backend.domain.member.entity.MemberTasteProfile;
 import matchuri.backend.domain.member.entity.MemberTasteProfileCategory;
+import matchuri.backend.domain.member.entity.MemberTasteProfileDislikedMenuItem;
 import matchuri.backend.domain.member.entity.MemberTasteProfileRestrictionIngredient;
 import matchuri.backend.domain.member.entity.MemberRole;
 import matchuri.backend.domain.member.entity.MemberStatus;
@@ -28,6 +29,7 @@ import matchuri.backend.domain.member.exception.MemberErrorCode;
 import matchuri.backend.domain.member.repository.MemberAgreementRepository;
 import matchuri.backend.domain.member.repository.MemberRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileCategoryRepository;
+import matchuri.backend.domain.member.repository.MemberTasteProfileDislikedMenuItemRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileRestrictionIngredientRepository;
 import matchuri.backend.domain.member.result.MemberTasteProfileSummaryResult;
@@ -41,8 +43,10 @@ import matchuri.backend.domain.member.support.onboarding.OnboardingStatusResolve
 import matchuri.backend.domain.menu.entity.AttributeCategory;
 import matchuri.backend.domain.menu.entity.CategoryType;
 import matchuri.backend.domain.menu.entity.Ingredient;
+import matchuri.backend.domain.menu.entity.MenuItem;
 import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
 import matchuri.backend.domain.menu.repository.IngredientRepository;
+import matchuri.backend.domain.menu.repository.MenuItemRepository;
 import matchuri.backend.global.exception.BusinessException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -72,10 +76,16 @@ class MemberServiceImplTest {
     private MemberTasteProfileRestrictionIngredientRepository memberTasteProfileRestrictionIngredientRepository;
 
     @Mock
+    private MemberTasteProfileDislikedMenuItemRepository memberTasteProfileDislikedMenuItemRepository;
+
+    @Mock
     private AttributeCategoryRepository attributeCategoryRepository;
 
     @Mock
     private IngredientRepository ingredientRepository;
+
+    @Mock
+    private MenuItemRepository menuItemRepository;
 
     @Mock
     private RequiredAgreementRequestValidator requiredAgreementRequestValidator;
@@ -214,6 +224,7 @@ class MemberServiceImplTest {
         assertThat(result.profileVersion()).isEqualTo(MemberTasteProfileSummaryResult.DEFAULT_PROFILE_VERSION);
         assertThat(result.attributeCategories()).isEmpty();
         assertThat(result.restrictionIngredients()).isEmpty();
+        assertThat(result.dislikedMenuItems()).isEmpty();
         assertThat(result.updatedAt()).isNull();
     }
 
@@ -230,6 +241,7 @@ class MemberServiceImplTest {
         MemberTasteProfile profile = new MemberTasteProfile(member, "v2");
         AttributeCategory attributeCategory = new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 10);
         Ingredient ingredient = new Ingredient("PEANUT", "땅콩", true, 10);
+        MenuItem menuItem = new MenuItem("PORK_CUTLET", "돈까스", "바삭한 돼지고기 튀김");
 
         when(activeMemberReader.getCurrentAuthenticatedActiveMember()).thenReturn(member);
         when(memberTasteProfileRepository.findByMemberId(1L)).thenReturn(java.util.Optional.of(profile));
@@ -237,6 +249,8 @@ class MemberServiceImplTest {
                 .thenReturn(List.of(new MemberTasteProfileCategory(profile, attributeCategory)));
         when(memberTasteProfileRestrictionIngredientRepository.findAllByProfileIdOrderByDisplay(profile.getId()))
                 .thenReturn(List.of(new MemberTasteProfileRestrictionIngredient(profile, ingredient)));
+        when(memberTasteProfileDislikedMenuItemRepository.findAllByProfileIdOrderByDisplay(profile.getId()))
+                .thenReturn(List.of(new MemberTasteProfileDislikedMenuItem(profile, menuItem)));
 
         MemberTasteProfileSummaryResult result = memberService.getMyTasteProfile();
 
@@ -256,6 +270,12 @@ class MemberServiceImplTest {
                         MemberTasteProfileSummaryResult.RestrictionIngredientItem::allergen
                 )
                 .containsExactly("PEANUT", "땅콩", true);
+        assertThat(result.dislikedMenuItems()).singleElement()
+                .extracting(
+                        MemberTasteProfileSummaryResult.DislikedMenuItem::code,
+                        MemberTasteProfileSummaryResult.DislikedMenuItem::name
+                )
+                .containsExactly("PORK_CUTLET", "돈까스");
     }
 
     @Test
@@ -270,6 +290,7 @@ class MemberServiceImplTest {
                 .build();
         AttributeCategory attributeCategory = new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 10);
         Ingredient ingredient = new Ingredient("PEANUT", "땅콩", true, 10);
+        MenuItem menuItem = new MenuItem("PORK_CUTLET", "돈까스", "바삭한 돼지고기 튀김");
         MemberTasteProfile savedProfile = new MemberTasteProfile(member, "v1");
 
         when(activeMemberReader.getCurrentAuthenticatedActiveMember()).thenReturn(member);
@@ -277,23 +298,29 @@ class MemberServiceImplTest {
         when(memberTasteProfileRepository.saveAndFlush(any(MemberTasteProfile.class))).thenReturn(savedProfile);
         when(attributeCategoryRepository.findAllByIdInAndActiveTrue(List.of(1L))).thenReturn(List.of(attributeCategory));
         when(ingredientRepository.findAllByIdInAndActiveTrue(List.of(101L))).thenReturn(List.of(ingredient));
+        when(menuItemRepository.findAllByIdInAndActiveTrue(List.of(1001L))).thenReturn(List.of(menuItem));
         when(memberTasteProfileCategoryRepository.findAllByProfileId(savedProfile.getId())).thenReturn(Collections.emptyList());
         when(memberTasteProfileRestrictionIngredientRepository.findAllByProfileId(savedProfile.getId())).thenReturn(Collections.emptyList());
+        when(memberTasteProfileDislikedMenuItemRepository.findAllByProfileId(savedProfile.getId())).thenReturn(Collections.emptyList());
         when(memberTasteProfileCategoryRepository.findAllByProfileIdOrderByDisplay(savedProfile.getId()))
                 .thenReturn(List.of(new MemberTasteProfileCategory(savedProfile, attributeCategory)));
         when(memberTasteProfileRestrictionIngredientRepository.findAllByProfileIdOrderByDisplay(savedProfile.getId()))
                 .thenReturn(List.of(new MemberTasteProfileRestrictionIngredient(savedProfile, ingredient)));
+        when(memberTasteProfileDislikedMenuItemRepository.findAllByProfileIdOrderByDisplay(savedProfile.getId()))
+                .thenReturn(List.of(new MemberTasteProfileDislikedMenuItem(savedProfile, menuItem)));
 
         MemberTasteProfileSummaryResult result = memberService.updateMyTasteProfile(
-                new UpdateMemberTasteProfileCommand(List.of(1L), List.of(101L))
+                new UpdateMemberTasteProfileCommand(List.of(1L), List.of(101L), List.of(1001L))
         );
 
         assertThat(result.profileVersion()).isEqualTo("v1");
         assertThat(result.attributeCategories()).hasSize(1);
         assertThat(result.restrictionIngredients()).hasSize(1);
+        assertThat(result.dislikedMenuItems()).hasSize(1);
         verify(memberTasteProfileRepository).saveAndFlush(any(MemberTasteProfile.class));
         verify(memberTasteProfileCategoryRepository).saveAll(any());
         verify(memberTasteProfileRestrictionIngredientRepository).saveAll(any());
+        verify(memberTasteProfileDislikedMenuItemRepository).saveAll(any());
     }
 
     @Test
@@ -310,11 +337,32 @@ class MemberServiceImplTest {
         when(activeMemberReader.getCurrentAuthenticatedActiveMember()).thenReturn(member);
 
         assertThatThrownBy(() -> memberService.updateMyTasteProfile(
-                new UpdateMemberTasteProfileCommand(List.of(1L, 1L), List.of())
+                new UpdateMemberTasteProfileCommand(List.of(1L, 1L), List.of(), List.of())
         ))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(MemberErrorCode.DUPLICATE_TASTE_ATTRIBUTE_CATEGORY);
+    }
+
+    @Test
+    @DisplayName("내 취향 프로필 저장은 중복 disliked menu item ID를 거절한다")
+    void updateMyTasteProfileRejectsDuplicateDislikedMenuItemIds() {
+        Member member = Member.builder()
+                .id(1L)
+                .loginId("tester01")
+                .memberRole(MemberRole.MEMBER)
+                .status(MemberStatus.ACTIVE)
+                .social(false)
+                .build();
+
+        when(activeMemberReader.getCurrentAuthenticatedActiveMember()).thenReturn(member);
+
+        assertThatThrownBy(() -> memberService.updateMyTasteProfile(
+                new UpdateMemberTasteProfileCommand(List.of(), List.of(), List.of(1001L, 1001L))
+        ))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(MemberErrorCode.DUPLICATE_TASTE_DISLIKED_MENU_ITEM);
     }
 
     @Test
@@ -333,11 +381,35 @@ class MemberServiceImplTest {
         when(ingredientRepository.findAllByIdInAndActiveTrue(List.of(999L))).thenReturn(List.of());
 
         assertThatThrownBy(() -> memberService.updateMyTasteProfile(
-                new UpdateMemberTasteProfileCommand(List.of(), List.of(999L))
+                new UpdateMemberTasteProfileCommand(List.of(), List.of(999L), List.of())
         ))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(MemberErrorCode.INVALID_TASTE_RESTRICTION_INGREDIENT);
+    }
+
+    @Test
+    @DisplayName("내 취향 프로필 저장은 비활성 또는 존재하지 않는 disliked menu item ID를 거절한다")
+    void updateMyTasteProfileRejectsInvalidDislikedMenuItemIds() {
+        Member member = Member.builder()
+                .id(1L)
+                .loginId("tester01")
+                .memberRole(MemberRole.MEMBER)
+                .status(MemberStatus.ACTIVE)
+                .social(false)
+                .build();
+
+        when(activeMemberReader.getCurrentAuthenticatedActiveMember()).thenReturn(member);
+        when(attributeCategoryRepository.findAllByIdInAndActiveTrue(List.of())).thenReturn(List.of());
+        when(ingredientRepository.findAllByIdInAndActiveTrue(List.of())).thenReturn(List.of());
+        when(menuItemRepository.findAllByIdInAndActiveTrue(List.of(999L))).thenReturn(List.of());
+
+        assertThatThrownBy(() -> memberService.updateMyTasteProfile(
+                new UpdateMemberTasteProfileCommand(List.of(), List.of(), List.of(999L))
+        ))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(MemberErrorCode.INVALID_TASTE_DISLIKED_MENU_ITEM);
     }
 
     @Test
@@ -356,17 +428,21 @@ class MemberServiceImplTest {
         when(memberTasteProfileRepository.findByMemberId(1L)).thenReturn(Optional.of(profile));
         when(attributeCategoryRepository.findAllByIdInAndActiveTrue(List.of())).thenReturn(List.of());
         when(ingredientRepository.findAllByIdInAndActiveTrue(List.of())).thenReturn(List.of());
+        when(menuItemRepository.findAllByIdInAndActiveTrue(List.of())).thenReturn(List.of());
         when(memberTasteProfileCategoryRepository.findAllByProfileId(profile.getId())).thenReturn(Collections.emptyList());
         when(memberTasteProfileRestrictionIngredientRepository.findAllByProfileId(profile.getId())).thenReturn(Collections.emptyList());
+        when(memberTasteProfileDislikedMenuItemRepository.findAllByProfileId(profile.getId())).thenReturn(Collections.emptyList());
         when(memberTasteProfileCategoryRepository.findAllByProfileIdOrderByDisplay(profile.getId())).thenReturn(List.of());
         when(memberTasteProfileRestrictionIngredientRepository.findAllByProfileIdOrderByDisplay(profile.getId())).thenReturn(List.of());
+        when(memberTasteProfileDislikedMenuItemRepository.findAllByProfileIdOrderByDisplay(profile.getId())).thenReturn(List.of());
 
         MemberTasteProfileSummaryResult result = memberService.updateMyTasteProfile(
-                new UpdateMemberTasteProfileCommand(List.of(), List.of())
+                new UpdateMemberTasteProfileCommand(List.of(), List.of(), List.of())
         );
 
         assertThat(result.profileVersion()).isEqualTo("v1");
         assertThat(result.attributeCategories()).isEmpty();
         assertThat(result.restrictionIngredients()).isEmpty();
+        assertThat(result.dislikedMenuItems()).isEmpty();
     }
 }

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -90,12 +90,16 @@ class OpenApiDocumentationIntegrationTest {
                         .value(org.hamcrest.Matchers.containsString("attribute category ID 목록")))
                 .andExpect(jsonPath("$.components.schemas.UpdateMemberTasteProfileRequest.properties.restrictionIngredientIds.description")
                         .value(org.hamcrest.Matchers.containsString("restriction ingredient ID 목록")))
+                .andExpect(jsonPath("$.components.schemas.UpdateMemberTasteProfileRequest.properties.dislikedMenuItemIds.description")
+                        .value(org.hamcrest.Matchers.containsString("disliked menu item ID 목록")))
                 .andExpect(jsonPath("$.components.schemas.MemberTasteProfileSummaryResponse.properties.memberId.description")
                         .value("현재 로그인한 회원 ID입니다."))
                 .andExpect(jsonPath("$.components.schemas.MemberTasteAttributeCategoryResponse.properties.categoryType.description")
                         .value("선택된 attribute category의 상위 유형입니다."))
                 .andExpect(jsonPath("$.components.schemas.MemberTasteRestrictionIngredientResponse.properties.allergen.description")
-                        .value("알레르기 유발 재료 여부입니다."));
+                        .value("알레르기 유발 재료 여부입니다."))
+                .andExpect(jsonPath("$.components.schemas.MemberTasteDislikedMenuItemResponse.properties.code.description")
+                        .value("선택된 disliked menu item 코드입니다."));
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
Closes #118 

## 📝 작업 내용
- `MemberTasteProfileDislikedMenuItem` 엔티티 정의
- 기존 `PATCH api/v1/members/me/taste-profile` 요청에 `dislikedMenuItems`를 추가
- 테스트 및 문서 작성

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [x] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
