### PR TITLE
[Feat] 취향등록 전용 메뉴 목록 API 구현 

### DIFF
--- a/src/main/java/matchuri/backend/api/menu/MenuReferenceApi.java
+++ b/src/main/java/matchuri/backend/api/menu/MenuReferenceApi.java
@@ -9,8 +9,10 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import matchuri.backend.api.menu.dto.docs.AttributeCategoryListApiResponse;
+import matchuri.backend.api.menu.dto.docs.MenuItemSummaryListApiResponse;
 import matchuri.backend.api.menu.dto.docs.RestrictionIngredientListApiResponse;
 import matchuri.backend.api.menu.dto.response.AttributeCategoryResponse;
+import matchuri.backend.api.menu.dto.response.MenuItemSummaryResponse;
 import matchuri.backend.api.menu.dto.response.RestrictionIngredientResponse;
 import matchuri.backend.global.api.ApiResponse;
 
@@ -99,4 +101,52 @@ public interface MenuReferenceApi {
             )
     })
     ApiResponse<List<RestrictionIngredientResponse>> getRestrictionIngredients();
+
+    @Operation(
+            summary = "메뉴 목록 조회",
+            description = """
+                    활성 메뉴 목록을 조회합니다.
+                    
+                    - 인증 없이 호출할 수 있습니다.
+                    - 응답에는 `is_active=true`인 메뉴만 포함됩니다.
+                    - 목록 응답은 `id`, `code`, `name`만 포함합니다.
+                    - `query`는 메뉴명 부분 검색입니다.
+                    - `attributeCategoryIds`, `ingredientIds`는 각 그룹 내부 OR 조건으로 처리합니다.
+                    - `query`, `attributeCategoryIds`, `ingredientIds` 그룹 간 조합은 AND 조건으로 처리합니다.
+                    - 존재하지 않거나 비활성화된 필터 ID가 포함되면 4xx로 거절합니다.
+                    - 정렬 기준은 `id` 오름차순입니다.
+                    """
+    )
+    @SecurityRequirements
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = MenuItemSummaryListApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "data": [
+                                                {
+                                                  "id": 1001,
+                                                  "code": "PORK_CUTLET",
+                                                  "name": "돈까스"
+                                                }
+                                              ],
+                                              "error": null
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ApiResponse<List<MenuItemSummaryResponse>> searchMenuItems(
+            String query,
+            List<Long> attributeCategoryIds,
+            List<Long> ingredientIds
+    );
 }

--- a/src/main/java/matchuri/backend/api/menu/MenuReferenceController.java
+++ b/src/main/java/matchuri/backend/api/menu/MenuReferenceController.java
@@ -3,12 +3,14 @@ package matchuri.backend.api.menu;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.api.menu.dto.response.AttributeCategoryResponse;
+import matchuri.backend.api.menu.dto.response.MenuItemSummaryResponse;
 import matchuri.backend.api.menu.dto.response.RestrictionIngredientResponse;
 import matchuri.backend.api.menu.mapper.MenuReferenceMapper;
 import matchuri.backend.domain.menu.service.MenuReferenceService;
 import matchuri.backend.global.api.ApiResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -33,6 +35,26 @@ public class MenuReferenceController implements MenuReferenceApi {
         return ApiResponse.success(
                 menuReferenceMapper.toRestrictionIngredientResponses(
                         menuReferenceService.getActiveRestrictionIngredients())
+        );
+    }
+
+    @Override
+    @GetMapping("/menu-items")
+    public ApiResponse<List<MenuItemSummaryResponse>> searchMenuItems(
+            @RequestParam(required = false) String query,
+            @RequestParam(required = false) List<Long> attributeCategoryIds,
+            @RequestParam(required = false) List<Long> ingredientIds
+    ) {
+        return ApiResponse.success(
+                menuReferenceMapper.toMenuItemSummaryResponses(
+                        menuReferenceService.searchMenuItems(
+                                menuReferenceMapper.toSearchMenuItemsCommand(
+                                        query,
+                                        attributeCategoryIds,
+                                        ingredientIds
+                                )
+                        )
+                )
         );
     }
 }

--- a/src/main/java/matchuri/backend/api/menu/MenuReferenceController.java
+++ b/src/main/java/matchuri/backend/api/menu/MenuReferenceController.java
@@ -24,18 +24,19 @@ public class MenuReferenceController implements MenuReferenceApi {
     @Override
     @GetMapping("/attribute-categories")
     public ApiResponse<List<AttributeCategoryResponse>> getAttributeCategories() {
-        return ApiResponse.success(
-                menuReferenceMapper.toAttributeCategoryResponses(menuReferenceService.getActiveAttributeCategories())
-        );
+        var categories = menuReferenceService.getActiveAttributeCategories();
+        var responses = menuReferenceMapper.toAttributeCategoryResponses(categories);
+
+        return ApiResponse.success(responses);
     }
 
     @Override
     @GetMapping("/restriction-ingredients")
     public ApiResponse<List<RestrictionIngredientResponse>> getRestrictionIngredients() {
-        return ApiResponse.success(
-                menuReferenceMapper.toRestrictionIngredientResponses(
-                        menuReferenceService.getActiveRestrictionIngredients())
-        );
+        var ingredients = menuReferenceService.getActiveRestrictionIngredients();
+        var responses = menuReferenceMapper.toRestrictionIngredientResponses(ingredients);
+
+        return ApiResponse.success(responses);
     }
 
     @Override
@@ -45,16 +46,10 @@ public class MenuReferenceController implements MenuReferenceApi {
             @RequestParam(required = false) List<Long> attributeCategoryIds,
             @RequestParam(required = false) List<Long> ingredientIds
     ) {
-        return ApiResponse.success(
-                menuReferenceMapper.toMenuItemSummaryResponses(
-                        menuReferenceService.searchMenuItems(
-                                menuReferenceMapper.toSearchMenuItemsCommand(
-                                        query,
-                                        attributeCategoryIds,
-                                        ingredientIds
-                                )
-                        )
-                )
-        );
+        var command = menuReferenceMapper.toSearchMenuItemsCommand(query, attributeCategoryIds, ingredientIds);
+        var menuItems = menuReferenceService.searchMenuItems(command);
+        var responses = menuReferenceMapper.toMenuItemSummaryResponses(menuItems);
+
+        return ApiResponse.success(responses);
     }
 }

--- a/src/main/java/matchuri/backend/api/menu/dto/docs/MenuItemSummaryListApiResponse.java
+++ b/src/main/java/matchuri/backend/api/menu/dto/docs/MenuItemSummaryListApiResponse.java
@@ -1,0 +1,19 @@
+package matchuri.backend.api.menu.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import matchuri.backend.api.menu.dto.response.MenuItemSummaryResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "메뉴 목록 조회 API의 공통 응답 envelope입니다.")
+public record MenuItemSummaryListApiResponse(
+        @Schema(description = "요청 성공 여부입니다.", example = "true")
+        boolean success,
+
+        @Schema(description = "성공 시 반환되는 활성 메뉴 목록입니다.")
+        List<MenuItemSummaryResponse> data,
+
+        @Schema(description = "실패 시 반환되는 에러 정보입니다.")
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/menu/dto/response/MenuItemSummaryResponse.java
+++ b/src/main/java/matchuri/backend/api/menu/dto/response/MenuItemSummaryResponse.java
@@ -1,0 +1,15 @@
+package matchuri.backend.api.menu.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MenuItemSummaryResponse(
+        @Schema(description = "메뉴 ID입니다.", example = "1001")
+        Long id,
+
+        @Schema(description = "메뉴 코드입니다.", example = "PORK_CUTLET")
+        String code,
+
+        @Schema(description = "메뉴 표시 이름입니다.", example = "돈까스")
+        String name
+) {
+}

--- a/src/main/java/matchuri/backend/api/menu/mapper/MenuReferenceMapper.java
+++ b/src/main/java/matchuri/backend/api/menu/mapper/MenuReferenceMapper.java
@@ -8,15 +8,18 @@ import matchuri.backend.api.menu.dto.request.UpdateAdminIngredientRequest;
 import matchuri.backend.api.menu.dto.response.AdminAttributeCategoryResponse;
 import matchuri.backend.api.menu.dto.response.AdminIngredientResponse;
 import matchuri.backend.api.menu.dto.response.AttributeCategoryResponse;
+import matchuri.backend.api.menu.dto.response.MenuItemSummaryResponse;
 import matchuri.backend.api.menu.dto.response.RestrictionIngredientResponse;
 import matchuri.backend.domain.menu.command.CreateAdminAttributeCategoryCommand;
 import matchuri.backend.domain.menu.command.CreateAdminIngredientCommand;
+import matchuri.backend.domain.menu.command.SearchMenuItemsCommand;
 import matchuri.backend.domain.menu.command.UpdateAdminAttributeCategoryCommand;
 import matchuri.backend.domain.menu.command.UpdateAdminIngredientCommand;
 import matchuri.backend.domain.menu.entity.CategoryType;
 import matchuri.backend.domain.menu.result.AdminAttributeCategoryResult;
 import matchuri.backend.domain.menu.result.AdminIngredientResult;
 import matchuri.backend.domain.menu.result.AttributeCategoryResult;
+import matchuri.backend.domain.menu.result.MenuItemSummaryResult;
 import matchuri.backend.domain.menu.result.RestrictionIngredientResult;
 import matchuri.backend.global.exception.RequestValidationException;
 import org.springframework.stereotype.Component;
@@ -68,6 +71,18 @@ public class MenuReferenceMapper {
         );
     }
 
+    public SearchMenuItemsCommand toSearchMenuItemsCommand(
+            String query,
+            List<Long> attributeCategoryIds,
+            List<Long> ingredientIds
+    ) {
+        return new SearchMenuItemsCommand(
+                trimNullable(query),
+                attributeCategoryIds == null ? List.of() : attributeCategoryIds,
+                ingredientIds == null ? List.of() : ingredientIds
+        );
+    }
+
     public List<AdminAttributeCategoryResponse> toAdminAttributeCategoryResponses(
             List<AdminAttributeCategoryResult> results) {
         return results.stream()
@@ -91,6 +106,12 @@ public class MenuReferenceMapper {
             List<RestrictionIngredientResult> results) {
         return results.stream()
                 .map(this::toRestrictionIngredientResponse)
+                .toList();
+    }
+
+    public List<MenuItemSummaryResponse> toMenuItemSummaryResponses(List<MenuItemSummaryResult> results) {
+        return results.stream()
+                .map(this::toMenuItemSummaryResponse)
                 .toList();
     }
 
@@ -133,6 +154,14 @@ public class MenuReferenceMapper {
                 result.name(),
                 result.allergen(),
                 result.sortOrder()
+        );
+    }
+
+    private MenuItemSummaryResponse toMenuItemSummaryResponse(MenuItemSummaryResult result) {
+        return new MenuItemSummaryResponse(
+                result.id(),
+                result.code(),
+                result.name()
         );
     }
 

--- a/src/main/java/matchuri/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/matchuri/backend/domain/member/repository/MemberRepository.java
@@ -3,8 +3,10 @@ package matchuri.backend.domain.member.repository;
 import java.util.Optional;
 import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.entity.SocialProviderType;
+import org.jspecify.annotations.NullMarked;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+@NullMarked
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByLoginId(String loginId);

--- a/src/main/java/matchuri/backend/domain/menu/MenuErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/menu/MenuErrorCode.java
@@ -14,7 +14,7 @@ public enum MenuErrorCode implements ErrorCode {
     ATTRIBUTE_CATEGORY_DUPLICATE(HttpStatus.CONFLICT, "속성 카테고리가 이미 존재합니다. categoryType : {0}, code : {1}"),
     INGREDIENT_NOT_FOUND(HttpStatus.NOT_FOUND, "재료를 찾을 수 없습니다. ingredientId : {0}"),
     INGREDIENT_DUPLICATE(HttpStatus.CONFLICT, "재료가 이미 존재합니다. code : {0}"),
-    INVALID_FILTER(HttpStatus.BAD_REQUEST, "메뉴 검색 필터가 유효하지 않습니다. {0}");
+    INVALID_FILTER(HttpStatus.BAD_REQUEST, "메뉴 검색 필터가 유효하지 않습니다. {0} : {1}");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/matchuri/backend/domain/menu/command/SearchMenuItemsCommand.java
+++ b/src/main/java/matchuri/backend/domain/menu/command/SearchMenuItemsCommand.java
@@ -1,0 +1,10 @@
+package matchuri.backend.domain.menu.command;
+
+import java.util.List;
+
+public record SearchMenuItemsCommand(
+        String query,
+        List<Long> attributeCategoryIds,
+        List<Long> ingredientIds
+) {
+}

--- a/src/main/java/matchuri/backend/domain/menu/repository/MenuAttributeCategoryRepository.java
+++ b/src/main/java/matchuri/backend/domain/menu/repository/MenuAttributeCategoryRepository.java
@@ -1,0 +1,7 @@
+package matchuri.backend.domain.menu.repository;
+
+import matchuri.backend.domain.menu.entity.MenuAttributeCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuAttributeCategoryRepository extends JpaRepository<MenuAttributeCategory, Long> {
+}

--- a/src/main/java/matchuri/backend/domain/menu/repository/MenuIngredientRepository.java
+++ b/src/main/java/matchuri/backend/domain/menu/repository/MenuIngredientRepository.java
@@ -1,0 +1,7 @@
+package matchuri.backend.domain.menu.repository;
+
+import matchuri.backend.domain.menu.entity.MenuIngredient;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuIngredientRepository extends JpaRepository<MenuIngredient, Long> {
+}

--- a/src/main/java/matchuri/backend/domain/menu/repository/MenuItemRepository.java
+++ b/src/main/java/matchuri/backend/domain/menu/repository/MenuItemRepository.java
@@ -3,11 +3,50 @@ package matchuri.backend.domain.menu.repository;
 import java.util.Collection;
 import java.util.List;
 import matchuri.backend.domain.menu.entity.MenuItem;
+import org.jspecify.annotations.NullMarked;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+@NullMarked
 public interface MenuItemRepository extends JpaRepository<MenuItem, Long> {
 
     boolean existsByCode(String code);
 
     List<MenuItem> findAllByIdInAndActiveTrue(Collection<Long> ids);
+
+    @Query("""
+            select distinct menu
+            from MenuItem menu
+            where menu.active = true
+              and (:query is null or lower(menu.name) like lower(concat('%', :query, '%')))
+              and (
+                    :attributeCategoryIdsEmpty = true
+                    or exists (
+                        select 1
+                        from MenuAttributeCategory menuAttributeCategory
+                        where menuAttributeCategory.menu = menu
+                          and menuAttributeCategory.attributeCategory.active = true
+                          and menuAttributeCategory.attributeCategory.id in :attributeCategoryIds
+                    )
+                  )
+              and (
+                    :ingredientIdsEmpty = true
+                    or exists (
+                        select 1
+                        from MenuIngredient menuIngredient
+                        where menuIngredient.menu = menu
+                          and menuIngredient.ingredient.active = true
+                          and menuIngredient.ingredient.id in :ingredientIds
+                    )
+                  )
+            order by menu.id asc
+            """)
+    List<MenuItem> searchActiveMenuItems(
+            @Param("query") String query,
+            @Param("attributeCategoryIds") Collection<Long> attributeCategoryIds,
+            @Param("attributeCategoryIdsEmpty") boolean attributeCategoryIdsEmpty,
+            @Param("ingredientIds") Collection<Long> ingredientIds,
+            @Param("ingredientIdsEmpty") boolean ingredientIdsEmpty
+    );
 }

--- a/src/main/java/matchuri/backend/domain/menu/result/MenuItemSummaryResult.java
+++ b/src/main/java/matchuri/backend/domain/menu/result/MenuItemSummaryResult.java
@@ -1,0 +1,18 @@
+package matchuri.backend.domain.menu.result;
+
+import matchuri.backend.domain.menu.entity.MenuItem;
+
+public record MenuItemSummaryResult(
+        Long id,
+        String code,
+        String name
+) {
+
+    public static MenuItemSummaryResult from(MenuItem menuItem) {
+        return new MenuItemSummaryResult(
+                menuItem.getId(),
+                menuItem.getCode(),
+                menuItem.getName()
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/domain/menu/service/MenuReferenceService.java
+++ b/src/main/java/matchuri/backend/domain/menu/service/MenuReferenceService.java
@@ -1,7 +1,9 @@
 package matchuri.backend.domain.menu.service;
 
 import java.util.List;
+import matchuri.backend.domain.menu.command.SearchMenuItemsCommand;
 import matchuri.backend.domain.menu.result.AttributeCategoryResult;
+import matchuri.backend.domain.menu.result.MenuItemSummaryResult;
 import matchuri.backend.domain.menu.result.RestrictionIngredientResult;
 
 public interface MenuReferenceService {
@@ -9,4 +11,6 @@ public interface MenuReferenceService {
     List<AttributeCategoryResult> getActiveAttributeCategories();
 
     List<RestrictionIngredientResult> getActiveRestrictionIngredients();
+
+    List<MenuItemSummaryResult> searchMenuItems(SearchMenuItemsCommand command);
 }

--- a/src/main/java/matchuri/backend/domain/menu/service/MenuReferenceServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/menu/service/MenuReferenceServiceImpl.java
@@ -2,10 +2,15 @@ package matchuri.backend.domain.menu.service;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import matchuri.backend.domain.menu.MenuErrorCode;
+import matchuri.backend.domain.menu.command.SearchMenuItemsCommand;
 import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
 import matchuri.backend.domain.menu.repository.IngredientRepository;
+import matchuri.backend.domain.menu.repository.MenuItemRepository;
 import matchuri.backend.domain.menu.result.AttributeCategoryResult;
+import matchuri.backend.domain.menu.result.MenuItemSummaryResult;
 import matchuri.backend.domain.menu.result.RestrictionIngredientResult;
+import matchuri.backend.global.exception.BusinessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +21,7 @@ public class MenuReferenceServiceImpl implements MenuReferenceService {
 
     private final AttributeCategoryRepository attributeCategoryRepository;
     private final IngredientRepository ingredientRepository;
+    private final MenuItemRepository menuItemRepository;
 
     @Override
     public List<AttributeCategoryResult> getActiveAttributeCategories() {
@@ -29,5 +35,80 @@ public class MenuReferenceServiceImpl implements MenuReferenceService {
         return ingredientRepository.findAllByActiveTrueOrderBySortOrderAscIdAsc().stream()
                 .map(RestrictionIngredientResult::from)
                 .toList();
+    }
+
+    @Override
+    public List<MenuItemSummaryResult> searchMenuItems(SearchMenuItemsCommand command) {
+        List<Long> attributeCategoryIds = distinctIds(command.attributeCategoryIds());
+        List<Long> ingredientIds = distinctIds(command.ingredientIds());
+
+        validateActiveAttributeCategoryIds(attributeCategoryIds);
+        validateActiveIngredientIds(ingredientIds);
+
+        List<Long> attributeCategoryIdsForQuery = idsForQuery(attributeCategoryIds);
+        List<Long> ingredientIdsForQuery = idsForQuery(ingredientIds);
+
+        return menuItemRepository.searchActiveMenuItems(
+                        normalizeQuery(command.query()),
+                        attributeCategoryIdsForQuery,
+                        attributeCategoryIds.isEmpty(),
+                        ingredientIdsForQuery,
+                        ingredientIds.isEmpty()
+                )
+                .stream()
+                .map(MenuItemSummaryResult::from)
+                .toList();
+    }
+
+    private List<Long> distinctIds(List<Long> ids) {
+        if (ids == null) {
+            return List.of();
+        }
+
+        return ids.stream()
+                .distinct()
+                .toList();
+    }
+
+    private void validateActiveAttributeCategoryIds(List<Long> attributeCategoryIds) {
+        if (attributeCategoryIds.isEmpty()) {
+            return;
+        }
+
+        int activeCount = attributeCategoryRepository.findAllByIdInAndActiveTrue(attributeCategoryIds).size();
+        if (activeCount != attributeCategoryIds.size()) {
+            throw new BusinessException(MenuErrorCode.INVALID_FILTER,
+                    "유효하지 않거나 비활성화된 attributeCategoryIds가 포함되어 있습니다. attributeCategoryIds : "
+                            + attributeCategoryIds);
+        }
+    }
+
+    private void validateActiveIngredientIds(List<Long> ingredientIds) {
+        if (ingredientIds.isEmpty()) {
+            return;
+        }
+
+        int activeCount = ingredientRepository.findAllByIdInAndActiveTrue(ingredientIds).size();
+        if (activeCount != ingredientIds.size()) {
+            throw new BusinessException(MenuErrorCode.INVALID_FILTER,
+                    "유효하지 않거나 비활성화된 ingredientIds가 포함되어 있습니다. ingredientIds : "
+                            + ingredientIds);
+        }
+    }
+
+    private List<Long> idsForQuery(List<Long> ids) {
+        if (ids.isEmpty()) {
+            return List.of(-1L);
+        }
+
+        return ids;
+    }
+
+    private String normalizeQuery(String query) {
+        if (query == null || query.isBlank()) {
+            return null;
+        }
+
+        return query.trim();
     }
 }

--- a/src/main/java/matchuri/backend/domain/menu/service/MenuReferenceServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/menu/service/MenuReferenceServiceImpl.java
@@ -77,9 +77,7 @@ public class MenuReferenceServiceImpl implements MenuReferenceService {
 
         int activeCount = attributeCategoryRepository.findAllByIdInAndActiveTrue(attributeCategoryIds).size();
         if (activeCount != attributeCategoryIds.size()) {
-            throw new BusinessException(MenuErrorCode.INVALID_FILTER,
-                    "유효하지 않거나 비활성화된 attributeCategoryIds가 포함되어 있습니다. attributeCategoryIds : "
-                            + attributeCategoryIds);
+            throw new BusinessException(MenuErrorCode.INVALID_FILTER, "attributeCategoryIds", attributeCategoryIds);
         }
     }
 
@@ -90,9 +88,7 @@ public class MenuReferenceServiceImpl implements MenuReferenceService {
 
         int activeCount = ingredientRepository.findAllByIdInAndActiveTrue(ingredientIds).size();
         if (activeCount != ingredientIds.size()) {
-            throw new BusinessException(MenuErrorCode.INVALID_FILTER,
-                    "유효하지 않거나 비활성화된 ingredientIds가 포함되어 있습니다. ingredientIds : "
-                            + ingredientIds);
+            throw new BusinessException(MenuErrorCode.INVALID_FILTER, "ingredientIds", ingredientIds);
         }
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,6 +41,7 @@ matchuri:
       - /api/v1/members/exists/**
       - /api/v1/attribute-categories
       - /api/v1/restriction-ingredients
+      - /api/v1/menu-items
       - /api/v1/auth/oauth2/google
       - /oauth2/authorization/**
       - /login/oauth2/code/**

--- a/src/test/java/matchuri/backend/api/menu/MenuReferenceIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/menu/MenuReferenceIntegrationTest.java
@@ -6,11 +6,17 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import matchuri.backend.domain.menu.entity.MenuAttributeCategory;
+import matchuri.backend.domain.menu.entity.MenuIngredient;
+import matchuri.backend.domain.menu.entity.MenuItem;
 import matchuri.backend.domain.menu.entity.AttributeCategory;
 import matchuri.backend.domain.menu.entity.CategoryType;
 import matchuri.backend.domain.menu.entity.Ingredient;
 import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
 import matchuri.backend.domain.menu.repository.IngredientRepository;
+import matchuri.backend.domain.menu.repository.MenuAttributeCategoryRepository;
+import matchuri.backend.domain.menu.repository.MenuIngredientRepository;
+import matchuri.backend.domain.menu.repository.MenuItemRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,8 +41,20 @@ class MenuReferenceIntegrationTest {
     @Autowired
     private IngredientRepository ingredientRepository;
 
+    @Autowired
+    private MenuItemRepository menuItemRepository;
+
+    @Autowired
+    private MenuAttributeCategoryRepository menuAttributeCategoryRepository;
+
+    @Autowired
+    private MenuIngredientRepository menuIngredientRepository;
+
     @BeforeEach
     void setUp() {
+        menuAttributeCategoryRepository.deleteAll();
+        menuIngredientRepository.deleteAll();
+        menuItemRepository.deleteAll();
         attributeCategoryRepository.deleteAll();
         ingredientRepository.deleteAll();
     }
@@ -92,5 +110,114 @@ class MenuReferenceIntegrationTest {
                 .andExpect(jsonPath("$.data[1].id").value(shrimp.getId()))
                 .andExpect(jsonPath("$.data[1].code").value("SHRIMP"))
                 .andExpect(jsonPath("$.data[2].code").value("MILK"));
+    }
+
+    @Test
+    @DisplayName("메뉴 목록 조회는 활성 메뉴의 id, code, name만 반환한다")
+    void searchMenuItemsReturnsOnlyActiveMenuSummaries() throws Exception {
+        MenuItem kimchiStew = menuItemRepository.save(
+                new MenuItem("KIMCHI_STEW", "김치찌개", "김치와 돼지고기를 넣고 끓인 찌개"));
+        MenuItem porkCutlet = menuItemRepository.save(
+                new MenuItem("PORK_CUTLET", "돈까스", "바삭한 돼지고기 튀김"));
+        MenuItem inactive = new MenuItem("SUSHI", "초밥", "밥 위에 생선을 올린 메뉴");
+        inactive.deactivate();
+        menuItemRepository.save(inactive);
+
+        mockMvc.perform(get("/api/v1/menu-items").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.error").value(nullValue()))
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].id").value(kimchiStew.getId()))
+                .andExpect(jsonPath("$.data[0].code").value("KIMCHI_STEW"))
+                .andExpect(jsonPath("$.data[0].name").value("김치찌개"))
+                .andExpect(jsonPath("$.data[0].description").doesNotExist())
+                .andExpect(jsonPath("$.data[1].id").value(porkCutlet.getId()))
+                .andExpect(jsonPath("$.data[1].code").value("PORK_CUTLET"))
+                .andExpect(jsonPath("$.data[1].name").value("돈까스"));
+    }
+
+    @Test
+    @DisplayName("메뉴 목록 조회는 메뉴명 부분 검색을 지원한다")
+    void searchMenuItemsFiltersByNameQuery() throws Exception {
+        menuItemRepository.save(new MenuItem("KIMCHI_STEW", "김치찌개", "김치와 돼지고기를 넣고 끓인 찌개"));
+        menuItemRepository.save(new MenuItem("DOENJANG_STEW", "된장찌개", "된장을 넣고 끓인 찌개"));
+        menuItemRepository.save(new MenuItem("PORK_CUTLET", "돈까스", "바삭한 돼지고기 튀김"));
+
+        mockMvc.perform(get("/api/v1/menu-items")
+                        .param("query", "찌개")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].code").value("KIMCHI_STEW"))
+                .andExpect(jsonPath("$.data[1].code").value("DOENJANG_STEW"));
+    }
+
+    @Test
+    @DisplayName("메뉴 목록 조회 필터는 그룹 내부 OR, 그룹 간 AND로 동작한다")
+    void searchMenuItemsCombinesFiltersWithOrInsideGroupsAndAndBetweenGroups() throws Exception {
+        AttributeCategory spicy = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 10));
+        AttributeCategory crispy = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.TEXTURE, "CRISPY", "바삭함", 20));
+        AttributeCategory soup = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.COOKING_METHOD, "SOUP", "국물", 30));
+        Ingredient pork = ingredientRepository.save(new Ingredient("PORK", "돼지고기", false, 10));
+        Ingredient shrimp = ingredientRepository.save(new Ingredient("SHRIMP", "새우", true, 20));
+
+        MenuItem kimchiStew = menuItemRepository.save(
+                new MenuItem("KIMCHI_STEW", "김치찌개", "김치와 돼지고기를 넣고 끓인 찌개"));
+        MenuItem jjampong = menuItemRepository.save(
+                new MenuItem("JJAMPPONG", "짬뽕", "해산물과 채소를 넣은 매콤한 국물 면 요리"));
+        MenuItem porkCutlet = menuItemRepository.save(
+                new MenuItem("PORK_CUTLET", "돈까스", "바삭한 돼지고기 튀김"));
+
+        mapAttributeCategory(kimchiStew, spicy);
+        mapAttributeCategory(kimchiStew, soup);
+        mapIngredient(kimchiStew, pork);
+        mapAttributeCategory(jjampong, spicy);
+        mapAttributeCategory(jjampong, soup);
+        mapIngredient(jjampong, shrimp);
+        mapAttributeCategory(porkCutlet, crispy);
+        mapIngredient(porkCutlet, pork);
+
+        mockMvc.perform(get("/api/v1/menu-items")
+                        .param("attributeCategoryIds", spicy.getId().toString(), crispy.getId().toString())
+                        .param("ingredientIds", pork.getId().toString())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].code").value("KIMCHI_STEW"))
+                .andExpect(jsonPath("$.data[1].code").value("PORK_CUTLET"));
+    }
+
+    @Test
+    @DisplayName("메뉴 목록 조회는 잘못된 attribute category 필터 ID를 거절한다")
+    void searchMenuItemsRejectsInvalidAttributeCategoryFilterIds() throws Exception {
+        mockMvc.perform(get("/api/v1/menu-items")
+                        .param("attributeCategoryIds", "999")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("MENU_INVALID_FILTER"));
+    }
+
+    @Test
+    @DisplayName("메뉴 목록 조회는 잘못된 ingredient 필터 ID를 거절한다")
+    void searchMenuItemsRejectsInvalidIngredientFilterIds() throws Exception {
+        mockMvc.perform(get("/api/v1/menu-items")
+                        .param("ingredientIds", "999")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("MENU_INVALID_FILTER"));
+    }
+
+    private void mapAttributeCategory(MenuItem menuItem, AttributeCategory attributeCategory) {
+        menuAttributeCategoryRepository.save(new MenuAttributeCategory(menuItem, attributeCategory));
+    }
+
+    private void mapIngredient(MenuItem menuItem, Ingredient ingredient) {
+        menuIngredientRepository.save(new MenuIngredient(menuItem, ingredient));
     }
 }

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -164,12 +164,20 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/restriction-ingredients'].get.responses['200'].content['application/json'].schema.$ref")
                         .value("#/components/schemas/RestrictionIngredientListApiResponse"))
+                .andExpect(jsonPath("$.paths['/api/v1/menu-items'].get.summary")
+                        .value("메뉴 목록 조회"))
+                .andExpect(jsonPath("$.paths['/api/v1/menu-items'].get.security").isEmpty())
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/menu-items'].get.responses['200'].content['application/json'].schema.$ref")
+                        .value("#/components/schemas/MenuItemSummaryListApiResponse"))
                 .andExpect(
                         jsonPath("$.components.schemas.AttributeCategoryResponse.properties.categoryType.description")
                                 .value("attribute category의 상위 유형입니다."))
                 .andExpect(
                         jsonPath("$.components.schemas.RestrictionIngredientResponse.properties.allergen.description")
-                                .value("알레르기 유발 재료 여부입니다."));
+                                .value("알레르기 유발 재료 여부입니다."))
+                .andExpect(jsonPath("$.components.schemas.MenuItemSummaryResponse.properties.code.description")
+                        .value("메뉴 코드입니다."));
     }
 
     @Test

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -39,6 +39,7 @@ matchuri:
       - /api/v1/members/exists/**
       - /api/v1/attribute-categories
       - /api/v1/restriction-ingredients
+      - /api/v1/menu-items
       - /api/v1/auth/oauth2/google
       - /oauth2/authorization/**
       - /login/oauth2/code/**


### PR DESCRIPTION
## 관련 이슈
Closes #115 

## 📝 작업 내용
- `GET api/v1/menu-items` 구현

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항

활성 메뉴 목록을 조회합니다.

- 인증 없이 호출할 수 있습니다.
- 응답에는 `is_active=true`인 메뉴만 포함됩니다.
- 목록 응답은 `id`, `code`, `name`만 포함합니다.
- `query`는 메뉴명 부분 검색입니다.
- `attributeCategoryIds`, `ingredientIds`는 각 그룹 내부 OR 조건으로 처리합니다.
- `query`, `attributeCategoryIds`, `ingredientIds` 그룹 간 조합은 AND 조건으로 처리합니다.
- 존재하지 않거나 비활성화된 필터 ID가 포함되면 4xx로 거절합니다.
- 정렬 기준은 `id` 오름차순입니다.
