### PR TITLE
[Feat] 메뉴 상세보기 조회 API 구현

### DIFF
--- a/src/main/java/matchuri/backend/api/menu/MenuReferenceApi.java
+++ b/src/main/java/matchuri/backend/api/menu/MenuReferenceApi.java
@@ -9,9 +9,11 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import matchuri.backend.api.menu.dto.docs.AttributeCategoryListApiResponse;
+import matchuri.backend.api.menu.dto.docs.MenuItemDetailApiResponse;
 import matchuri.backend.api.menu.dto.docs.MenuItemSummaryListApiResponse;
 import matchuri.backend.api.menu.dto.docs.RestrictionIngredientListApiResponse;
 import matchuri.backend.api.menu.dto.response.AttributeCategoryResponse;
+import matchuri.backend.api.menu.dto.response.MenuItemDetailResponse;
 import matchuri.backend.api.menu.dto.response.MenuItemSummaryResponse;
 import matchuri.backend.api.menu.dto.response.RestrictionIngredientResponse;
 import matchuri.backend.global.api.ApiResponse;
@@ -149,4 +151,82 @@ public interface MenuReferenceApi {
             List<Long> attributeCategoryIds,
             List<Long> ingredientIds
     );
+
+    @Operation(
+            summary = "메뉴 상세 조회",
+            description = """
+                    활성 메뉴의 상세 정보를 조회합니다.
+                    
+                    - 인증 없이 호출할 수 있습니다.
+                    - 비활성 메뉴 또는 존재하지 않는 메뉴 ID는 404로 응답합니다.
+                    - 상세 응답은 메뉴 기본 정보와 연결된 활성 `attribute category`, `ingredient` 목록을 포함합니다.
+                    """
+    )
+    @SecurityRequirements
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = MenuItemDetailApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "data": {
+                                                "id": 1001,
+                                                "code": "PORK_CUTLET",
+                                                "name": "돈까스",
+                                                "description": "돼지고기를 튀겨 소스와 함께 먹는 바삭한 메뉴입니다.",
+                                                "attributeCategories": [
+                                                  {
+                                                    "id": 1,
+                                                    "categoryType": "TEXTURE",
+                                                    "code": "CRISPY",
+                                                    "name": "바삭함",
+                                                    "sortOrder": 10
+                                                  }
+                                                ],
+                                                "ingredients": [
+                                                  {
+                                                    "id": 101,
+                                                    "code": "PORK",
+                                                    "name": "돼지고기",
+                                                    "allergen": false,
+                                                    "sortOrder": 10
+                                                  }
+                                                ]
+                                              },
+                                              "error": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "메뉴 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "menuNotFound",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "data": null,
+                                              "error": {
+                                                "status": 404,
+                                                "code": "MENU_NOT_FOUND",
+                                                "message": "메뉴를 찾을 수 없습니다. menuId : 999",
+                                                "details": []
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ApiResponse<MenuItemDetailResponse> getMenuItem(Long menuItemId);
 }

--- a/src/main/java/matchuri/backend/api/menu/MenuReferenceController.java
+++ b/src/main/java/matchuri/backend/api/menu/MenuReferenceController.java
@@ -3,12 +3,14 @@ package matchuri.backend.api.menu;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.api.menu.dto.response.AttributeCategoryResponse;
+import matchuri.backend.api.menu.dto.response.MenuItemDetailResponse;
 import matchuri.backend.api.menu.dto.response.MenuItemSummaryResponse;
 import matchuri.backend.api.menu.dto.response.RestrictionIngredientResponse;
 import matchuri.backend.api.menu.mapper.MenuReferenceMapper;
 import matchuri.backend.domain.menu.service.MenuReferenceService;
 import matchuri.backend.global.api.ApiResponse;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -51,5 +53,14 @@ public class MenuReferenceController implements MenuReferenceApi {
         var responses = menuReferenceMapper.toMenuItemSummaryResponses(menuItems);
 
         return ApiResponse.success(responses);
+    }
+
+    @Override
+    @GetMapping("/menu-items/{menuItemId}")
+    public ApiResponse<MenuItemDetailResponse> getMenuItem(@PathVariable Long menuItemId) {
+        var menuItem = menuReferenceService.getMenuItem(menuItemId);
+        var response = menuReferenceMapper.toMenuItemDetailResponse(menuItem);
+
+        return ApiResponse.success(response);
     }
 }

--- a/src/main/java/matchuri/backend/api/menu/dto/docs/MenuItemDetailApiResponse.java
+++ b/src/main/java/matchuri/backend/api/menu/dto/docs/MenuItemDetailApiResponse.java
@@ -1,0 +1,18 @@
+package matchuri.backend.api.menu.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.menu.dto.response.MenuItemDetailResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "메뉴 상세 조회 API의 공통 응답 envelope입니다.")
+public record MenuItemDetailApiResponse(
+        @Schema(description = "요청 성공 여부입니다.", example = "true")
+        boolean success,
+
+        @Schema(description = "성공 시 반환되는 메뉴 상세 정보입니다.")
+        MenuItemDetailResponse data,
+
+        @Schema(description = "실패 시 반환되는 에러 정보입니다.")
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/menu/dto/response/MenuItemDetailResponse.java
+++ b/src/main/java/matchuri/backend/api/menu/dto/response/MenuItemDetailResponse.java
@@ -1,0 +1,25 @@
+package matchuri.backend.api.menu.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record MenuItemDetailResponse(
+        @Schema(description = "메뉴 ID입니다.", example = "1001")
+        Long id,
+
+        @Schema(description = "메뉴 코드입니다.", example = "PORK_CUTLET")
+        String code,
+
+        @Schema(description = "메뉴 표시 이름입니다.", example = "돈까스")
+        String name,
+
+        @Schema(description = "메뉴 설명입니다.", example = "돼지고기를 튀겨 소스와 함께 먹는 바삭한 메뉴입니다.")
+        String description,
+
+        @Schema(description = "메뉴에 연결된 활성 attribute category 목록입니다.")
+        List<AttributeCategoryResponse> attributeCategories,
+
+        @Schema(description = "메뉴에 연결된 활성 ingredient 목록입니다.")
+        List<RestrictionIngredientResponse> ingredients
+) {
+}

--- a/src/main/java/matchuri/backend/api/menu/mapper/MenuReferenceMapper.java
+++ b/src/main/java/matchuri/backend/api/menu/mapper/MenuReferenceMapper.java
@@ -8,6 +8,7 @@ import matchuri.backend.api.menu.dto.request.UpdateAdminIngredientRequest;
 import matchuri.backend.api.menu.dto.response.AdminAttributeCategoryResponse;
 import matchuri.backend.api.menu.dto.response.AdminIngredientResponse;
 import matchuri.backend.api.menu.dto.response.AttributeCategoryResponse;
+import matchuri.backend.api.menu.dto.response.MenuItemDetailResponse;
 import matchuri.backend.api.menu.dto.response.MenuItemSummaryResponse;
 import matchuri.backend.api.menu.dto.response.RestrictionIngredientResponse;
 import matchuri.backend.domain.menu.command.CreateAdminAttributeCategoryCommand;
@@ -19,6 +20,7 @@ import matchuri.backend.domain.menu.entity.CategoryType;
 import matchuri.backend.domain.menu.result.AdminAttributeCategoryResult;
 import matchuri.backend.domain.menu.result.AdminIngredientResult;
 import matchuri.backend.domain.menu.result.AttributeCategoryResult;
+import matchuri.backend.domain.menu.result.MenuItemDetailResult;
 import matchuri.backend.domain.menu.result.MenuItemSummaryResult;
 import matchuri.backend.domain.menu.result.RestrictionIngredientResult;
 import matchuri.backend.global.exception.RequestValidationException;
@@ -113,6 +115,17 @@ public class MenuReferenceMapper {
         return results.stream()
                 .map(this::toMenuItemSummaryResponse)
                 .toList();
+    }
+
+    public MenuItemDetailResponse toMenuItemDetailResponse(MenuItemDetailResult result) {
+        return new MenuItemDetailResponse(
+                result.id(),
+                result.code(),
+                result.name(),
+                result.description(),
+                toAttributeCategoryResponses(result.attributeCategories()),
+                toRestrictionIngredientResponses(result.ingredients())
+        );
     }
 
     private AttributeCategoryResponse toAttributeCategoryResponse(AttributeCategoryResult result) {

--- a/src/main/java/matchuri/backend/domain/menu/repository/MenuAttributeCategoryRepository.java
+++ b/src/main/java/matchuri/backend/domain/menu/repository/MenuAttributeCategoryRepository.java
@@ -1,7 +1,14 @@
 package matchuri.backend.domain.menu.repository;
 
+import java.util.List;
 import matchuri.backend.domain.menu.entity.MenuAttributeCategory;
+import org.jspecify.annotations.NullMarked;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+@NullMarked
 public interface MenuAttributeCategoryRepository extends JpaRepository<MenuAttributeCategory, Long> {
+
+    List<MenuAttributeCategory> findAllByMenuIdAndAttributeCategoryActiveTrueOrderByAttributeCategoryCategoryTypeAscAttributeCategorySortOrderAscAttributeCategoryIdAsc(
+            Long menuId
+    );
 }

--- a/src/main/java/matchuri/backend/domain/menu/repository/MenuIngredientRepository.java
+++ b/src/main/java/matchuri/backend/domain/menu/repository/MenuIngredientRepository.java
@@ -1,7 +1,12 @@
 package matchuri.backend.domain.menu.repository;
 
+import java.util.List;
 import matchuri.backend.domain.menu.entity.MenuIngredient;
+import org.jspecify.annotations.NullMarked;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+@NullMarked
 public interface MenuIngredientRepository extends JpaRepository<MenuIngredient, Long> {
+
+    List<MenuIngredient> findAllByMenuIdAndIngredientActiveTrueOrderByIngredientSortOrderAscIngredientIdAsc(Long menuId);
 }

--- a/src/main/java/matchuri/backend/domain/menu/repository/MenuItemRepository.java
+++ b/src/main/java/matchuri/backend/domain/menu/repository/MenuItemRepository.java
@@ -2,6 +2,7 @@ package matchuri.backend.domain.menu.repository;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import matchuri.backend.domain.menu.entity.MenuItem;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,6 +15,8 @@ public interface MenuItemRepository extends JpaRepository<MenuItem, Long> {
     boolean existsByCode(String code);
 
     List<MenuItem> findAllByIdInAndActiveTrue(Collection<Long> ids);
+
+    Optional<MenuItem> findByIdAndActiveTrue(Long id);
 
     @Query("""
             select distinct menu

--- a/src/main/java/matchuri/backend/domain/menu/result/MenuItemDetailResult.java
+++ b/src/main/java/matchuri/backend/domain/menu/result/MenuItemDetailResult.java
@@ -1,0 +1,29 @@
+package matchuri.backend.domain.menu.result;
+
+import java.util.List;
+import matchuri.backend.domain.menu.entity.MenuItem;
+
+public record MenuItemDetailResult(
+        Long id,
+        String code,
+        String name,
+        String description,
+        List<AttributeCategoryResult> attributeCategories,
+        List<RestrictionIngredientResult> ingredients
+) {
+
+    public static MenuItemDetailResult of(
+            MenuItem menuItem,
+            List<AttributeCategoryResult> attributeCategories,
+            List<RestrictionIngredientResult> ingredients
+    ) {
+        return new MenuItemDetailResult(
+                menuItem.getId(),
+                menuItem.getCode(),
+                menuItem.getName(),
+                menuItem.getDescription(),
+                attributeCategories,
+                ingredients
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/domain/menu/service/MenuReferenceService.java
+++ b/src/main/java/matchuri/backend/domain/menu/service/MenuReferenceService.java
@@ -3,6 +3,7 @@ package matchuri.backend.domain.menu.service;
 import java.util.List;
 import matchuri.backend.domain.menu.command.SearchMenuItemsCommand;
 import matchuri.backend.domain.menu.result.AttributeCategoryResult;
+import matchuri.backend.domain.menu.result.MenuItemDetailResult;
 import matchuri.backend.domain.menu.result.MenuItemSummaryResult;
 import matchuri.backend.domain.menu.result.RestrictionIngredientResult;
 
@@ -13,4 +14,6 @@ public interface MenuReferenceService {
     List<RestrictionIngredientResult> getActiveRestrictionIngredients();
 
     List<MenuItemSummaryResult> searchMenuItems(SearchMenuItemsCommand command);
+
+    MenuItemDetailResult getMenuItem(Long menuItemId);
 }

--- a/src/main/java/matchuri/backend/domain/menu/service/MenuReferenceServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/menu/service/MenuReferenceServiceImpl.java
@@ -6,8 +6,11 @@ import matchuri.backend.domain.menu.MenuErrorCode;
 import matchuri.backend.domain.menu.command.SearchMenuItemsCommand;
 import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
 import matchuri.backend.domain.menu.repository.IngredientRepository;
+import matchuri.backend.domain.menu.repository.MenuAttributeCategoryRepository;
+import matchuri.backend.domain.menu.repository.MenuIngredientRepository;
 import matchuri.backend.domain.menu.repository.MenuItemRepository;
 import matchuri.backend.domain.menu.result.AttributeCategoryResult;
+import matchuri.backend.domain.menu.result.MenuItemDetailResult;
 import matchuri.backend.domain.menu.result.MenuItemSummaryResult;
 import matchuri.backend.domain.menu.result.RestrictionIngredientResult;
 import matchuri.backend.global.exception.BusinessException;
@@ -22,6 +25,8 @@ public class MenuReferenceServiceImpl implements MenuReferenceService {
     private final AttributeCategoryRepository attributeCategoryRepository;
     private final IngredientRepository ingredientRepository;
     private final MenuItemRepository menuItemRepository;
+    private final MenuAttributeCategoryRepository menuAttributeCategoryRepository;
+    private final MenuIngredientRepository menuIngredientRepository;
 
     @Override
     public List<AttributeCategoryResult> getActiveAttributeCategories() {
@@ -58,6 +63,25 @@ public class MenuReferenceServiceImpl implements MenuReferenceService {
                 .stream()
                 .map(MenuItemSummaryResult::from)
                 .toList();
+    }
+
+    @Override
+    public MenuItemDetailResult getMenuItem(Long menuItemId) {
+        var menuItem = menuItemRepository.findByIdAndActiveTrue(menuItemId)
+                .orElseThrow(() -> new BusinessException(MenuErrorCode.NOT_FOUND, menuItemId));
+        var attributeCategories = menuAttributeCategoryRepository
+                .findAllByMenuIdAndAttributeCategoryActiveTrueOrderByAttributeCategoryCategoryTypeAscAttributeCategorySortOrderAscAttributeCategoryIdAsc(
+                        menuItemId)
+                .stream()
+                .map(menuAttributeCategory -> AttributeCategoryResult.from(menuAttributeCategory.getAttributeCategory()))
+                .toList();
+        var ingredients = menuIngredientRepository
+                .findAllByMenuIdAndIngredientActiveTrueOrderByIngredientSortOrderAscIngredientIdAsc(menuItemId)
+                .stream()
+                .map(menuIngredient -> RestrictionIngredientResult.from(menuIngredient.getIngredient()))
+                .toList();
+
+        return MenuItemDetailResult.of(menuItem, attributeCategories, ingredients);
     }
 
     private List<Long> distinctIds(List<Long> ids) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -42,6 +42,7 @@ matchuri:
       - /api/v1/attribute-categories
       - /api/v1/restriction-ingredients
       - /api/v1/menu-items
+      - /api/v1/menu-items/**
       - /api/v1/auth/oauth2/google
       - /oauth2/authorization/**
       - /login/oauth2/code/**

--- a/src/test/java/matchuri/backend/api/menu/MenuReferenceIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/menu/MenuReferenceIntegrationTest.java
@@ -213,6 +213,73 @@ class MenuReferenceIntegrationTest {
                 .andExpect(jsonPath("$.error.code").value("MENU_INVALID_FILTER"));
     }
 
+    @Test
+    @DisplayName("메뉴 상세 조회는 기본 정보와 활성 속성/재료 연결 정보를 반환한다")
+    void getMenuItemReturnsDetailWithActiveAttributesAndIngredients() throws Exception {
+        AttributeCategory spicy = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 20));
+        AttributeCategory crispy = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.TEXTURE, "CRISPY", "바삭함", 10));
+        AttributeCategory inactive = new AttributeCategory(CategoryType.FLAVOR, "MILD", "순한맛", 5);
+        inactive.deactivate();
+        attributeCategoryRepository.save(inactive);
+        Ingredient pork = ingredientRepository.save(new Ingredient("PORK", "돼지고기", false, 20));
+        Ingredient egg = ingredientRepository.save(new Ingredient("EGG", "계란", true, 10));
+        Ingredient inactiveIngredient = new Ingredient("MILK", "우유", true, 5);
+        inactiveIngredient.deactivate();
+        ingredientRepository.save(inactiveIngredient);
+
+        MenuItem porkCutlet = menuItemRepository.save(
+                new MenuItem("PORK_CUTLET", "돈까스", "바삭한 돼지고기 튀김"));
+        mapAttributeCategory(porkCutlet, spicy);
+        mapAttributeCategory(porkCutlet, crispy);
+        mapAttributeCategory(porkCutlet, inactive);
+        mapIngredient(porkCutlet, pork);
+        mapIngredient(porkCutlet, egg);
+        mapIngredient(porkCutlet, inactiveIngredient);
+
+        mockMvc.perform(get("/api/v1/menu-items/{menuItemId}", porkCutlet.getId())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.error").value(nullValue()))
+                .andExpect(jsonPath("$.data.id").value(porkCutlet.getId()))
+                .andExpect(jsonPath("$.data.code").value("PORK_CUTLET"))
+                .andExpect(jsonPath("$.data.name").value("돈까스"))
+                .andExpect(jsonPath("$.data.description").value("바삭한 돼지고기 튀김"))
+                .andExpect(jsonPath("$.data.attributeCategories.length()").value(2))
+                .andExpect(jsonPath("$.data.attributeCategories[0].code").value("SPICY"))
+                .andExpect(jsonPath("$.data.attributeCategories[1].code").value("CRISPY"))
+                .andExpect(jsonPath("$.data.ingredients.length()").value(2))
+                .andExpect(jsonPath("$.data.ingredients[0].code").value("EGG"))
+                .andExpect(jsonPath("$.data.ingredients[0].allergen").value(true))
+                .andExpect(jsonPath("$.data.ingredients[1].code").value("PORK"));
+    }
+
+    @Test
+    @DisplayName("메뉴 상세 조회는 없는 메뉴 ID를 404로 응답한다")
+    void getMenuItemRejectsUnknownMenuItemId() throws Exception {
+        mockMvc.perform(get("/api/v1/menu-items/{menuItemId}", 999L)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("MENU_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("메뉴 상세 조회는 비활성 메뉴 ID를 404로 응답한다")
+    void getMenuItemRejectsInactiveMenuItemId() throws Exception {
+        MenuItem inactive = new MenuItem("SUSHI", "초밥", "밥 위에 생선을 올린 메뉴");
+        inactive.deactivate();
+        menuItemRepository.save(inactive);
+
+        mockMvc.perform(get("/api/v1/menu-items/{menuItemId}", inactive.getId())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("MENU_NOT_FOUND"));
+    }
+
     private void mapAttributeCategory(MenuItem menuItem, AttributeCategory attributeCategory) {
         menuAttributeCategoryRepository.save(new MenuAttributeCategory(menuItem, attributeCategory));
     }

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -170,6 +170,15 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/menu-items'].get.responses['200'].content['application/json'].schema.$ref")
                         .value("#/components/schemas/MenuItemSummaryListApiResponse"))
+                .andExpect(jsonPath("$.paths['/api/v1/menu-items/{menuItemId}'].get.summary")
+                        .value("메뉴 상세 조회"))
+                .andExpect(jsonPath("$.paths['/api/v1/menu-items/{menuItemId}'].get.security").isEmpty())
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/menu-items/{menuItemId}'].get.responses['200'].content['application/json'].schema.$ref")
+                        .value("#/components/schemas/MenuItemDetailApiResponse"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/menu-items/{menuItemId}'].get.responses['404'].content['application/json'].examples.menuNotFound.value.error.code")
+                        .value("MENU_NOT_FOUND"))
                 .andExpect(
                         jsonPath("$.components.schemas.AttributeCategoryResponse.properties.categoryType.description")
                                 .value("attribute category의 상위 유형입니다."))
@@ -177,7 +186,9 @@ class OpenApiDocumentationIntegrationTest {
                         jsonPath("$.components.schemas.RestrictionIngredientResponse.properties.allergen.description")
                                 .value("알레르기 유발 재료 여부입니다."))
                 .andExpect(jsonPath("$.components.schemas.MenuItemSummaryResponse.properties.code.description")
-                        .value("메뉴 코드입니다."));
+                        .value("메뉴 코드입니다."))
+                .andExpect(jsonPath("$.components.schemas.MenuItemDetailResponse.properties.description.description")
+                        .value("메뉴 설명입니다."));
     }
 
     @Test

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -40,6 +40,7 @@ matchuri:
       - /api/v1/attribute-categories
       - /api/v1/restriction-ingredients
       - /api/v1/menu-items
+      - /api/v1/menu-items/**
       - /api/v1/auth/oauth2/google
       - /oauth2/authorization/**
       - /login/oauth2/code/**


### PR DESCRIPTION
## 관련 이슈
Closes #114 

## 📝 작업 내용
- `GET api/v1/menu-items/{menuItemId}`

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항

- 인증 없이 호출할 수 있습니다.
- 비활성 메뉴 또는 존재하지 않는 메뉴 ID는 404로 응답합니다.
- 상세 응답은 메뉴 기본 정보와 연결된 활성 `attribute category`, `ingredient` 목록을 포함합니다.
