### PR TITLE
[Refactor] 취향 등록용 카테고리 목록 조회 API에 타입 필터링 추가

### DIFF
--- a/src/main/java/matchuri/backend/api/menu/MenuReferenceApi.java
+++ b/src/main/java/matchuri/backend/api/menu/MenuReferenceApi.java
@@ -16,6 +16,7 @@ import matchuri.backend.api.menu.dto.response.AttributeCategoryResponse;
 import matchuri.backend.api.menu.dto.response.MenuItemDetailResponse;
 import matchuri.backend.api.menu.dto.response.MenuItemSummaryResponse;
 import matchuri.backend.api.menu.dto.response.RestrictionIngredientResponse;
+import matchuri.backend.domain.menu.entity.CategoryType;
 import matchuri.backend.global.api.ApiResponse;
 
 @Tag(name = "Menu Reference", description = "취향 입력과 메뉴 분류에 공통으로 쓰는 참조 데이터 조회 API")
@@ -28,6 +29,7 @@ public interface MenuReferenceApi {
                     
                     - 인증 없이 호출할 수 있습니다.
                     - 응답에는 `is_active=true`인 데이터만 포함됩니다.
+                    - `categoryTypes`가 있으면 해당 유형의 데이터만 반환합니다.
                     - 정렬 기준은 `categoryType`, `sortOrder`, `id`입니다.
                     """
     )
@@ -60,7 +62,7 @@ public interface MenuReferenceApi {
                     )
             )
     })
-    ApiResponse<List<AttributeCategoryResponse>> getAttributeCategories();
+    ApiResponse<List<AttributeCategoryResponse>> getAttributeCategories(List<CategoryType> categoryTypes);
 
     @Operation(
             summary = "restriction ingredient 목록 조회",

--- a/src/main/java/matchuri/backend/api/menu/MenuReferenceController.java
+++ b/src/main/java/matchuri/backend/api/menu/MenuReferenceController.java
@@ -7,6 +7,7 @@ import matchuri.backend.api.menu.dto.response.MenuItemDetailResponse;
 import matchuri.backend.api.menu.dto.response.MenuItemSummaryResponse;
 import matchuri.backend.api.menu.dto.response.RestrictionIngredientResponse;
 import matchuri.backend.api.menu.mapper.MenuReferenceMapper;
+import matchuri.backend.domain.menu.entity.CategoryType;
 import matchuri.backend.domain.menu.service.MenuReferenceService;
 import matchuri.backend.global.api.ApiResponse;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,8 +26,11 @@ public class MenuReferenceController implements MenuReferenceApi {
 
     @Override
     @GetMapping("/attribute-categories")
-    public ApiResponse<List<AttributeCategoryResponse>> getAttributeCategories() {
-        var categories = menuReferenceService.getActiveAttributeCategories();
+    public ApiResponse<List<AttributeCategoryResponse>> getAttributeCategories(
+            @RequestParam(required = false) List<CategoryType> categoryTypes
+    ) {
+        var command = menuReferenceMapper.toGetAttributeCategoriesCommand(categoryTypes);
+        var categories = menuReferenceService.getActiveAttributeCategories(command);
         var responses = menuReferenceMapper.toAttributeCategoryResponses(categories);
 
         return ApiResponse.success(responses);

--- a/src/main/java/matchuri/backend/api/menu/mapper/MenuReferenceMapper.java
+++ b/src/main/java/matchuri/backend/api/menu/mapper/MenuReferenceMapper.java
@@ -13,6 +13,7 @@ import matchuri.backend.api.menu.dto.response.MenuItemSummaryResponse;
 import matchuri.backend.api.menu.dto.response.RestrictionIngredientResponse;
 import matchuri.backend.domain.menu.command.CreateAdminAttributeCategoryCommand;
 import matchuri.backend.domain.menu.command.CreateAdminIngredientCommand;
+import matchuri.backend.domain.menu.command.GetAttributeCategoriesCommand;
 import matchuri.backend.domain.menu.command.SearchMenuItemsCommand;
 import matchuri.backend.domain.menu.command.UpdateAdminAttributeCategoryCommand;
 import matchuri.backend.domain.menu.command.UpdateAdminIngredientCommand;
@@ -83,6 +84,10 @@ public class MenuReferenceMapper {
                 attributeCategoryIds == null ? List.of() : attributeCategoryIds,
                 ingredientIds == null ? List.of() : ingredientIds
         );
+    }
+
+    public GetAttributeCategoriesCommand toGetAttributeCategoriesCommand(List<CategoryType> categoryTypes) {
+        return new GetAttributeCategoriesCommand(categoryTypes == null ? List.of() : categoryTypes);
     }
 
     public List<AdminAttributeCategoryResponse> toAdminAttributeCategoryResponses(

--- a/src/main/java/matchuri/backend/domain/menu/command/GetAttributeCategoriesCommand.java
+++ b/src/main/java/matchuri/backend/domain/menu/command/GetAttributeCategoriesCommand.java
@@ -1,0 +1,9 @@
+package matchuri.backend.domain.menu.command;
+
+import java.util.List;
+import matchuri.backend.domain.menu.entity.CategoryType;
+
+public record GetAttributeCategoriesCommand(
+        List<CategoryType> categoryTypes
+) {
+}

--- a/src/main/java/matchuri/backend/domain/menu/repository/AttributeCategoryRepository.java
+++ b/src/main/java/matchuri/backend/domain/menu/repository/AttributeCategoryRepository.java
@@ -14,5 +14,9 @@ public interface AttributeCategoryRepository extends JpaRepository<AttributeCate
 
     List<AttributeCategory> findAllByActiveTrueOrderByCategoryTypeAscSortOrderAscIdAsc();
 
+    List<AttributeCategory> findAllByActiveTrueAndCategoryTypeInOrderByCategoryTypeAscSortOrderAscIdAsc(
+            Collection<CategoryType> categoryTypes
+    );
+
     List<AttributeCategory> findAllByIdInAndActiveTrue(Collection<Long> ids);
 }

--- a/src/main/java/matchuri/backend/domain/menu/repository/MenuAttributeCategoryRepository.java
+++ b/src/main/java/matchuri/backend/domain/menu/repository/MenuAttributeCategoryRepository.java
@@ -5,6 +5,7 @@ import matchuri.backend.domain.menu.entity.MenuAttributeCategory;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+// TODO: 의도가 명확한 메서드명으로 변경하기
 @NullMarked
 public interface MenuAttributeCategoryRepository extends JpaRepository<MenuAttributeCategory, Long> {
 

--- a/src/main/java/matchuri/backend/domain/menu/service/MenuReferenceService.java
+++ b/src/main/java/matchuri/backend/domain/menu/service/MenuReferenceService.java
@@ -1,6 +1,7 @@
 package matchuri.backend.domain.menu.service;
 
 import java.util.List;
+import matchuri.backend.domain.menu.command.GetAttributeCategoriesCommand;
 import matchuri.backend.domain.menu.command.SearchMenuItemsCommand;
 import matchuri.backend.domain.menu.result.AttributeCategoryResult;
 import matchuri.backend.domain.menu.result.MenuItemDetailResult;
@@ -9,7 +10,7 @@ import matchuri.backend.domain.menu.result.RestrictionIngredientResult;
 
 public interface MenuReferenceService {
 
-    List<AttributeCategoryResult> getActiveAttributeCategories();
+    List<AttributeCategoryResult> getActiveAttributeCategories(GetAttributeCategoriesCommand command);
 
     List<RestrictionIngredientResult> getActiveRestrictionIngredients();
 

--- a/src/main/java/matchuri/backend/domain/menu/service/MenuReferenceServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/menu/service/MenuReferenceServiceImpl.java
@@ -3,7 +3,9 @@ package matchuri.backend.domain.menu.service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.domain.menu.MenuErrorCode;
+import matchuri.backend.domain.menu.command.GetAttributeCategoriesCommand;
 import matchuri.backend.domain.menu.command.SearchMenuItemsCommand;
+import matchuri.backend.domain.menu.entity.CategoryType;
 import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
 import matchuri.backend.domain.menu.repository.IngredientRepository;
 import matchuri.backend.domain.menu.repository.MenuAttributeCategoryRepository;
@@ -29,8 +31,16 @@ public class MenuReferenceServiceImpl implements MenuReferenceService {
     private final MenuIngredientRepository menuIngredientRepository;
 
     @Override
-    public List<AttributeCategoryResult> getActiveAttributeCategories() {
-        return attributeCategoryRepository.findAllByActiveTrueOrderByCategoryTypeAscSortOrderAscIdAsc().stream()
+    public List<AttributeCategoryResult> getActiveAttributeCategories(GetAttributeCategoriesCommand command) {
+        List<CategoryType> categoryTypes = command.categoryTypes() == null ? List.of()
+                : command.categoryTypes().stream().distinct().toList();
+
+        var categories = categoryTypes.isEmpty()
+                ? attributeCategoryRepository.findAllByActiveTrueOrderByCategoryTypeAscSortOrderAscIdAsc()
+                : attributeCategoryRepository
+                        .findAllByActiveTrueAndCategoryTypeInOrderByCategoryTypeAscSortOrderAscIdAsc(categoryTypes);
+
+        return categories.stream()
                 .map(AttributeCategoryResult::from)
                 .toList();
     }
@@ -69,12 +79,14 @@ public class MenuReferenceServiceImpl implements MenuReferenceService {
     public MenuItemDetailResult getMenuItem(Long menuItemId) {
         var menuItem = menuItemRepository.findByIdAndActiveTrue(menuItemId)
                 .orElseThrow(() -> new BusinessException(MenuErrorCode.NOT_FOUND, menuItemId));
+
         var attributeCategories = menuAttributeCategoryRepository
                 .findAllByMenuIdAndAttributeCategoryActiveTrueOrderByAttributeCategoryCategoryTypeAscAttributeCategorySortOrderAscAttributeCategoryIdAsc(
                         menuItemId)
                 .stream()
                 .map(menuAttributeCategory -> AttributeCategoryResult.from(menuAttributeCategory.getAttributeCategory()))
                 .toList();
+
         var ingredients = menuIngredientRepository
                 .findAllByMenuIdAndIngredientActiveTrueOrderByIngredientSortOrderAscIngredientIdAsc(menuItemId)
                 .stream()

--- a/src/test/java/matchuri/backend/api/menu/MenuReferenceIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/menu/MenuReferenceIntegrationTest.java
@@ -90,6 +90,49 @@ class MenuReferenceIntegrationTest {
     }
 
     @Test
+    @DisplayName("attribute category 목록 조회는 categoryTypes로 취향 입력에 필요한 유형만 반환한다")
+    void getAttributeCategoriesFiltersByCategoryTypes() throws Exception {
+        AttributeCategory spicy = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 20));
+        AttributeCategory sweet = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.FLAVOR, "SWEET", "달콤함", 10));
+        AttributeCategory crispy = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.TEXTURE, "CRISPY", "바삭함", 10));
+        attributeCategoryRepository.save(new AttributeCategory(CategoryType.COOKING_METHOD, "GRILLED", "구이", 10));
+        AttributeCategory inactive = new AttributeCategory(CategoryType.FLAVOR, "MILD", "순한맛", 5);
+        inactive.deactivate();
+        attributeCategoryRepository.save(inactive);
+
+        mockMvc.perform(get("/api/v1/attribute-categories")
+                        .param("categoryTypes", "FLAVOR", "TEXTURE")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.error").value(nullValue()))
+                .andExpect(jsonPath("$.data.length()").value(3))
+                .andExpect(jsonPath("$.data[0].id").value(sweet.getId()))
+                .andExpect(jsonPath("$.data[0].categoryType").value("FLAVOR"))
+                .andExpect(jsonPath("$.data[0].code").value("SWEET"))
+                .andExpect(jsonPath("$.data[1].id").value(spicy.getId()))
+                .andExpect(jsonPath("$.data[1].categoryType").value("FLAVOR"))
+                .andExpect(jsonPath("$.data[1].code").value("SPICY"))
+                .andExpect(jsonPath("$.data[2].id").value(crispy.getId()))
+                .andExpect(jsonPath("$.data[2].categoryType").value("TEXTURE"))
+                .andExpect(jsonPath("$.data[2].code").value("CRISPY"));
+    }
+
+    @Test
+    @DisplayName("attribute category 목록 조회는 잘못된 categoryTypes 값을 거절한다")
+    void getAttributeCategoriesRejectsInvalidCategoryTypes() throws Exception {
+        mockMvc.perform(get("/api/v1/attribute-categories")
+                        .param("categoryTypes", "UNKNOWN")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("COMMON_INVALID_QUERY_PARAMETER"));
+    }
+
+    @Test
     @DisplayName("restriction ingredient 목록 조회는 공개 API로 활성 데이터만 정렬해서 반환한다")
     void getRestrictionIngredientsReturnsOnlyActiveRowsInSortedOrder() throws Exception {
         Ingredient peanut = ingredientRepository.save(new Ingredient("PEANUT", "땅콩", true, 10));


### PR DESCRIPTION
## 관련 이슈
Closes #130 

## 📝 작업 내용
- `GET api/v1/attribute-categories`에 `categoryTypes` 쿼리 파라미터 추가

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 타입별로 따로 호출이 가능하나, 카테고리와 같은 경우는 거의 고정된 값이기에 모든 목록을 불러온 후 캐싱 처리를 할 것으로 예상