### PR TITLE
[Refactor] 알레르기 재료 리스트 조회 API에 필터링 추가

### DIFF
--- a/src/main/java/matchuri/backend/api/menu/MenuReferenceApi.java
+++ b/src/main/java/matchuri/backend/api/menu/MenuReferenceApi.java
@@ -71,6 +71,8 @@ public interface MenuReferenceApi {
                     
                     - 인증 없이 호출할 수 있습니다.
                     - 응답에는 `is_active=true`인 데이터만 포함됩니다.
+                    - `query`는 재료명 부분 검색입니다.
+                    - `allergen`이 있으면 알레르기 유발 여부로 필터링합니다.
                     - 정렬 기준은 `sortOrder`, `id`입니다.
                     - 응답에는 UI 표시를 위한 `allergen` 여부를 함께 포함합니다.
                     """
@@ -104,7 +106,7 @@ public interface MenuReferenceApi {
                     )
             )
     })
-    ApiResponse<List<RestrictionIngredientResponse>> getRestrictionIngredients();
+    ApiResponse<List<RestrictionIngredientResponse>> getRestrictionIngredients(String query, Boolean allergen);
 
     @Operation(
             summary = "메뉴 목록 조회",

--- a/src/main/java/matchuri/backend/api/menu/MenuReferenceController.java
+++ b/src/main/java/matchuri/backend/api/menu/MenuReferenceController.java
@@ -38,8 +38,12 @@ public class MenuReferenceController implements MenuReferenceApi {
 
     @Override
     @GetMapping("/restriction-ingredients")
-    public ApiResponse<List<RestrictionIngredientResponse>> getRestrictionIngredients() {
-        var ingredients = menuReferenceService.getActiveRestrictionIngredients();
+    public ApiResponse<List<RestrictionIngredientResponse>> getRestrictionIngredients(
+            @RequestParam(required = false) String query,
+            @RequestParam(required = false) Boolean allergen
+    ) {
+        var command = menuReferenceMapper.toGetRestrictionIngredientsCommand(query, allergen);
+        var ingredients = menuReferenceService.getActiveRestrictionIngredients(command);
         var responses = menuReferenceMapper.toRestrictionIngredientResponses(ingredients);
 
         return ApiResponse.success(responses);

--- a/src/main/java/matchuri/backend/api/menu/mapper/MenuReferenceMapper.java
+++ b/src/main/java/matchuri/backend/api/menu/mapper/MenuReferenceMapper.java
@@ -14,6 +14,7 @@ import matchuri.backend.api.menu.dto.response.RestrictionIngredientResponse;
 import matchuri.backend.domain.menu.command.CreateAdminAttributeCategoryCommand;
 import matchuri.backend.domain.menu.command.CreateAdminIngredientCommand;
 import matchuri.backend.domain.menu.command.GetAttributeCategoriesCommand;
+import matchuri.backend.domain.menu.command.GetRestrictionIngredientsCommand;
 import matchuri.backend.domain.menu.command.SearchMenuItemsCommand;
 import matchuri.backend.domain.menu.command.UpdateAdminAttributeCategoryCommand;
 import matchuri.backend.domain.menu.command.UpdateAdminIngredientCommand;
@@ -88,6 +89,10 @@ public class MenuReferenceMapper {
 
     public GetAttributeCategoriesCommand toGetAttributeCategoriesCommand(List<CategoryType> categoryTypes) {
         return new GetAttributeCategoriesCommand(categoryTypes == null ? List.of() : categoryTypes);
+    }
+
+    public GetRestrictionIngredientsCommand toGetRestrictionIngredientsCommand(String query, Boolean allergen) {
+        return new GetRestrictionIngredientsCommand(trimNullable(query), allergen);
     }
 
     public List<AdminAttributeCategoryResponse> toAdminAttributeCategoryResponses(

--- a/src/main/java/matchuri/backend/domain/menu/command/GetRestrictionIngredientsCommand.java
+++ b/src/main/java/matchuri/backend/domain/menu/command/GetRestrictionIngredientsCommand.java
@@ -1,0 +1,7 @@
+package matchuri.backend.domain.menu.command;
+
+public record GetRestrictionIngredientsCommand(
+        String query,
+        Boolean allergen
+) {
+}

--- a/src/main/java/matchuri/backend/domain/menu/repository/IngredientRepository.java
+++ b/src/main/java/matchuri/backend/domain/menu/repository/IngredientRepository.java
@@ -4,6 +4,8 @@ import java.util.Collection;
 import java.util.List;
 import matchuri.backend.domain.menu.entity.Ingredient;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
 
@@ -12,6 +14,19 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
     List<Ingredient> findAllByOrderBySortOrderAscIdAsc();
 
     List<Ingredient> findAllByActiveTrueOrderBySortOrderAscIdAsc();
+
+    @Query("""
+            select ingredient
+            from Ingredient ingredient
+            where ingredient.active = true
+              and (:query is null or lower(ingredient.name) like lower(concat('%', :query, '%')))
+              and (:allergen is null or ingredient.allergen = :allergen)
+            order by ingredient.sortOrder asc, ingredient.id asc
+            """)
+    List<Ingredient> searchActiveRestrictionIngredients(
+            @Param("query") String query,
+            @Param("allergen") Boolean allergen
+    );
 
     List<Ingredient> findAllByIdInAndActiveTrue(Collection<Long> ids);
 }

--- a/src/main/java/matchuri/backend/domain/menu/service/MenuReferenceService.java
+++ b/src/main/java/matchuri/backend/domain/menu/service/MenuReferenceService.java
@@ -2,6 +2,7 @@ package matchuri.backend.domain.menu.service;
 
 import java.util.List;
 import matchuri.backend.domain.menu.command.GetAttributeCategoriesCommand;
+import matchuri.backend.domain.menu.command.GetRestrictionIngredientsCommand;
 import matchuri.backend.domain.menu.command.SearchMenuItemsCommand;
 import matchuri.backend.domain.menu.result.AttributeCategoryResult;
 import matchuri.backend.domain.menu.result.MenuItemDetailResult;
@@ -12,7 +13,7 @@ public interface MenuReferenceService {
 
     List<AttributeCategoryResult> getActiveAttributeCategories(GetAttributeCategoriesCommand command);
 
-    List<RestrictionIngredientResult> getActiveRestrictionIngredients();
+    List<RestrictionIngredientResult> getActiveRestrictionIngredients(GetRestrictionIngredientsCommand command);
 
     List<MenuItemSummaryResult> searchMenuItems(SearchMenuItemsCommand command);
 

--- a/src/main/java/matchuri/backend/domain/menu/service/MenuReferenceServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/menu/service/MenuReferenceServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.domain.menu.MenuErrorCode;
 import matchuri.backend.domain.menu.command.GetAttributeCategoriesCommand;
+import matchuri.backend.domain.menu.command.GetRestrictionIngredientsCommand;
 import matchuri.backend.domain.menu.command.SearchMenuItemsCommand;
 import matchuri.backend.domain.menu.entity.CategoryType;
 import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
@@ -46,8 +47,12 @@ public class MenuReferenceServiceImpl implements MenuReferenceService {
     }
 
     @Override
-    public List<RestrictionIngredientResult> getActiveRestrictionIngredients() {
-        return ingredientRepository.findAllByActiveTrueOrderBySortOrderAscIdAsc().stream()
+    public List<RestrictionIngredientResult> getActiveRestrictionIngredients(GetRestrictionIngredientsCommand command) {
+        return ingredientRepository.searchActiveRestrictionIngredients(
+                        normalizeQuery(command.query()),
+                        command.allergen()
+                )
+                .stream()
                 .map(RestrictionIngredientResult::from)
                 .toList();
     }

--- a/src/test/java/matchuri/backend/api/menu/MenuReferenceIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/menu/MenuReferenceIntegrationTest.java
@@ -156,6 +156,40 @@ class MenuReferenceIntegrationTest {
     }
 
     @Test
+    @DisplayName("restriction ingredient 목록 조회는 query와 allergen으로 취향 입력에 필요한 재료만 반환한다")
+    void getRestrictionIngredientsFiltersByQueryAndAllergen() throws Exception {
+        Ingredient peanut = ingredientRepository.save(new Ingredient("PEANUT", "땅콩", true, 10));
+        ingredientRepository.save(new Ingredient("PEANUT_OIL", "땅콩기름", false, 20));
+        ingredientRepository.save(new Ingredient("SHRIMP", "새우", true, 30));
+        Ingredient inactive = new Ingredient("PEANUT_POWDER", "땅콩가루", true, 5);
+        inactive.deactivate();
+        ingredientRepository.save(inactive);
+
+        mockMvc.perform(get("/api/v1/restriction-ingredients")
+                        .param("query", "땅콩")
+                        .param("allergen", "true")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.error").value(nullValue()))
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].id").value(peanut.getId()))
+                .andExpect(jsonPath("$.data[0].code").value("PEANUT"))
+                .andExpect(jsonPath("$.data[0].allergen").value(true));
+    }
+
+    @Test
+    @DisplayName("restriction ingredient 목록 조회는 잘못된 allergen 값을 거절한다")
+    void getRestrictionIngredientsRejectsInvalidAllergen() throws Exception {
+        mockMvc.perform(get("/api/v1/restriction-ingredients")
+                        .param("allergen", "UNKNOWN")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("COMMON_INVALID_QUERY_PARAMETER"));
+    }
+
+    @Test
     @DisplayName("메뉴 목록 조회는 활성 메뉴의 id, code, name만 반환한다")
     void searchMenuItemsReturnsOnlyActiveMenuSummaries() throws Exception {
         MenuItem kimchiStew = menuItemRepository.save(


### PR DESCRIPTION
## 관련 이슈
Closes #132 

## 📝 작업 내용
- `GET api/v1/restriction-ingredients`에 `query`, `allergen` 쿼리 파라미터 추가

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [ ] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [ ] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [ ] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [ ] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항

재료명 및 알러지 여부 필터링 조회 가능

- `query`는 재료명 부분 검색입니다.
- `allergen`이 있으면 알레르기 유발 여부로 필터링합니다.
