### PR TITLE
[Feat] 이메일 전송 요청 API 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webmvc")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-starter-mail")
+    implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
     implementation("io.jsonwebtoken:jjwt-api:0.12.7")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2")
     compileOnly("org.projectlombok:lombok")

--- a/src/main/java/matchuri/backend/api/auth/EmailApi.java
+++ b/src/main/java/matchuri/backend/api/auth/EmailApi.java
@@ -2,7 +2,8 @@ package matchuri.backend.api.auth;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import matchuri.backend.api.auth.dto.request.EmailVerificationRequest;
+import matchuri.backend.api.auth.dto.request.EmailSendRequest;
+import matchuri.backend.api.auth.dto.response.EmailSendResponse;
 import matchuri.backend.global.api.ApiResponse;
 
 @Tag(name = "Email", description = "이메일 관련 API")
@@ -14,5 +15,5 @@ public interface EmailApi {
                     명세 추후 작성
                     """
     )
-    ApiResponse<Void> sendTxtEmail(EmailVerificationRequest request);
+    ApiResponse<EmailSendResponse> sendTxtEmail(EmailSendRequest request);
 }

--- a/src/main/java/matchuri/backend/api/auth/EmailApi.java
+++ b/src/main/java/matchuri/backend/api/auth/EmailApi.java
@@ -1,0 +1,18 @@
+package matchuri.backend.api.auth;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import matchuri.backend.api.auth.dto.request.EmailVerificationRequest;
+import matchuri.backend.global.api.ApiResponse;
+
+@Tag(name = "Email", description = "이메일 관련 API")
+public interface EmailApi {
+
+    @Operation(
+            summary = "이메일 인증",
+            description = """
+                    명세 추후 작성
+                    """
+    )
+    ApiResponse<Void> sendTxtEmail(EmailVerificationRequest request);
+}

--- a/src/main/java/matchuri/backend/api/auth/EmailController.java
+++ b/src/main/java/matchuri/backend/api/auth/EmailController.java
@@ -1,7 +1,8 @@
 package matchuri.backend.api.auth;
 
 import lombok.RequiredArgsConstructor;
-import matchuri.backend.api.auth.dto.request.EmailVerificationRequest;
+import matchuri.backend.api.auth.dto.request.EmailSendRequest;
+import matchuri.backend.api.auth.dto.response.EmailSendResponse;
 import matchuri.backend.domain.auth.service.EmailVerificationService;
 import matchuri.backend.global.api.ApiResponse;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,8 +18,8 @@ public class EmailController implements EmailApi {
 
     @Override
     @PostMapping("/email")
-    public ApiResponse<Void> sendTxtEmail(EmailVerificationRequest request) {
-        emailVerificationService.sendTxtEmail(request);
-        return ApiResponse.success(null);
+    public ApiResponse<EmailSendResponse> sendTxtEmail(EmailSendRequest request) {
+        EmailSendResponse response = emailVerificationService.sendTxtEmail(request);
+        return ApiResponse.success(response);
     }
 }

--- a/src/main/java/matchuri/backend/api/auth/EmailController.java
+++ b/src/main/java/matchuri/backend/api/auth/EmailController.java
@@ -1,0 +1,24 @@
+package matchuri.backend.api.auth;
+
+import lombok.RequiredArgsConstructor;
+import matchuri.backend.api.auth.dto.request.EmailVerificationRequest;
+import matchuri.backend.domain.auth.service.EmailVerificationService;
+import matchuri.backend.global.api.ApiResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class EmailController implements EmailApi {
+
+    private final EmailVerificationService emailVerificationService;
+
+    @Override
+    @PostMapping("/email")
+    public ApiResponse<Void> sendTxtEmail(EmailVerificationRequest request) {
+        emailVerificationService.sendTxtEmail(request);
+        return ApiResponse.success(null);
+    }
+}

--- a/src/main/java/matchuri/backend/api/auth/dto/request/EmailSendRequest.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/request/EmailSendRequest.java
@@ -1,8 +1,6 @@
 package matchuri.backend.api.auth.dto.request;
 
 public record EmailSendRequest(
-        String email,
-        String subject,
-        String content
+        String email
 ) {
 }

--- a/src/main/java/matchuri/backend/api/auth/dto/request/EmailSendRequest.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/request/EmailSendRequest.java
@@ -1,6 +1,6 @@
 package matchuri.backend.api.auth.dto.request;
 
-public record EmailVerificationRequest(
+public record EmailSendRequest(
         String email,
         String subject,
         String content

--- a/src/main/java/matchuri/backend/api/auth/dto/request/EmailSendRequest.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/request/EmailSendRequest.java
@@ -1,6 +1,7 @@
 package matchuri.backend.api.auth.dto.request;
 
 public record EmailSendRequest(
-        String email
+        String email,
+        String type
 ) {
 }

--- a/src/main/java/matchuri/backend/api/auth/dto/request/EmailVerificationRequest.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/request/EmailVerificationRequest.java
@@ -1,0 +1,8 @@
+package matchuri.backend.api.auth.dto.request;
+
+public record EmailVerificationRequest(
+        String email,
+        String subject,
+        String content
+) {
+}

--- a/src/main/java/matchuri/backend/api/auth/dto/response/EmailSendResponse.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/response/EmailSendResponse.java
@@ -2,6 +2,7 @@ package matchuri.backend.api.auth.dto.response;
 
 public record EmailSendResponse(
         long id,
-        String email
+        String email,
+        String type
 ) {
 }

--- a/src/main/java/matchuri/backend/api/auth/dto/response/EmailSendResponse.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/response/EmailSendResponse.java
@@ -1,0 +1,7 @@
+package matchuri.backend.api.auth.dto.response;
+
+public record EmailSendResponse(
+        long id,
+        String email
+) {
+}

--- a/src/main/java/matchuri/backend/domain/auth/entity/EmailVerification.java
+++ b/src/main/java/matchuri/backend/domain/auth/entity/EmailVerification.java
@@ -2,6 +2,8 @@ package matchuri.backend.domain.auth.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -30,7 +32,12 @@ public class EmailVerification extends BaseEntity {
     private String code;
 
     @Column(name = "type")
+    @Enumerated(EnumType.STRING)
     private EmailVerificationType type;
+
+    public static EmailVerification from(String email, String code, EmailVerificationType type) {
+        return new EmailVerification(null, email, code, type);
+    }
 
     public static EmailVerification fromSignUp(String email, String code) {
         return new EmailVerification(null, email, code, EmailVerificationType.SIGNUP);

--- a/src/main/java/matchuri/backend/domain/auth/entity/EmailVerification.java
+++ b/src/main/java/matchuri/backend/domain/auth/entity/EmailVerification.java
@@ -1,0 +1,35 @@
+package matchuri.backend.domain.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import matchuri.backend.domain.common.BaseEntity;
+
+@Getter
+@Entity
+@Table(name = "email_verification")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailVerification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "email")
+    private String email;
+
+    @Column(name = "code")
+    private String code;
+
+    public static EmailVerification from(String email, String code) {
+        return new EmailVerification(null, email, code);
+    }
+}

--- a/src/main/java/matchuri/backend/domain/auth/entity/EmailVerification.java
+++ b/src/main/java/matchuri/backend/domain/auth/entity/EmailVerification.java
@@ -29,7 +29,10 @@ public class EmailVerification extends BaseEntity {
     @Column(name = "code")
     private String code;
 
-    public static EmailVerification from(String email, String code) {
-        return new EmailVerification(null, email, code);
+    @Column(name = "type")
+    private EmailVerificationType type;
+
+    public static EmailVerification fromSignUp(String email, String code) {
+        return new EmailVerification(null, email, code, EmailVerificationType.SIGNUP);
     }
 }

--- a/src/main/java/matchuri/backend/domain/auth/entity/EmailVerification.java
+++ b/src/main/java/matchuri/backend/domain/auth/entity/EmailVerification.java
@@ -38,8 +38,4 @@ public class EmailVerification extends BaseEntity {
     public static EmailVerification from(String email, String code, EmailVerificationType type) {
         return new EmailVerification(null, email, code, type);
     }
-
-    public static EmailVerification fromSignUp(String email, String code) {
-        return new EmailVerification(null, email, code, EmailVerificationType.SIGNUP);
-    }
 }

--- a/src/main/java/matchuri/backend/domain/auth/entity/EmailVerificationType.java
+++ b/src/main/java/matchuri/backend/domain/auth/entity/EmailVerificationType.java
@@ -1,0 +1,7 @@
+package matchuri.backend.domain.auth.entity;
+
+public enum EmailVerificationType {
+    SIGNUP,
+    LOGIN,
+    PASSWORD
+}

--- a/src/main/java/matchuri/backend/domain/auth/repository/EmailVerificationRepository.java
+++ b/src/main/java/matchuri/backend/domain/auth/repository/EmailVerificationRepository.java
@@ -1,0 +1,9 @@
+package matchuri.backend.domain.auth.repository;
+
+import matchuri.backend.domain.auth.entity.EmailVerification;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+@NullMarked
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
+}

--- a/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationService.java
@@ -1,0 +1,7 @@
+package matchuri.backend.domain.auth.service;
+
+import matchuri.backend.api.auth.dto.request.EmailVerificationRequest;
+
+public interface EmailVerificationService {
+    void sendTxtEmail(EmailVerificationRequest request);
+}

--- a/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationService.java
@@ -1,7 +1,8 @@
 package matchuri.backend.domain.auth.service;
 
-import matchuri.backend.api.auth.dto.request.EmailVerificationRequest;
+import matchuri.backend.api.auth.dto.request.EmailSendRequest;
+import matchuri.backend.api.auth.dto.response.EmailSendResponse;
 
 public interface EmailVerificationService {
-    void sendTxtEmail(EmailVerificationRequest request);
+    EmailSendResponse sendTxtEmail(EmailSendRequest request);
 }

--- a/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationServiceImpl.java
@@ -1,36 +1,49 @@
 package matchuri.backend.domain.auth.service;
 
 import lombok.RequiredArgsConstructor;
-import matchuri.backend.api.auth.dto.request.EmailVerificationRequest;
+import lombok.extern.slf4j.Slf4j;
+import matchuri.backend.api.auth.dto.request.EmailSendRequest;
+import matchuri.backend.api.auth.dto.response.EmailSendResponse;
+import matchuri.backend.domain.auth.entity.EmailVerification;
+import matchuri.backend.domain.auth.repository.EmailVerificationRepository;
 import matchuri.backend.domain.auth.support.vertification.VerificationCodeGenerator;
 import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EmailVerificationServiceImpl implements EmailVerificationService {
 
     private final JavaMailSender mailSender;
+    private final EmailVerificationRepository repository;
 
     public static String EMAIL_SUBJECT = "맛추리 회원가입 인증 요청";
 
     @Override
-    public void sendTxtEmail(EmailVerificationRequest request) {
+    public EmailSendResponse sendTxtEmail(EmailSendRequest request) {
 
         SimpleMailMessage smm = new SimpleMailMessage();
+        String email = request.email();
         String code = VerificationCodeGenerator.generateCode();
 
-        smm.setTo(request.email());
+        smm.setTo(email);
         smm.setSubject(EMAIL_SUBJECT);
         smm.setText(code);
 
+        EmailVerification emailVerification = EmailVerification.from(email, code);
+        EmailVerification saved = repository.save(emailVerification);
+
+        EmailSendResponse response = new EmailSendResponse(saved.getId(), saved.getEmail());
+
         try {
             mailSender.send(smm);
-            System.out.println("이메일 전송 성공!");
+            log.info("이메일 전송 성공!");
+            return response;
         } catch (MailException e) {
-            System.out.println("[-] 이메일 전송중에 오류가 발생하였습니다 " + e.getMessage());
+            log.info("[-] 이메일 전송중에 오류가 발생하였습니다 {}", e.getMessage());
             throw e;
         }
     }

--- a/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationServiceImpl.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import matchuri.backend.api.auth.dto.request.EmailSendRequest;
 import matchuri.backend.api.auth.dto.response.EmailSendResponse;
 import matchuri.backend.domain.auth.entity.EmailVerification;
+import matchuri.backend.domain.auth.entity.EmailVerificationType;
 import matchuri.backend.domain.auth.repository.EmailVerificationRepository;
 import matchuri.backend.domain.auth.support.vertification.VerificationCodeGenerator;
 import org.springframework.mail.MailException;
@@ -27,13 +28,14 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
 
         SimpleMailMessage smm = new SimpleMailMessage();
         String email = request.email();
+        EmailVerificationType type = EmailVerificationType.valueOf(request.type());
         String code = VerificationCodeGenerator.generateCode();
 
         smm.setTo(email);
         smm.setSubject(EMAIL_SUBJECT);
         smm.setText(code);
 
-        EmailVerification emailVerification = EmailVerification.fromSignUp(email, code);
+        EmailVerification emailVerification = EmailVerification.from(email, code, type);
         EmailVerification saved = repository.save(emailVerification);
 
         EmailSendResponse response = new EmailSendResponse(

--- a/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationServiceImpl.java
@@ -2,6 +2,7 @@ package matchuri.backend.domain.auth.service;
 
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.api.auth.dto.request.EmailVerificationRequest;
+import matchuri.backend.domain.auth.support.vertification.VerificationCodeGenerator;
 import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -13,12 +14,18 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
 
     private final JavaMailSender mailSender;
 
+    public static String EMAIL_SUBJECT = "맛추리 회원가입 인증 요청";
+
     @Override
     public void sendTxtEmail(EmailVerificationRequest request) {
+
         SimpleMailMessage smm = new SimpleMailMessage();
+        String code = VerificationCodeGenerator.generateCode();
+
         smm.setTo(request.email());
-        smm.setSubject(request.subject());
-        smm.setText(request.content());
+        smm.setSubject(EMAIL_SUBJECT);
+        smm.setText(code);
+
         try {
             mailSender.send(smm);
             System.out.println("이메일 전송 성공!");

--- a/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationServiceImpl.java
@@ -20,7 +20,7 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
     private final JavaMailSender mailSender;
     private final EmailVerificationRepository repository;
 
-    public static String SIGNUP_EMAIL_SUBJECT = "맛추리 회원가입 인증 요청";
+    public static String EMAIL_SUBJECT = "맛추리 인증 요청";
 
     @Override
     public EmailSendResponse sendTxtEmail(EmailSendRequest request) {
@@ -30,7 +30,7 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
         String code = VerificationCodeGenerator.generateCode();
 
         smm.setTo(email);
-        smm.setSubject(SIGNUP_EMAIL_SUBJECT);
+        smm.setSubject(EMAIL_SUBJECT);
         smm.setText(code);
 
         EmailVerification emailVerification = EmailVerification.from(email, code);

--- a/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationServiceImpl.java
@@ -20,7 +20,7 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
     private final JavaMailSender mailSender;
     private final EmailVerificationRepository repository;
 
-    public static String EMAIL_SUBJECT = "맛추리 회원가입 인증 요청";
+    public static String SIGNUP_EMAIL_SUBJECT = "맛추리 회원가입 인증 요청";
 
     @Override
     public EmailSendResponse sendTxtEmail(EmailSendRequest request) {
@@ -30,7 +30,7 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
         String code = VerificationCodeGenerator.generateCode();
 
         smm.setTo(email);
-        smm.setSubject(EMAIL_SUBJECT);
+        smm.setSubject(SIGNUP_EMAIL_SUBJECT);
         smm.setText(code);
 
         EmailVerification emailVerification = EmailVerification.from(email, code);

--- a/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationServiceImpl.java
@@ -33,10 +33,14 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
         smm.setSubject(EMAIL_SUBJECT);
         smm.setText(code);
 
-        EmailVerification emailVerification = EmailVerification.from(email, code);
+        EmailVerification emailVerification = EmailVerification.fromSignUp(email, code);
         EmailVerification saved = repository.save(emailVerification);
 
-        EmailSendResponse response = new EmailSendResponse(saved.getId(), saved.getEmail());
+        EmailSendResponse response = new EmailSendResponse(
+                saved.getId(),
+                saved.getEmail(),
+                saved.getType().name()
+        );
 
         try {
             mailSender.send(smm);

--- a/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationServiceImpl.java
@@ -1,0 +1,31 @@
+package matchuri.backend.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import matchuri.backend.api.auth.dto.request.EmailVerificationRequest;
+import org.springframework.mail.MailException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationServiceImpl implements EmailVerificationService {
+
+    private final JavaMailSender mailSender;
+
+    @Override
+    public void sendTxtEmail(EmailVerificationRequest request) {
+        SimpleMailMessage smm = new SimpleMailMessage();
+        smm.setTo(request.email());
+        smm.setSubject(request.subject());
+        smm.setText(request.content());
+        try {
+            mailSender.send(smm);
+            System.out.println("이메일 전송 성공!");
+        } catch (MailException e) {
+            System.out.println("[-] 이메일 전송중에 오류가 발생하였습니다 " + e.getMessage());
+            throw e;
+        }
+    }
+
+}

--- a/src/main/java/matchuri/backend/domain/auth/support/vertification/VerificationCodeGenerator.java
+++ b/src/main/java/matchuri/backend/domain/auth/support/vertification/VerificationCodeGenerator.java
@@ -1,0 +1,15 @@
+package matchuri.backend.domain.auth.support.vertification;
+
+import java.security.SecureRandom;
+import org.springframework.stereotype.Component;
+
+@Component
+public class VerificationCodeGenerator {
+
+    private static final SecureRandom secureRandom = new SecureRandom();
+
+    public static String generateCode() {
+        int code = secureRandom.nextInt(1_000_000);
+        return String.format("%06d", code);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -67,6 +67,7 @@ matchuri:
       - /api/v1/auth/login
       - /api/v1/auth/refresh
       - /api/v1/auth/oauth2/exchange
+      - /api/v1/auth/email
     public-options-api-patterns:
       - /**
     cors:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,6 +17,19 @@ spring:
               - openid
               - profile
               - email
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: you720223721@gmail.com
+    password: ${MATCHURI_GOOGLE_EMAIL_APP_PW}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          timeout: 5000
+          starttls:
+            enable: true
+
   docker:
     compose:
       lifecycle-management: start-only


### PR DESCRIPTION
## 관련 이슈
Closes #111 

## 📝 작업 내용
- `POST api/v1/auth/email` 추가

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [x] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항

- 아직 명세서는 작성하지 않았습니다.
- 이메일 전송시 별개의 템플릿은 만들지 않았습니다.
- 아래와 같이 요청하시면 됩니다.

```json
{
  "email": "yourj1n@naver.com",
  "type": "SIGNUP"
}
```

- `type`의 종류는 다음과 같습니다.

```
SIGNUP,
LOGIN,
PASSWORD
```

- 이어서 요청 코드 검증 API를 바로 작업할 계획입니다.
