### PR TITLE
[Feat] 이메일 검증 API 구현

### DIFF
--- a/src/main/java/matchuri/backend/api/auth/EmailApi.java
+++ b/src/main/java/matchuri/backend/api/auth/EmailApi.java
@@ -8,8 +8,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import matchuri.backend.api.auth.dto.docs.ConfirmEmailVerificationApiResponse;
 import matchuri.backend.api.auth.dto.docs.SendEmailVerificationApiResponse;
+import matchuri.backend.api.auth.dto.request.ConfirmEmailRequest;
 import matchuri.backend.api.auth.dto.request.SendEmailRequest;
+import matchuri.backend.api.auth.dto.response.ConfirmEmailResponse;
 import matchuri.backend.api.auth.dto.response.SendEmailResponse;
 import matchuri.backend.global.api.ApiResponse;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -103,4 +106,92 @@ public interface EmailApi {
             )
     })
     ApiResponse<SendEmailResponse> sendVerificationEmail(@Valid @RequestBody SendEmailRequest request);
+
+    @Operation(
+            summary = "이메일 인증 코드 확인",
+            description = """
+                    이메일로 받은 6자리 인증 코드를 확인하고 후속 회원가입/계정 복구용 `emailVerificationToken`을 발급합니다.
+                    
+                    - 인증 코드는 최신 `PENDING` 레코드 하나만 대상으로 검증합니다.
+                    - 만료, 시도 횟수 초과, 틀린 코드, 이미 사용된 코드는 모두 같은 인증 실패 응답을 반환합니다.
+                    - `emailVerificationToken` 원문은 이 응답에서 한 번만 노출하고 DB에는 hash만 저장합니다.
+                    - `RESET_PASSWORD` 목적에서는 `loginId`가 필요합니다.
+                    """
+    )
+    @SecurityRequirements
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "인증 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ConfirmEmailVerificationApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "data": {
+                                                "verified": true,
+                                                "emailVerificationToken": "ev_q3JxFrSxYk4zJw2zq3ZpQh0a3z9q0x1y2z3A4b5C6dE",
+                                                "expiresIn": 600
+                                              },
+                                              "error": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "요청 바디 형식 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "invalidBodyField",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "data": null,
+                                              "error": {
+                                                "status": 400,
+                                                "code": "COMMON_INVALID_BODY_FIELD",
+                                                "message": "요청 바디 필드가 올바르지 않습니다.",
+                                                "details": [
+                                                  {
+                                                    "source": "BODY",
+                                                    "field": "code",
+                                                    "reason": "code는 6자리 숫자여야 합니다."
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 레코드가 없거나, 만료되었거나, 코드가 올바르지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "verificationFailed",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "data": null,
+                                              "error": {
+                                                "status": 401,
+                                                "code": "AUTH_EMAIL_VERIFICATION_FAILED",
+                                                "message": "이메일 인증에 실패했습니다.",
+                                                "details": []
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ApiResponse<ConfirmEmailResponse> confirmVerificationEmail(@Valid @RequestBody ConfirmEmailRequest request);
 }

--- a/src/main/java/matchuri/backend/api/auth/EmailController.java
+++ b/src/main/java/matchuri/backend/api/auth/EmailController.java
@@ -2,8 +2,11 @@ package matchuri.backend.api.auth;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import matchuri.backend.api.auth.dto.request.ConfirmEmailRequest;
 import matchuri.backend.api.auth.dto.request.SendEmailRequest;
+import matchuri.backend.api.auth.dto.response.ConfirmEmailResponse;
 import matchuri.backend.api.auth.dto.response.SendEmailResponse;
+import matchuri.backend.domain.auth.command.ConfirmEmailVerificationCommand;
 import matchuri.backend.domain.auth.command.SendEmailVerificationCommand;
 import matchuri.backend.domain.auth.entity.EmailVerificationPurpose;
 import matchuri.backend.domain.auth.service.EmailVerificationService;
@@ -40,7 +43,38 @@ public class EmailController implements EmailApi {
         return ApiResponse.success(response);
     }
 
+    @Override
+    @PostMapping("/email/confirm")
+    public ApiResponse<ConfirmEmailResponse> confirmVerificationEmail(@Valid @RequestBody ConfirmEmailRequest request) {
+        validateConditionalFields(request);
+
+        var command = new ConfirmEmailVerificationCommand(
+                request.email(),
+                request.purpose(),
+                request.loginId(),
+                request.code()
+        );
+        var result = emailVerificationService.confirmVerificationEmail(command);
+        ConfirmEmailResponse response = new ConfirmEmailResponse(
+                result.verified(),
+                result.emailVerificationToken(),
+                result.expiresIn()
+        );
+
+        return ApiResponse.success(response);
+    }
+
     private void validateConditionalFields(SendEmailRequest request) {
+        if (request.purpose() == EmailVerificationPurpose.RESET_PASSWORD
+                && (request.loginId() == null || request.loginId().isBlank())) {
+            throw RequestValidationException.invalidBodyField(
+                    "loginId",
+                    "RESET_PASSWORD 목적에서는 loginId가 필요합니다."
+            );
+        }
+    }
+
+    private void validateConditionalFields(ConfirmEmailRequest request) {
         if (request.purpose() == EmailVerificationPurpose.RESET_PASSWORD
                 && (request.loginId() == null || request.loginId().isBlank())) {
             throw RequestValidationException.invalidBodyField(

--- a/src/main/java/matchuri/backend/api/auth/dto/docs/ConfirmEmailVerificationApiResponse.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/docs/ConfirmEmailVerificationApiResponse.java
@@ -1,0 +1,18 @@
+package matchuri.backend.api.auth.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.auth.dto.response.ConfirmEmailResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "이메일 인증 코드 확인 API의 공통 응답 envelope입니다.")
+public record ConfirmEmailVerificationApiResponse(
+        @Schema(description = "요청 성공 여부입니다.", example = "true")
+        boolean success,
+
+        @Schema(description = "성공 시 반환되는 이메일 인증 확인 payload입니다.")
+        ConfirmEmailResponse data,
+
+        @Schema(description = "실패 시 반환되는 에러 정보입니다.")
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/auth/dto/request/ConfirmEmailRequest.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/request/ConfirmEmailRequest.java
@@ -1,0 +1,32 @@
+package matchuri.backend.api.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import matchuri.backend.domain.auth.entity.EmailVerificationPurpose;
+
+@Schema(description = "이메일 인증 코드 확인 요청입니다.")
+public record ConfirmEmailRequest(
+        @Schema(description = "인증 코드를 받은 이메일입니다.", example = "tester@example.com", maxLength = 150)
+        @NotBlank(message = "email은 비어 있을 수 없습니다.")
+        @Email(message = "email은 올바른 이메일 형식이어야 합니다.")
+        @Size(max = 150, message = "email은 150자 이하여야 합니다.")
+        String email,
+
+        @Schema(description = "이메일 인증 목적입니다.", example = "RESET_PASSWORD")
+        @NotNull(message = "purpose는 필수입니다.")
+        EmailVerificationPurpose purpose,
+
+        @Schema(description = "비밀번호 재설정 목적에서 확인할 로그인 ID입니다.", example = "tester01", maxLength = 50)
+        @Size(max = 50, message = "loginId는 50자 이하여야 합니다.")
+        String loginId,
+
+        @Schema(description = "이메일로 받은 6자리 인증 코드입니다.", example = "123456")
+        @NotBlank(message = "code는 비어 있을 수 없습니다.")
+        @Pattern(regexp = "^\\d{6}$", message = "code는 6자리 숫자여야 합니다.")
+        String code
+) {
+}

--- a/src/main/java/matchuri/backend/api/auth/dto/response/ConfirmEmailResponse.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/response/ConfirmEmailResponse.java
@@ -1,0 +1,16 @@
+package matchuri.backend.api.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "이메일 인증 코드 확인 응답입니다.")
+public record ConfirmEmailResponse(
+        @Schema(description = "인증 성공 여부입니다.", example = "true")
+        boolean verified,
+
+        @Schema(description = "후속 회원가입/계정 복구 API에 전달할 이메일 인증 token입니다.")
+        String emailVerificationToken,
+
+        @Schema(description = "이메일 인증 token 유효 시간(초)입니다.", example = "600")
+        long expiresIn
+) {
+}

--- a/src/main/java/matchuri/backend/domain/auth/command/ConfirmEmailVerificationCommand.java
+++ b/src/main/java/matchuri/backend/domain/auth/command/ConfirmEmailVerificationCommand.java
@@ -2,15 +2,17 @@ package matchuri.backend.domain.auth.command;
 
 import matchuri.backend.domain.auth.entity.EmailVerificationPurpose;
 
-public record SendEmailVerificationCommand(
+public record ConfirmEmailVerificationCommand(
         String email,
         EmailVerificationPurpose purpose,
-        String loginId
+        String loginId,
+        String code
 ) {
-    public SendEmailVerificationCommand {
+    public ConfirmEmailVerificationCommand {
         email = email == null ? null : email.trim().toLowerCase();
         loginId = purpose == EmailVerificationPurpose.RESET_PASSWORD && loginId != null && !loginId.isBlank()
                 ? loginId.trim()
                 : null;
+        code = code == null ? null : code.trim();
     }
 }

--- a/src/main/java/matchuri/backend/domain/auth/entity/EmailVerification.java
+++ b/src/main/java/matchuri/backend/domain/auth/entity/EmailVerification.java
@@ -111,4 +111,18 @@ public class EmailVerification extends BaseEntity {
     public void markFailed() {
         this.status = EmailVerificationStatus.FAILED;
     }
+
+    public void recordFailedAttempt(int maxAttempts) {
+        this.attemptCount += 1;
+        if (this.attemptCount >= maxAttempts) {
+            markFailed();
+        }
+    }
+
+    public void verify(String verificationTokenHash, LocalDateTime tokenExpiresAt, LocalDateTime verifiedAt) {
+        this.status = EmailVerificationStatus.VERIFIED;
+        this.verifiedAt = verifiedAt;
+        this.verificationTokenHash = verificationTokenHash;
+        this.verificationTokenExpiresAt = tokenExpiresAt;
+    }
 }

--- a/src/main/java/matchuri/backend/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/auth/exception/AuthErrorCode.java
@@ -24,7 +24,8 @@ public enum AuthErrorCode implements ErrorCode {
     OAUTH2_PROVIDER_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인 제공자입니다."),
     OAUTH2_PROCESSING_FAILED(HttpStatus.UNAUTHORIZED, "소셜 로그인 처리에 실패했습니다."),
     OAUTH2_EXCHANGE_CODE_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 소셜 로그인 교환 코드입니다."),
-    EMAIL_SEND_FAILED(HttpStatus.BAD_GATEWAY, "이메일 발송에 실패했습니다.");
+    EMAIL_SEND_FAILED(HttpStatus.BAD_GATEWAY, "이메일 발송에 실패했습니다."),
+    EMAIL_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "이메일 인증에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/matchuri/backend/domain/auth/result/ConfirmEmailVerificationResult.java
+++ b/src/main/java/matchuri/backend/domain/auth/result/ConfirmEmailVerificationResult.java
@@ -1,0 +1,11 @@
+package matchuri.backend.domain.auth.result;
+
+public record ConfirmEmailVerificationResult(
+        boolean verified,
+        String emailVerificationToken,
+        long expiresIn
+) {
+    public static ConfirmEmailVerificationResult verified(String emailVerificationToken, long expiresIn) {
+        return new ConfirmEmailVerificationResult(true, emailVerificationToken, expiresIn);
+    }
+}

--- a/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationService.java
@@ -1,8 +1,12 @@
 package matchuri.backend.domain.auth.service;
 
+import matchuri.backend.domain.auth.command.ConfirmEmailVerificationCommand;
 import matchuri.backend.domain.auth.command.SendEmailVerificationCommand;
+import matchuri.backend.domain.auth.result.ConfirmEmailVerificationResult;
 import matchuri.backend.domain.auth.result.SendEmailVerificationResult;
 
 public interface EmailVerificationService {
     SendEmailVerificationResult sendVerificationEmail(SendEmailVerificationCommand command);
+
+    ConfirmEmailVerificationResult confirmVerificationEmail(ConfirmEmailVerificationCommand command);
 }

--- a/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationServiceImpl.java
@@ -2,21 +2,26 @@ package matchuri.backend.domain.auth.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import matchuri.backend.domain.auth.command.ConfirmEmailVerificationCommand;
 import matchuri.backend.domain.auth.command.SendEmailVerificationCommand;
 import matchuri.backend.domain.auth.entity.EmailVerification;
 import matchuri.backend.domain.auth.entity.EmailVerificationPurpose;
 import matchuri.backend.domain.auth.entity.EmailVerificationStatus;
 import matchuri.backend.domain.auth.exception.AuthErrorCode;
 import matchuri.backend.domain.auth.repository.EmailVerificationRepository;
+import matchuri.backend.domain.auth.result.ConfirmEmailVerificationResult;
 import matchuri.backend.domain.auth.result.SendEmailVerificationResult;
 import matchuri.backend.domain.auth.support.mail.AuthMailSender;
 import matchuri.backend.domain.auth.support.verification.EmailVerificationPolicy;
+import matchuri.backend.domain.auth.support.verification.EmailVerificationTokenGenerator;
 import matchuri.backend.domain.auth.support.verification.VerificationCodeGenerator;
 import matchuri.backend.domain.auth.support.verification.VerificationCodeHasher;
 import matchuri.backend.domain.member.entity.MemberStatus;
 import matchuri.backend.domain.member.repository.MemberRepository;
+import matchuri.backend.global.exception.AuthenticationException;
 import matchuri.backend.global.exception.BusinessException;
 import org.springframework.mail.MailException;
 import org.springframework.stereotype.Service;
@@ -32,6 +37,7 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
     private final VerificationCodeGenerator codeGenerator;
     private final VerificationCodeHasher codeHasher;
     private final EmailVerificationPolicy policy;
+    private final EmailVerificationTokenGenerator tokenGenerator;
     private final AuthMailSender authMailSender;
 
     @Override
@@ -81,6 +87,36 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
         }
     }
 
+    @Override
+    @Transactional(noRollbackFor = AuthenticationException.class)
+    public ConfirmEmailVerificationResult confirmVerificationEmail(ConfirmEmailVerificationCommand command) {
+        LocalDateTime now = LocalDateTime.now();
+        EmailVerification verification = findLatestPending(command)
+                .orElseThrow(() -> new AuthenticationException(AuthErrorCode.EMAIL_VERIFICATION_FAILED));
+
+        if (verification.getExpiresAt().isBefore(now) || verification.getExpiresAt().isEqual(now)) {
+            verification.expire();
+            throw new AuthenticationException(AuthErrorCode.EMAIL_VERIFICATION_FAILED);
+        }
+
+        if (verification.getAttemptCount() >= policy.maxAttempts()) {
+            verification.markFailed();
+            throw new AuthenticationException(AuthErrorCode.EMAIL_VERIFICATION_FAILED);
+        }
+
+        if (!codeHasher.matches(command.code(), verification.getCodeHash())) {
+            verification.recordFailedAttempt(policy.maxAttempts());
+            throw new AuthenticationException(AuthErrorCode.EMAIL_VERIFICATION_FAILED);
+        }
+
+        String token = tokenGenerator.generateToken();
+        verification.verify(tokenGenerator.hashToken(token), policy.tokenExpiresAt(now), now);
+
+        log.info("Email verification confirmed: purpose={}, email={}",
+                command.purpose(), maskEmail(command.email()));
+        return ConfirmEmailVerificationResult.verified(token, policy.tokenTtlSeconds());
+    }
+
     private long resendCooldownRemainingSeconds(List<EmailVerification> pendingVerifications, LocalDateTime now) {
         return pendingVerifications.stream()
                 .findFirst()
@@ -103,6 +139,17 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
             );
         }
         return false;
+    }
+
+    private Optional<EmailVerification> findLatestPending(ConfirmEmailVerificationCommand command) {
+        return repository.findAllByTargetAndStatus(
+                        command.email(),
+                        command.purpose(),
+                        command.loginId(),
+                        EmailVerificationStatus.PENDING
+                )
+                .stream()
+                .findFirst();
     }
 
     private void expirePrevious(List<EmailVerification> pendingVerifications) {

--- a/src/main/java/matchuri/backend/domain/auth/support/verification/EmailVerificationPolicy.java
+++ b/src/main/java/matchuri/backend/domain/auth/support/verification/EmailVerificationPolicy.java
@@ -20,8 +20,20 @@ public class EmailVerificationPolicy {
         return matchuriProperties.getAuth().getEmailVerification().getResendCooldownSeconds();
     }
 
+    public long tokenTtlSeconds() {
+        return matchuriProperties.getAuth().getEmailVerification().getTokenTtlSeconds();
+    }
+
+    public int maxAttempts() {
+        return matchuriProperties.getAuth().getEmailVerification().getMaxAttempts();
+    }
+
     public LocalDateTime codeExpiresAt(LocalDateTime now) {
         return now.plusSeconds(codeTtlSeconds());
+    }
+
+    public LocalDateTime tokenExpiresAt(LocalDateTime now) {
+        return now.plusSeconds(tokenTtlSeconds());
     }
 
     public boolean isInResendCooldown(LocalDateTime lastSentAt, LocalDateTime now) {

--- a/src/main/java/matchuri/backend/domain/auth/support/verification/EmailVerificationTokenGenerator.java
+++ b/src/main/java/matchuri/backend/domain/auth/support/verification/EmailVerificationTokenGenerator.java
@@ -1,0 +1,33 @@
+package matchuri.backend.domain.auth.support.verification;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EmailVerificationTokenGenerator {
+
+    private static final String TOKEN_PREFIX = "ev_";
+    private static final int TOKEN_BYTE_LENGTH = 32;
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public String generateToken() {
+        byte[] tokenBytes = new byte[TOKEN_BYTE_LENGTH];
+        secureRandom.nextBytes(tokenBytes);
+        return TOKEN_PREFIX + Base64.getUrlEncoder().withoutPadding().encodeToString(tokenBytes);
+    }
+
+    public String hashToken(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 digest is not available", e);
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -68,6 +68,7 @@ matchuri:
       - /api/v1/auth/refresh
       - /api/v1/auth/oauth2/exchange
       - /api/v1/auth/email
+      - /api/v1/auth/email/confirm
     public-options-api-patterns:
       - /**
     cors:

--- a/src/test/java/matchuri/backend/domain/auth/service/EmailVerificationServiceImplTest.java
+++ b/src/test/java/matchuri/backend/domain/auth/service/EmailVerificationServiceImplTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import matchuri.backend.domain.auth.command.ConfirmEmailVerificationCommand;
 import matchuri.backend.domain.auth.command.SendEmailVerificationCommand;
 import matchuri.backend.domain.auth.entity.EmailVerification;
 import matchuri.backend.domain.auth.entity.EmailVerificationPurpose;
@@ -17,10 +18,12 @@ import matchuri.backend.domain.auth.exception.AuthErrorCode;
 import matchuri.backend.domain.auth.repository.EmailVerificationRepository;
 import matchuri.backend.domain.auth.support.mail.AuthMailSender;
 import matchuri.backend.domain.auth.support.verification.EmailVerificationPolicy;
+import matchuri.backend.domain.auth.support.verification.EmailVerificationTokenGenerator;
 import matchuri.backend.domain.auth.support.verification.VerificationCodeGenerator;
 import matchuri.backend.domain.auth.support.verification.VerificationCodeHasher;
 import matchuri.backend.domain.member.entity.MemberStatus;
 import matchuri.backend.domain.member.repository.MemberRepository;
+import matchuri.backend.global.exception.AuthenticationException;
 import matchuri.backend.global.exception.BusinessException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,6 +51,9 @@ class EmailVerificationServiceImplTest {
 
     @Mock
     private EmailVerificationPolicy policy;
+
+    @Mock
+    private EmailVerificationTokenGenerator tokenGenerator;
 
     @Mock
     private AuthMailSender authMailSender;
@@ -151,5 +157,154 @@ class EmailVerificationServiceImplTest {
         ArgumentCaptor<EmailVerification> verificationCaptor = ArgumentCaptor.forClass(EmailVerification.class);
         verify(repository).save(verificationCaptor.capture());
         assertThat(verificationCaptor.getValue().getStatus()).isEqualTo(EmailVerificationStatus.FAILED);
+    }
+
+    @Test
+    @DisplayName("올바른 인증 코드를 확인하면 verification token 원문은 결과로, hash는 엔티티에 저장한다")
+    void confirmVerificationEmailIssuesToken() {
+        LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(5);
+        LocalDateTime tokenExpiresAt = LocalDateTime.of(2026, 4, 26, 12, 10);
+        EmailVerification verification = EmailVerification.issue(
+                "tester@example.com",
+                null,
+                EmailVerificationPurpose.SIGNUP,
+                "hashed-code",
+                expiresAt,
+                LocalDateTime.now()
+        );
+        when(repository.findAllByTargetAndStatus(
+                "tester@example.com",
+                EmailVerificationPurpose.SIGNUP,
+                null,
+                EmailVerificationStatus.PENDING
+        )).thenReturn(List.of(verification));
+        when(policy.maxAttempts()).thenReturn(5);
+        when(codeHasher.matches("123456", "hashed-code")).thenReturn(true);
+        when(tokenGenerator.generateToken()).thenReturn("ev_raw-token");
+        when(tokenGenerator.hashToken("ev_raw-token")).thenReturn("hashed-token");
+        when(policy.tokenExpiresAt(any(LocalDateTime.class))).thenReturn(tokenExpiresAt);
+        when(policy.tokenTtlSeconds()).thenReturn(600L);
+
+        var result = service.confirmVerificationEmail(new ConfirmEmailVerificationCommand(
+                "TESTER@example.com ",
+                EmailVerificationPurpose.SIGNUP,
+                null,
+                "123456"
+        ));
+
+        assertThat(result.verified()).isTrue();
+        assertThat(result.emailVerificationToken()).isEqualTo("ev_raw-token");
+        assertThat(result.expiresIn()).isEqualTo(600L);
+        assertThat(verification.getStatus()).isEqualTo(EmailVerificationStatus.VERIFIED);
+        assertThat(verification.getVerificationTokenHash()).isEqualTo("hashed-token");
+        assertThat(verification.getVerificationTokenExpiresAt()).isEqualTo(tokenExpiresAt);
+        assertThat(verification.getVerifiedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("틀린 인증 코드는 실패 시도 횟수를 증가시키고 AUTH_EMAIL_VERIFICATION_FAILED를 반환한다")
+    void confirmVerificationEmailIncrementsAttemptWhenCodeDoesNotMatch() {
+        EmailVerification verification = EmailVerification.issue(
+                "tester@example.com",
+                null,
+                EmailVerificationPurpose.SIGNUP,
+                "hashed-code",
+                LocalDateTime.now().plusMinutes(5),
+                LocalDateTime.now()
+        );
+        when(repository.findAllByTargetAndStatus(
+                "tester@example.com",
+                EmailVerificationPurpose.SIGNUP,
+                null,
+                EmailVerificationStatus.PENDING
+        )).thenReturn(List.of(verification));
+        when(policy.maxAttempts()).thenReturn(5);
+        when(codeHasher.matches("000000", "hashed-code")).thenReturn(false);
+
+        assertThatThrownBy(() -> service.confirmVerificationEmail(new ConfirmEmailVerificationCommand(
+                "tester@example.com",
+                EmailVerificationPurpose.SIGNUP,
+                null,
+                "000000"
+        )))
+                .isInstanceOf(AuthenticationException.class)
+                .extracting("errorCode")
+                .isEqualTo(AuthErrorCode.EMAIL_VERIFICATION_FAILED);
+
+        assertThat(verification.getAttemptCount()).isEqualTo(1);
+        assertThat(verification.getStatus()).isEqualTo(EmailVerificationStatus.PENDING);
+        verify(tokenGenerator, never()).generateToken();
+    }
+
+    @Test
+    @DisplayName("틀린 인증 코드가 최대 시도 횟수에 도달하면 인증 레코드를 FAILED 상태로 전환한다")
+    void confirmVerificationEmailMarksFailedWhenMaxAttemptsReached() {
+        EmailVerification verification = EmailVerification.issue(
+                "tester@example.com",
+                null,
+                EmailVerificationPurpose.SIGNUP,
+                "hashed-code",
+                LocalDateTime.now().plusMinutes(5),
+                LocalDateTime.now()
+        );
+        verification.recordFailedAttempt(5);
+        verification.recordFailedAttempt(5);
+        verification.recordFailedAttempt(5);
+        verification.recordFailedAttempt(5);
+
+        when(repository.findAllByTargetAndStatus(
+                "tester@example.com",
+                EmailVerificationPurpose.SIGNUP,
+                null,
+                EmailVerificationStatus.PENDING
+        )).thenReturn(List.of(verification));
+        when(policy.maxAttempts()).thenReturn(5);
+        when(codeHasher.matches("000000", "hashed-code")).thenReturn(false);
+
+        assertThatThrownBy(() -> service.confirmVerificationEmail(new ConfirmEmailVerificationCommand(
+                "tester@example.com",
+                EmailVerificationPurpose.SIGNUP,
+                null,
+                "000000"
+        )))
+                .isInstanceOf(AuthenticationException.class)
+                .extracting("errorCode")
+                .isEqualTo(AuthErrorCode.EMAIL_VERIFICATION_FAILED);
+
+        assertThat(verification.getAttemptCount()).isEqualTo(5);
+        assertThat(verification.getStatus()).isEqualTo(EmailVerificationStatus.FAILED);
+        verify(tokenGenerator, never()).generateToken();
+    }
+
+    @Test
+    @DisplayName("만료된 인증 코드는 EXPIRED 상태로 전환하고 검증 실패를 반환한다")
+    void confirmVerificationEmailExpiresExpiredCode() {
+        EmailVerification verification = EmailVerification.issue(
+                "tester@example.com",
+                null,
+                EmailVerificationPurpose.SIGNUP,
+                "hashed-code",
+                LocalDateTime.now().minusSeconds(1),
+                LocalDateTime.now().minusMinutes(10)
+        );
+        when(repository.findAllByTargetAndStatus(
+                "tester@example.com",
+                EmailVerificationPurpose.SIGNUP,
+                null,
+                EmailVerificationStatus.PENDING
+        )).thenReturn(List.of(verification));
+
+        assertThatThrownBy(() -> service.confirmVerificationEmail(new ConfirmEmailVerificationCommand(
+                "tester@example.com",
+                EmailVerificationPurpose.SIGNUP,
+                null,
+                "123456"
+        )))
+                .isInstanceOf(AuthenticationException.class)
+                .extracting("errorCode")
+                .isEqualTo(AuthErrorCode.EMAIL_VERIFICATION_FAILED);
+
+        assertThat(verification.getStatus()).isEqualTo(EmailVerificationStatus.EXPIRED);
+        verify(codeHasher, never()).matches(any(), any());
     }
 }

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -78,6 +78,15 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/auth/email'].post.responses['502'].content['application/json'].examples.sendFailed.value.error.code")
                         .value("AUTH_EMAIL_SEND_FAILED"))
+                .andExpect(jsonPath("$.paths['/api/v1/auth/email/confirm'].post.summary")
+                        .value("이메일 인증 코드 확인"))
+                .andExpect(jsonPath("$.paths['/api/v1/auth/email/confirm'].post.security").isEmpty())
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/auth/email/confirm'].post.responses['200'].content['application/json'].schema.$ref")
+                        .value("#/components/schemas/ConfirmEmailVerificationApiResponse"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/auth/email/confirm'].post.responses['401'].content['application/json'].examples.verificationFailed.value.error.code")
+                        .value("AUTH_EMAIL_VERIFICATION_FAILED"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/auth/oauth2/exchange'].post.responses['400'].content['application/json'].examples.providerNotSupported.value.error.code")
                         .value("AUTH_OAUTH2_PROVIDER_NOT_SUPPORTED"))

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -52,6 +52,7 @@ matchuri:
       - /api/v1/auth/refresh
       - /api/v1/auth/oauth2/exchange
       - /api/v1/auth/email
+      - /api/v1/auth/email/confirm
     public-options-api-patterns:
       - /**
     cors:


### PR DESCRIPTION
## 관련 이슈
Closes #135 

## 📝 작업 내용
- `GET /api/v1/auth/email/confirm`

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항

```json
{
  "success": true,
  "data": {
    "verified": true,
    "emailVerificationToken": "ev_7XZW-cpsrjxykBjMeuuGtxWm_Ch2BiLdwKaNTyipweo",
    "expiresIn": 600
  },
  "error": null
}
```

- `emailVerificationToken` 토큰은 회원가입 요청시 해당 이메일에 대해 유효한지 확인한 뒤 회원을 생성합니다.
- 5회 이상 실패시 해당 인증 토큰은 사용 불가 합니다.
