### PR TITLE
[Refactor] 회원가입 로직에 이메일 인증 토큰 추가

### DIFF
--- a/src/main/java/matchuri/backend/api/member/MemberApi.java
+++ b/src/main/java/matchuri/backend/api/member/MemberApi.java
@@ -34,11 +34,13 @@ public interface MemberApi {
     @Operation(
             summary = "자체 회원가입 통합",
             description = """
-                    자체 회원가입에서 `loginId`, `password`, 필수 약관 동의, `nickname`을 하나의 요청으로 원자적으로 처리합니다.
+                    자체 회원가입에서 `loginId`, `password`, `nickname`, 검증된 `email`, 필수 약관 동의를 하나의 요청으로 원자적으로 처리합니다.
                     
                     - 가입 성공 시 자동 로그인되지 않습니다.
                     - 필수 약관 2종과 최신 버전이 모두 포함되어야 합니다.
                     - 닉네임은 기본값 없이 필수 입력입니다.
+                    - 회원 생성 전에 `SIGNUP` 목적의 `emailVerificationToken`이 필요합니다.
+                    - 한 이메일에 여러 자체 로그인 ID는 허용하지 않습니다.
                     - 처리 중 하나라도 실패하면 회원과 약관 동의 기록은 저장되지 않습니다.
                     """
     )
@@ -58,6 +60,7 @@ public interface MemberApi {
                                               "data": {
                                                 "memberId": 1,
                                                 "loginId": "tester01",
+                                                "email": "tester@example.com",
                                                 "nickname": "점심탐험가",
                                                 "createdAt": "2026-04-14T20:15:30"
                                               },
@@ -92,8 +95,30 @@ public interface MemberApi {
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "이메일 인증 token이 없거나, 만료되었거나, 요청 이메일과 맞지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "emailVerificationFailed",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "data": null,
+                                              "error": {
+                                                "status": 401,
+                                                "code": "AUTH_EMAIL_VERIFICATION_FAILED",
+                                                "message": "이메일 인증에 실패했습니다.",
+                                                "details": []
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "409",
-                    description = "이미 사용 중인 loginId 또는 nickname",
+                    description = "이미 사용 중인 loginId, nickname 또는 email",
                     content = @Content(
                             mediaType = "application/json",
                             examples = {
@@ -110,7 +135,7 @@ public interface MemberApi {
                                                         "details": []
                                                       }
                                                     }
-                                                    """
+                                            """
                                     ),
                                     @ExampleObject(
                                             name = "duplicateNickname",
@@ -122,6 +147,21 @@ public interface MemberApi {
                                                         "status": 409,
                                                         "code": "MEMBER_DUPLICATE_NICKNAME",
                                                         "message": "이미 사용 중인 닉네임입니다. nickname : 점심탐험가",
+                                                        "details": []
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "duplicateEmail",
+                                            value = """
+                                                    {
+                                                      "success": false,
+                                                      "data": null,
+                                                      "error": {
+                                                        "status": 409,
+                                                        "code": "MEMBER_DUPLICATE_EMAIL",
+                                                        "message": "이미 사용 중인 이메일입니다. email : tester@example.com",
                                                         "details": []
                                                       }
                                                     }

--- a/src/main/java/matchuri/backend/api/member/dto/request/RegisterLocalMemberRequest.java
+++ b/src/main/java/matchuri/backend/api/member/dto/request/RegisterLocalMemberRequest.java
@@ -2,6 +2,7 @@ package matchuri.backend.api.member.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
@@ -14,8 +15,10 @@ import matchuri.backend.domain.member.entity.Member;
         example = """
                 {
                   "loginId": "tester2372",
-                  "password": "P@ssw0rd!",
+                  "password": "tester2372!",
                   "nickname": "점심탐험가123",
+                  "email": "tester@example.com",
+                  "emailVerificationToken": "ev_q3JxFrSxYk4zJw2zq3ZpQh0a3z9q0x1y2z3A4b5C6dE",
                   "agreements": [
                     {
                       "agreementType": "TERMS_OF_SERVICE",
@@ -64,6 +67,23 @@ public record RegisterLocalMemberRequest(
         @Pattern(regexp = "^(?!\\s*$).+", message = "nickname은 비어 있을 수 없습니다.")
         @Size(max = Member.NICKNAME_MAX_SIZE, message = "nickname은 " + Member.NICKNAME_MAX_SIZE + "자를 초과할 수 없습니다.")
         String nickname,
+
+        @Schema(
+                description = "이메일 인증을 완료한 자체 로그인 계정 복구용 이메일입니다.",
+                example = "tester@example.com",
+                maxLength = 150
+        )
+        @NotBlank(message = "email은 비어 있을 수 없습니다.")
+        @Email(message = "email은 올바른 이메일 형식이어야 합니다.")
+        @Size(max = 150, message = "email은 150자 이하여야 합니다.")
+        String email,
+
+        @Schema(
+                description = "SIGNUP 목적 이메일 인증 확인 API에서 발급받은 token입니다.",
+                example = "ev_q3JxFrSxYk4zJw2zq3ZpQh0a3z9q0x1y2z3A4b5C6dE"
+        )
+        @NotBlank(message = "emailVerificationToken은 비어 있을 수 없습니다.")
+        String emailVerificationToken,
 
         @Schema(
                 description = "필수 약관 동의 목록입니다. 현재는 서비스 이용약관과 개인정보 처리방침 2종을 모두 포함해야 합니다.",

--- a/src/main/java/matchuri/backend/api/member/dto/response/RegisterLocalMemberResponse.java
+++ b/src/main/java/matchuri/backend/api/member/dto/response/RegisterLocalMemberResponse.java
@@ -10,6 +10,9 @@ public record RegisterLocalMemberResponse(
         @Schema(description = "가입 완료된 loginId입니다.", example = "tester01")
         String loginId,
 
+        @Schema(description = "가입 시 인증 완료된 이메일입니다.", example = "tester@example.com")
+        String email,
+
         @Schema(description = "가입 시 확정된 닉네임입니다.", example = "점심탐험가")
         String nickname,
 

--- a/src/main/java/matchuri/backend/api/member/mapper/MemberMapper.java
+++ b/src/main/java/matchuri/backend/api/member/mapper/MemberMapper.java
@@ -59,6 +59,8 @@ public class MemberMapper {
                 request.loginId(),
                 request.password(),
                 request.nickname(),
+                request.email(),
+                request.emailVerificationToken(),
                 request.agreements().stream()
                         .map(agreement -> new SubmitRequiredAgreementsCommand.AgreementConsentCommand(
                                 agreement.agreementType(),
@@ -72,6 +74,7 @@ public class MemberMapper {
         return new RegisterLocalMemberResponse(
                 result.memberId(),
                 result.loginId(),
+                result.email(),
                 result.nickname(),
                 result.createdAt()
         );

--- a/src/main/java/matchuri/backend/domain/auth/entity/EmailVerification.java
+++ b/src/main/java/matchuri/backend/domain/auth/entity/EmailVerification.java
@@ -125,4 +125,8 @@ public class EmailVerification extends BaseEntity {
         this.verificationTokenHash = verificationTokenHash;
         this.verificationTokenExpiresAt = tokenExpiresAt;
     }
+
+    public void markVerificationTokenUsed(LocalDateTime usedAt) {
+        this.verificationTokenUsedAt = usedAt;
+    }
 }

--- a/src/main/java/matchuri/backend/domain/auth/repository/EmailVerificationRepository.java
+++ b/src/main/java/matchuri/backend/domain/auth/repository/EmailVerificationRepository.java
@@ -1,6 +1,7 @@
 package matchuri.backend.domain.auth.repository;
 
 import java.util.List;
+import java.util.Optional;
 import matchuri.backend.domain.auth.entity.EmailVerification;
 import matchuri.backend.domain.auth.entity.EmailVerificationPurpose;
 import matchuri.backend.domain.auth.entity.EmailVerificationStatus;
@@ -12,6 +13,8 @@ import org.springframework.data.repository.query.Param;
 
 @NullMarked
 public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
+
+    Optional<EmailVerification> findByVerificationTokenHash(String verificationTokenHash);
 
     @Query("""
             select e

--- a/src/main/java/matchuri/backend/domain/auth/support/verification/EmailVerificationTokenVerifier.java
+++ b/src/main/java/matchuri/backend/domain/auth/support/verification/EmailVerificationTokenVerifier.java
@@ -1,0 +1,44 @@
+package matchuri.backend.domain.auth.support.verification;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import matchuri.backend.domain.auth.entity.EmailVerification;
+import matchuri.backend.domain.auth.entity.EmailVerificationPurpose;
+import matchuri.backend.domain.auth.entity.EmailVerificationStatus;
+import matchuri.backend.domain.auth.exception.AuthErrorCode;
+import matchuri.backend.domain.auth.repository.EmailVerificationRepository;
+import matchuri.backend.global.exception.AuthenticationException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EmailVerificationTokenVerifier {
+
+    private final EmailVerificationRepository repository;
+    private final EmailVerificationTokenGenerator tokenGenerator;
+
+    public EmailVerification verifySignupToken(String email, String token) {
+        String normalizedEmail = email == null ? null : email.trim().toLowerCase();
+        LocalDateTime now = LocalDateTime.now();
+        EmailVerification verification = repository.findByVerificationTokenHash(tokenGenerator.hashToken(token))
+                .orElseThrow(() -> new AuthenticationException(AuthErrorCode.EMAIL_VERIFICATION_FAILED));
+
+        if (!isUsableSignupToken(verification, normalizedEmail, now)) {
+            throw new AuthenticationException(AuthErrorCode.EMAIL_VERIFICATION_FAILED);
+        }
+
+        verification.markVerificationTokenUsed(now);
+        return verification;
+    }
+
+    private boolean isUsableSignupToken(EmailVerification verification, String email, LocalDateTime now) {
+        return verification.getStatus() == EmailVerificationStatus.VERIFIED
+                && verification.getPurpose() == EmailVerificationPurpose.SIGNUP
+                && verification.getEmail().equals(email)
+                && verification.getLoginId() == null
+                && verification.getVerificationTokenHash() != null
+                && verification.getVerificationTokenExpiresAt() != null
+                && verification.getVerificationTokenExpiresAt().isAfter(now)
+                && verification.getVerificationTokenUsedAt() == null;
+    }
+}

--- a/src/main/java/matchuri/backend/domain/member/command/RegisterLocalMemberCommand.java
+++ b/src/main/java/matchuri/backend/domain/member/command/RegisterLocalMemberCommand.java
@@ -6,6 +6,12 @@ public record RegisterLocalMemberCommand(
         String loginId,
         String password,
         String nickname,
+        String email,
+        String emailVerificationToken,
         List<SubmitRequiredAgreementsCommand.AgreementConsentCommand> agreements
 ) {
+    public RegisterLocalMemberCommand {
+        email = email == null ? null : email.trim().toLowerCase();
+        emailVerificationToken = emailVerificationToken == null ? null : emailVerificationToken.trim();
+    }
 }

--- a/src/main/java/matchuri/backend/domain/member/entity/Member.java
+++ b/src/main/java/matchuri/backend/domain/member/entity/Member.java
@@ -117,9 +117,14 @@ public class Member extends BaseEntity {
     }
 
     public static Member createWithEncodedPassword(String loginId, String passwordHash, String nickname) {
+        return createWithEncodedPassword(loginId, passwordHash, nickname, null);
+    }
+
+    public static Member createWithEncodedPassword(String loginId, String passwordHash, String nickname, String email) {
         return Member.builder()
                 .loginId(loginId)
                 .passwordHash(passwordHash)
+                .email(email)
                 .nickname(nickname)
                 .nicknameCompleted(true)
                 .social(false)

--- a/src/main/java/matchuri/backend/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/member/exception/MemberErrorCode.java
@@ -14,6 +14,7 @@ public enum MemberErrorCode implements ErrorCode {
     NOT_FOUND_LOGIN_ID(HttpStatus.NOT_FOUND, "해당 로그인 아이디의 회원을 찾을 수 없습니다. loginId : {0}"),
     DUPLICATE_LOGIN_ID(HttpStatus.CONFLICT, "이미 사용 중인 로그인 아이디입니다. loginId : {0}"),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다. nickname : {0}"),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다. email : {0}"),
     DUPLICATE_TASTE_ATTRIBUTE_CATEGORY(HttpStatus.BAD_REQUEST,
             "중복된 attribute category ID가 포함되어 있습니다. attributeCategoryIds : {0}"),
     DUPLICATE_TASTE_RESTRICTION_INGREDIENT(HttpStatus.BAD_REQUEST,

--- a/src/main/java/matchuri/backend/domain/member/result/RegisterLocalMemberResult.java
+++ b/src/main/java/matchuri/backend/domain/member/result/RegisterLocalMemberResult.java
@@ -6,6 +6,7 @@ import matchuri.backend.domain.member.entity.Member;
 public record RegisterLocalMemberResult(
         Long memberId,
         String loginId,
+        String email,
         String nickname,
         LocalDateTime createdAt
 ) {
@@ -14,6 +15,7 @@ public record RegisterLocalMemberResult(
         return new RegisterLocalMemberResult(
                 member.getId(),
                 member.getLoginId(),
+                member.getEmail(),
                 member.getNickname(),
                 member.getCreatedAt()
         );

--- a/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
@@ -6,12 +6,14 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import matchuri.backend.domain.auth.support.verification.EmailVerificationTokenVerifier;
 import matchuri.backend.domain.member.command.CreateMemberCommand;
 import matchuri.backend.domain.member.command.RegisterLocalMemberCommand;
 import matchuri.backend.domain.member.command.UpdateMemberBasicInfoCommand;
 import matchuri.backend.domain.member.command.UpdateMemberTasteProfileCommand;
 import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.entity.MemberAgreement;
+import matchuri.backend.domain.member.entity.MemberStatus;
 import matchuri.backend.domain.member.entity.MemberTasteProfile;
 import matchuri.backend.domain.member.entity.MemberTasteProfileCategory;
 import matchuri.backend.domain.member.entity.MemberTasteProfileDislikedMenuItem;
@@ -62,6 +64,7 @@ public class MemberServiceImpl implements MemberService {
     private final PasswordEncoder passwordEncoder;
     private final ActiveMemberReader activeMemberReader;
     private final OnboardingStatusResolver onboardingStatusResolver;
+    private final EmailVerificationTokenVerifier emailVerificationTokenVerifier;
 
     @Override
     public boolean existsByLoginId(String loginId) {
@@ -77,8 +80,12 @@ public class MemberServiceImpl implements MemberService {
     @Transactional
     public RegisterLocalMemberResult registerLocalMember(RegisterLocalMemberCommand command) {
         String loginId = command.loginId();
+
+        emailVerificationTokenVerifier.verifySignupToken(command.email(), command.emailVerificationToken());
+        validateEmailDuplication(command.email());
+
         String passwordHash = passwordEncoder.encode(command.password());
-        Member member = createLocalMember(loginId, passwordHash, command.nickname());
+        Member member = createLocalMember(loginId, passwordHash, command.nickname(), command.email());
 
         requiredAgreementRequestValidator.validateAndIndex(command.agreements())
                 .forEach((agreementType, agreementVersion) ->
@@ -97,7 +104,7 @@ public class MemberServiceImpl implements MemberService {
         }
 
         String passwordHash = passwordEncoder.encode(command.password());
-        Member member = createLocalMember(loginId, passwordHash, null);
+        Member member = createLocalMember(loginId, passwordHash, null, null);
 
         return CreateMemberResult.from(member);
     }
@@ -199,18 +206,24 @@ public class MemberServiceImpl implements MemberService {
         return WithdrawMemberResult.from(member);
     }
 
-    private Member createLocalMember(String loginId, String passwordHash, String nickname) {
+    private Member createLocalMember(String loginId, String passwordHash, String nickname, String email) {
         validateLoginIdDuplication(null, loginId);
         validateNicknameDuplication(null, nickname);
 
         try {
-            Member newMember = Member.createWithEncodedPassword(loginId, passwordHash, nickname);
+            Member newMember = Member.createWithEncodedPassword(loginId, passwordHash, nickname, email);
             return memberRepository.saveAndFlush(newMember);
         } catch (DataIntegrityViolationException exception) {
             if (nickname != null && memberRepository.existsByNickname(nickname)) {
                 throw new BusinessException(MemberErrorCode.DUPLICATE_NICKNAME, nickname);
             }
             throw new BusinessException(MemberErrorCode.DUPLICATE_LOGIN_ID, loginId);
+        }
+    }
+
+    private void validateEmailDuplication(String email) {
+        if (memberRepository.existsByEmailAndSocialFalseAndStatus(email, MemberStatus.ACTIVE)) {
+            throw new BusinessException(MemberErrorCode.DUPLICATE_EMAIL, email);
         }
     }
 

--- a/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
@@ -23,8 +23,12 @@ import java.util.Date;
 import javax.crypto.SecretKey;
 import matchuri.backend.domain.auth.entity.AuthExchangeCode;
 import matchuri.backend.domain.auth.entity.AuthRefreshToken;
+import matchuri.backend.domain.auth.entity.EmailVerification;
+import matchuri.backend.domain.auth.entity.EmailVerificationPurpose;
 import matchuri.backend.domain.auth.repository.AuthExchangeCodeRepository;
 import matchuri.backend.domain.auth.repository.AuthRefreshTokenRepository;
+import matchuri.backend.domain.auth.repository.EmailVerificationRepository;
+import matchuri.backend.domain.auth.support.verification.EmailVerificationTokenGenerator;
 import matchuri.backend.domain.member.entity.AgreementType;
 import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.entity.MemberAgreement;
@@ -82,6 +86,12 @@ class MemberAuthIntegrationTest {
     private AuthExchangeCodeRepository authExchangeCodeRepository;
 
     @Autowired
+    private EmailVerificationRepository emailVerificationRepository;
+
+    @Autowired
+    private EmailVerificationTokenGenerator emailVerificationTokenGenerator;
+
+    @Autowired
     private MemberTasteProfileRepository memberTasteProfileRepository;
 
     @Autowired
@@ -110,6 +120,7 @@ class MemberAuthIntegrationTest {
 
     @BeforeEach
     void setUp() {
+        emailVerificationRepository.deleteAll();
         authExchangeCodeRepository.deleteAll();
         authRefreshTokenRepository.deleteAll();
         memberAgreementRepository.deleteAll();
@@ -126,6 +137,8 @@ class MemberAuthIntegrationTest {
     @Test
     @DisplayName("자체 회원가입 통합 API는 약관과 닉네임을 함께 저장하지만 로그인 상태는 만들지 않는다")
     void registerLocalMember() throws Exception {
+        String emailVerificationToken = issueSignupEmailVerificationToken("signup@example.com");
+
         mockMvc.perform(post("/api/v1/members/signup")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
@@ -133,6 +146,8 @@ class MemberAuthIntegrationTest {
                                   "loginId": "signup-user",
                                   "password": "P@ssw0rd!",
                                   "nickname": "점심탐험가",
+                                  "email": "signup@example.com",
+                                  "emailVerificationToken": "%s",
                                   "agreements": [
                                     {
                                       "agreementType": "TERMS_OF_SERVICE",
@@ -144,19 +159,27 @@ class MemberAuthIntegrationTest {
                                     }
                                   ]
                                 }
-                                """))
+                                """.formatted(emailVerificationToken)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.loginId").value("signup-user"))
+                .andExpect(jsonPath("$.data.email").value("signup@example.com"))
                 .andExpect(jsonPath("$.data.nickname").value("점심탐험가"))
                 .andExpect(jsonPath("$.data.memberId").isNumber())
                 .andExpect(header().doesNotExist(HttpHeaders.SET_COOKIE));
 
         Member member = memberRepository.findByLoginId("signup-user").orElseThrow();
         assertThat(member.getPasswordHash()).isNotEqualTo("P@ssw0rd!");
+        assertThat(member.getEmail()).isEqualTo("signup@example.com");
         assertThat(member.getNickname()).isEqualTo("점심탐험가");
         assertThat(member.isNicknameCompleted()).isTrue();
         assertThat(memberAgreementRepository.count()).isEqualTo(2);
+        assertThat(emailVerificationRepository.findByVerificationTokenHash(
+                emailVerificationTokenGenerator.hashToken(emailVerificationToken)
+        )).isPresent()
+                .get()
+                .extracting(EmailVerification::getVerificationTokenUsedAt)
+                .isNotNull();
 
         mockMvc.perform(get("/api/v1/members/me"))
                 .andExpect(status().isUnauthorized())
@@ -173,6 +196,8 @@ class MemberAuthIntegrationTest {
     @Test
     @DisplayName("자체 회원가입 통합 API에서 약관 검증이 실패하면 회원과 약관 기록이 남지 않는다")
     void registerLocalMemberRollsBackWhenAgreementValidationFails() throws Exception {
+        String emailVerificationToken = issueSignupEmailVerificationToken("rollback@example.com");
+
         mockMvc.perform(post("/api/v1/members/signup")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
@@ -180,6 +205,8 @@ class MemberAuthIntegrationTest {
                                   "loginId": "rollback-user",
                                   "password": "P@ssw0rd!",
                                   "nickname": "롤백검증",
+                                  "email": "rollback@example.com",
+                                  "emailVerificationToken": "%s",
                                   "agreements": [
                                     {
                                       "agreementType": "TERMS_OF_SERVICE",
@@ -191,12 +218,97 @@ class MemberAuthIntegrationTest {
                                     }
                                   ]
                                 }
-                                """))
+                                """.formatted(emailVerificationToken)))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error.code").value("MEMBER_AGREEMENT_VERSION_MISMATCH"));
 
         assertThat(memberRepository.findByLoginId("rollback-user")).isEmpty();
         assertThat(memberAgreementRepository.count()).isZero();
+        assertThat(emailVerificationRepository.findByVerificationTokenHash(
+                emailVerificationTokenGenerator.hashToken(emailVerificationToken)
+        )).isPresent()
+                .get()
+                .extracting(EmailVerification::getVerificationTokenUsedAt)
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("자체 회원가입 통합 API는 SIGNUP 이메일 인증 token이 유효하지 않으면 회원을 생성하지 않는다")
+    void registerLocalMemberFailsWhenEmailVerificationTokenIsInvalid() throws Exception {
+        mockMvc.perform(post("/api/v1/members/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "loginId": "invalid-token-user",
+                                  "password": "P@ssw0rd!",
+                                  "nickname": "토큰검증",
+                                  "email": "invalid-token@example.com",
+                                  "emailVerificationToken": "ev_missing-token",
+                                  "agreements": [
+                                    {
+                                      "agreementType": "TERMS_OF_SERVICE",
+                                      "agreementVersion": "2026-04-10"
+                                    },
+                                    {
+                                      "agreementType": "PRIVACY_POLICY",
+                                      "agreementVersion": "2026-04-10"
+                                    }
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("AUTH_EMAIL_VERIFICATION_FAILED"));
+
+        assertThat(memberRepository.findByLoginId("invalid-token-user")).isEmpty();
+        assertThat(memberAgreementRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("자체 회원가입 통합 API는 이미 자체 로그인 계정에 사용 중인 이메일이면 거절한다")
+    void registerLocalMemberFailsWhenLocalEmailIsDuplicated() throws Exception {
+        memberRepository.save(new Member(
+                "existing-email-user",
+                "hashed-password",
+                "duplicate@example.com",
+                false,
+                null,
+                null,
+                MemberRole.MEMBER,
+                MemberStatus.ACTIVE
+        ));
+        String emailVerificationToken = issueSignupEmailVerificationToken("duplicate@example.com");
+
+        mockMvc.perform(post("/api/v1/members/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "loginId": "duplicate-email-user",
+                                  "password": "P@ssw0rd!",
+                                  "nickname": "이메일중복",
+                                  "email": "duplicate@example.com",
+                                  "emailVerificationToken": "%s",
+                                  "agreements": [
+                                    {
+                                      "agreementType": "TERMS_OF_SERVICE",
+                                      "agreementVersion": "2026-04-10"
+                                    },
+                                    {
+                                      "agreementType": "PRIVACY_POLICY",
+                                      "agreementVersion": "2026-04-10"
+                                    }
+                                  ]
+                                }
+                                """.formatted(emailVerificationToken)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("MEMBER_DUPLICATE_EMAIL"));
+
+        assertThat(memberRepository.findByLoginId("duplicate-email-user")).isEmpty();
+        assertThat(emailVerificationRepository.findByVerificationTokenHash(
+                emailVerificationTokenGenerator.hashToken(emailVerificationToken)
+        )).isPresent()
+                .get()
+                .extracting(EmailVerification::getVerificationTokenUsedAt)
+                .isNull();
     }
 
     @Test
@@ -921,6 +1033,25 @@ class MemberAuthIntegrationTest {
                                 }
                                 """.formatted(loginId, password)))
                 .andExpect(status().isOk());
+    }
+
+    private String issueSignupEmailVerificationToken(String email) {
+        String token = "ev_test_" + email.replace("@", "_").replace(".", "_");
+        EmailVerification verification = EmailVerification.issue(
+                email,
+                null,
+                EmailVerificationPurpose.SIGNUP,
+                "hashed-code",
+                LocalDateTime.now().plusMinutes(5),
+                LocalDateTime.now()
+        );
+        verification.verify(
+                emailVerificationTokenGenerator.hashToken(token),
+                LocalDateTime.now().plusMinutes(10),
+                LocalDateTime.now()
+        );
+        emailVerificationRepository.save(verification);
+        return token;
     }
 
     private AuthSession login(String loginId, String password) throws Exception {

--- a/src/test/java/matchuri/backend/domain/auth/support/verification/EmailVerificationTokenVerifierTest.java
+++ b/src/test/java/matchuri/backend/domain/auth/support/verification/EmailVerificationTokenVerifierTest.java
@@ -1,0 +1,72 @@
+package matchuri.backend.domain.auth.support.verification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import matchuri.backend.domain.auth.entity.EmailVerification;
+import matchuri.backend.domain.auth.entity.EmailVerificationPurpose;
+import matchuri.backend.domain.auth.exception.AuthErrorCode;
+import matchuri.backend.domain.auth.repository.EmailVerificationRepository;
+import matchuri.backend.global.exception.AuthenticationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EmailVerificationTokenVerifierTest {
+
+    @Mock
+    private EmailVerificationRepository repository;
+
+    @Mock
+    private EmailVerificationTokenGenerator tokenGenerator;
+
+    @Test
+    @DisplayName("SIGNUP token이 유효하면 사용 완료 시각을 기록한다")
+    void verifySignupTokenMarksTokenUsed() {
+        EmailVerification verification = verifiedSignupVerification("tester@example.com", "hashed-token");
+        EmailVerificationTokenVerifier verifier = new EmailVerificationTokenVerifier(repository, tokenGenerator);
+
+        when(tokenGenerator.hashToken("ev_raw-token")).thenReturn("hashed-token");
+        when(repository.findByVerificationTokenHash("hashed-token")).thenReturn(Optional.of(verification));
+
+        EmailVerification result = verifier.verifySignupToken(" TESTER@example.com ", "ev_raw-token");
+
+        assertThat(result).isSameAs(verification);
+        assertThat(verification.getVerificationTokenUsedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("이미 사용된 SIGNUP token은 인증 실패로 거절한다")
+    void verifySignupTokenRejectsUsedToken() {
+        EmailVerification verification = verifiedSignupVerification("tester@example.com", "hashed-token");
+        verification.markVerificationTokenUsed(LocalDateTime.now());
+        EmailVerificationTokenVerifier verifier = new EmailVerificationTokenVerifier(repository, tokenGenerator);
+
+        when(tokenGenerator.hashToken("ev_raw-token")).thenReturn("hashed-token");
+        when(repository.findByVerificationTokenHash("hashed-token")).thenReturn(Optional.of(verification));
+
+        assertThatThrownBy(() -> verifier.verifySignupToken("tester@example.com", "ev_raw-token"))
+                .isInstanceOf(AuthenticationException.class)
+                .extracting("errorCode")
+                .isEqualTo(AuthErrorCode.EMAIL_VERIFICATION_FAILED);
+    }
+
+    private EmailVerification verifiedSignupVerification(String email, String tokenHash) {
+        EmailVerification verification = EmailVerification.issue(
+                email,
+                null,
+                EmailVerificationPurpose.SIGNUP,
+                "hashed-code",
+                LocalDateTime.now().plusMinutes(5),
+                LocalDateTime.now()
+        );
+        verification.verify(tokenHash, LocalDateTime.now().plusMinutes(10), LocalDateTime.now());
+        return verification;
+    }
+}

--- a/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
+++ b/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import matchuri.backend.domain.auth.support.verification.EmailVerificationTokenVerifier;
 import matchuri.backend.domain.member.command.CreateMemberCommand;
 import matchuri.backend.domain.member.command.RegisterLocalMemberCommand;
 import matchuri.backend.domain.member.command.SubmitRequiredAgreementsCommand;
@@ -99,6 +100,9 @@ class MemberServiceImplTest {
     @Mock
     private OnboardingStatusResolver onboardingStatusResolver;
 
+    @Mock
+    private EmailVerificationTokenVerifier emailVerificationTokenVerifier;
+
     @InjectMocks
     private MemberServiceImpl memberService;
 
@@ -109,6 +113,8 @@ class MemberServiceImplTest {
                 "tester01",
                 "P@ssw0rd!",
                 "점심탐험가",
+                "tester@example.com",
+                "ev_signup-token",
                 List.of(
                         new SubmitRequiredAgreementsCommand.AgreementConsentCommand("TERMS_OF_SERVICE", "2026-04-10"),
                         new SubmitRequiredAgreementsCommand.AgreementConsentCommand("PRIVACY_POLICY", "2026-04-10")
@@ -119,6 +125,7 @@ class MemberServiceImplTest {
                 .id(1L)
                 .loginId("tester01")
                 .passwordHash("encoded-password")
+                .email("tester@example.com")
                 .nickname("점심탐험가")
                 .memberRole(MemberRole.MEMBER)
                 .status(MemberStatus.ACTIVE)
@@ -126,6 +133,8 @@ class MemberServiceImplTest {
                 .build();
 
         when(memberRepository.existsByNickname("점심탐험가")).thenReturn(false);
+        when(memberRepository.existsByEmailAndSocialFalseAndStatus("tester@example.com", MemberStatus.ACTIVE))
+                .thenReturn(false);
         when(passwordEncoder.encode("P@ssw0rd!")).thenReturn("encoded-password");
         when(memberRepository.saveAndFlush(any(Member.class))).thenReturn(savedMember);
         when(requiredAgreementRequestValidator.validateAndIndex(any())).thenReturn(Map.of(
@@ -137,7 +146,9 @@ class MemberServiceImplTest {
 
         assertThat(result.memberId()).isEqualTo(1L);
         assertThat(result.loginId()).isEqualTo("tester01");
+        assertThat(result.email()).isEqualTo("tester@example.com");
         assertThat(result.nickname()).isEqualTo("점심탐험가");
+        verify(emailVerificationTokenVerifier).verifySignupToken("tester@example.com", "ev_signup-token");
         verify(memberRepository).saveAndFlush(any(Member.class));
         verify(requiredAgreementRequestValidator).validateAndIndex(command.agreements());
         verify(memberAgreementRepository, times(2)).save(any(MemberAgreement.class));

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -108,6 +108,21 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/members/signup'].post.responses['200'].content['application/json'].schema.$ref")
                         .value("#/components/schemas/RegisterLocalMemberApiResponse"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/members/signup'].post.responses['401'].content['application/json'].examples.emailVerificationFailed.value.error.code")
+                        .value("AUTH_EMAIL_VERIFICATION_FAILED"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/members/signup'].post.responses['409'].content['application/json'].examples.duplicateEmail.value.error.code")
+                        .value("MEMBER_DUPLICATE_EMAIL"))
+                .andExpect(jsonPath(
+                        "$.components.schemas.RegisterLocalMemberRequest.properties.email.description")
+                        .value(org.hamcrest.Matchers.containsString("이메일 인증")))
+                .andExpect(jsonPath(
+                        "$.components.schemas.RegisterLocalMemberRequest.properties.emailVerificationToken.description")
+                        .value(org.hamcrest.Matchers.containsString("SIGNUP 목적")))
+                .andExpect(jsonPath(
+                        "$.components.schemas.RegisterLocalMemberResponse.properties.email.description")
+                        .value("가입 시 인증 완료된 이메일입니다."))
                 .andExpect(jsonPath("$.paths['/api/v1/members'].post.security").isEmpty())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/members'].post.responses['200'].content['application/json'].schema.$ref")


### PR DESCRIPTION
## 관련 이슈
Closes #139 

## 📝 작업 내용
- `POST /api/v1/auth/members/signup` 에 인증 토큰 추가

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항

- 회원 생성 전에 SIGNUP 목적의 `emailVerificationToken`이 필요합니다.

### reqeust

```json
{
  "loginId": "tester2372",
  "password": "tester2372!",
  "nickname": "점심탐험가123",
  "email": "yourj1n@naver.com",
  "emailVerificationToken": "ev_VGI376ncJZW9jYkoR0ePmXPZ-PjOX6uz7vUhAOJQCBQ",
  "agreements": [
    {
      "agreementType": "TERMS_OF_SERVICE",
      "agreementVersion": "2026-04-10"
    },
    {
      "agreementType": "PRIVACY_POLICY",
      "agreementVersion": "2026-04-10"
    }
  ]
}
```

### response

```json
{
  "success": true,
  "data": {
    "memberId": 3,
    "loginId": "tester2372",
    "email": "yourj1n@naver.com",
    "nickname": "점심탐험가123",
    "createdAt": "2026-04-26T15:48:28.2652845"
  },
  "error": null
}

```