### PR TITLE
[Feat] 계정 찾기 API 구현

### DIFF
--- a/src/main/java/matchuri/backend/api/auth/AccountRecoveryApi.java
+++ b/src/main/java/matchuri/backend/api/auth/AccountRecoveryApi.java
@@ -1,0 +1,195 @@
+package matchuri.backend.api.auth;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import matchuri.backend.api.auth.dto.docs.FindLoginIdApiResponse;
+import matchuri.backend.api.auth.dto.docs.ResetPasswordApiResponse;
+import matchuri.backend.api.auth.dto.request.FindLoginIdRequest;
+import matchuri.backend.api.auth.dto.request.ResetPasswordRequest;
+import matchuri.backend.api.auth.dto.response.FindLoginIdResponse;
+import matchuri.backend.api.auth.dto.response.ResetPasswordResponse;
+import matchuri.backend.global.api.ApiResponse;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Account Recovery", description = "로그인 ID 찾기와 비밀번호 재설정 관련 API")
+public interface AccountRecoveryApi {
+
+    @Operation(
+            summary = "로그인 ID 찾기",
+            description = """
+                    이메일 인증 확인 후 발급받은 `emailVerificationToken`으로 자체 로그인 ID를 조회합니다.
+                    
+                    - token은 `FIND_LOGIN_ID` 목적이어야 합니다.
+                    - token은 만료되지 않았고 아직 사용되지 않은 상태여야 합니다.
+                    - 성공 시 token은 사용 완료 처리되어 재사용할 수 없습니다.
+                    - 한 이메일에 여러 자체 로그인 ID는 허용하지 않으므로 단일 `loginId`를 반환합니다.
+                    """
+    )
+    @SecurityRequirements
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "로그인 ID 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = FindLoginIdApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "data": {
+                                                "loginId": "tester01"
+                                              },
+                                              "error": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "요청 바디 형식 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "invalidBodyField",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "data": null,
+                                              "error": {
+                                                "status": 400,
+                                                "code": "COMMON_INVALID_BODY_FIELD",
+                                                "message": "요청 바디 필드가 올바르지 않습니다.",
+                                                "details": [
+                                                  {
+                                                    "source": "BODY",
+                                                    "field": "emailVerificationToken",
+                                                    "reason": "emailVerificationToken은 비어 있을 수 없습니다."
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "이메일 인증 token이 없거나, 목적이 다르거나, 만료/사용된 상태",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "emailVerificationFailed",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "data": null,
+                                              "error": {
+                                                "status": 401,
+                                                "code": "AUTH_EMAIL_VERIFICATION_FAILED",
+                                                "message": "이메일 인증에 실패했습니다.",
+                                                "details": []
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ApiResponse<FindLoginIdResponse> findLoginId(@Valid @RequestBody FindLoginIdRequest request);
+
+    @Operation(
+            summary = "비밀번호 재설정",
+            description = """
+                    이메일 인증 확인 후 발급받은 `emailVerificationToken`으로 자체 로그인 계정의 비밀번호를 재설정합니다.
+                    
+                    - token은 `RESET_PASSWORD` 목적이어야 합니다.
+                    - token의 `loginId`, `email`이 요청 계정과 일치해야 합니다.
+                    - 성공 시 token은 사용 완료 처리되어 재사용할 수 없습니다.
+                    - 성공 시 해당 회원의 기존 refresh token 전체를 폐기합니다.
+                    - 비밀번호 재설정 후 자동 로그인하거나 access token을 발급하지 않습니다.
+                    """
+    )
+    @SecurityRequirements
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "비밀번호 재설정 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ResetPasswordApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "data": {
+                                                "reset": true
+                                              },
+                                              "error": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "요청 바디 형식 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "invalidBodyField",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "data": null,
+                                              "error": {
+                                                "status": 400,
+                                                "code": "COMMON_INVALID_BODY_FIELD",
+                                                "message": "요청 바디 필드가 올바르지 않습니다.",
+                                                "details": [
+                                                  {
+                                                    "source": "BODY",
+                                                    "field": "newPassword",
+                                                    "reason": "newPassword는 8자 이상 100자 이하여야 합니다."
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "이메일 인증 token이 없거나, 목적/계정이 다르거나, 만료/사용된 상태",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "emailVerificationFailed",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "data": null,
+                                              "error": {
+                                                "status": 401,
+                                                "code": "AUTH_EMAIL_VERIFICATION_FAILED",
+                                                "message": "이메일 인증에 실패했습니다.",
+                                                "details": []
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ApiResponse<ResetPasswordResponse> resetPassword(@Valid @RequestBody ResetPasswordRequest request);
+}

--- a/src/main/java/matchuri/backend/api/auth/AccountRecoveryController.java
+++ b/src/main/java/matchuri/backend/api/auth/AccountRecoveryController.java
@@ -25,14 +25,16 @@ public class AccountRecoveryController implements AccountRecoveryApi {
     @Override
     @PostMapping("/login-id")
     public ApiResponse<FindLoginIdResponse> findLoginId(@Valid @RequestBody FindLoginIdRequest request) {
-        var result = accountRecoveryService.findLoginId(authMapper.toFindLoginIdCommand(request));
+        var command = authMapper.toFindLoginIdCommand(request);
+        var result = accountRecoveryService.findLoginId(command);
         return ApiResponse.success(authMapper.toFindLoginIdResponse(result));
     }
 
     @Override
     @PostMapping("/password")
     public ApiResponse<ResetPasswordResponse> resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
-        var result = accountRecoveryService.resetPassword(authMapper.toResetPasswordCommand(request));
+        var command = authMapper.toResetPasswordCommand(request);
+        var result = accountRecoveryService.resetPassword(command);
         return ApiResponse.success(authMapper.toResetPasswordResponse(result));
     }
 }

--- a/src/main/java/matchuri/backend/api/auth/AccountRecoveryController.java
+++ b/src/main/java/matchuri/backend/api/auth/AccountRecoveryController.java
@@ -1,0 +1,38 @@
+package matchuri.backend.api.auth;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import matchuri.backend.api.auth.mapper.AuthMapper;
+import matchuri.backend.api.auth.dto.request.FindLoginIdRequest;
+import matchuri.backend.api.auth.dto.request.ResetPasswordRequest;
+import matchuri.backend.api.auth.dto.response.FindLoginIdResponse;
+import matchuri.backend.api.auth.dto.response.ResetPasswordResponse;
+import matchuri.backend.domain.auth.service.AccountRecoveryService;
+import matchuri.backend.global.api.ApiResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth/recovery")
+public class AccountRecoveryController implements AccountRecoveryApi {
+
+    private final AccountRecoveryService accountRecoveryService;
+    private final AuthMapper authMapper;
+
+    @Override
+    @PostMapping("/login-id")
+    public ApiResponse<FindLoginIdResponse> findLoginId(@Valid @RequestBody FindLoginIdRequest request) {
+        var result = accountRecoveryService.findLoginId(authMapper.toFindLoginIdCommand(request));
+        return ApiResponse.success(authMapper.toFindLoginIdResponse(result));
+    }
+
+    @Override
+    @PostMapping("/password")
+    public ApiResponse<ResetPasswordResponse> resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
+        var result = accountRecoveryService.resetPassword(authMapper.toResetPasswordCommand(request));
+        return ApiResponse.success(authMapper.toResetPasswordResponse(result));
+    }
+}

--- a/src/main/java/matchuri/backend/api/auth/dto/docs/FindLoginIdApiResponse.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/docs/FindLoginIdApiResponse.java
@@ -1,0 +1,18 @@
+package matchuri.backend.api.auth.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.auth.dto.response.FindLoginIdResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "로그인 ID 찾기 API의 공통 응답 envelope입니다.")
+public record FindLoginIdApiResponse(
+        @Schema(description = "요청 성공 여부입니다.", example = "true")
+        boolean success,
+
+        @Schema(description = "성공 시 반환되는 로그인 ID 찾기 payload입니다.")
+        FindLoginIdResponse data,
+
+        @Schema(description = "실패 시 반환되는 에러 정보입니다.")
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/auth/dto/docs/ResetPasswordApiResponse.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/docs/ResetPasswordApiResponse.java
@@ -1,0 +1,18 @@
+package matchuri.backend.api.auth.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.auth.dto.response.ResetPasswordResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "비밀번호 재설정 API의 공통 응답 envelope입니다.")
+public record ResetPasswordApiResponse(
+        @Schema(description = "요청 성공 여부입니다.", example = "true")
+        boolean success,
+
+        @Schema(description = "성공 시 반환되는 비밀번호 재설정 payload입니다.")
+        ResetPasswordResponse data,
+
+        @Schema(description = "실패 시 반환되는 에러 정보입니다.")
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/auth/dto/request/FindLoginIdRequest.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/request/FindLoginIdRequest.java
@@ -1,0 +1,15 @@
+package matchuri.backend.api.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "로그인 ID 찾기 요청입니다.")
+public record FindLoginIdRequest(
+        @Schema(
+                description = "FIND_LOGIN_ID 목적 이메일 인증 확인 API에서 발급받은 token입니다.",
+                example = "ev_q3JxFrSxYk4zJw2zq3ZpQh0a3z9q0x1y2z3A4b5C6dE"
+        )
+        @NotBlank(message = "emailVerificationToken은 비어 있을 수 없습니다.")
+        String emailVerificationToken
+) {
+}

--- a/src/main/java/matchuri/backend/api/auth/dto/request/ResetPasswordRequest.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/request/ResetPasswordRequest.java
@@ -1,0 +1,42 @@
+package matchuri.backend.api.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import matchuri.backend.domain.member.entity.Member;
+
+@Schema(description = "비밀번호 재설정 요청입니다.")
+public record ResetPasswordRequest(
+        @Schema(
+                description = "비밀번호를 재설정할 자체 로그인 ID입니다.",
+                example = "tester01",
+                maxLength = Member.LOGIN_ID_MAX_SIZE
+        )
+        @NotBlank(message = "loginId는 비어 있을 수 없습니다.")
+        @Size(max = Member.LOGIN_ID_MAX_SIZE, message = "loginId는 " + Member.LOGIN_ID_MAX_SIZE + "자를 초과할 수 없습니다.")
+        @Pattern(regexp = Member.LOGIN_ID_PATTERN, message = "loginId는 영문, 숫자, 점(.), 밑줄(_), 하이픈(-)만 사용할 수 있습니다.")
+        String loginId,
+
+        @Schema(
+                description = "RESET_PASSWORD 목적 이메일 인증 확인 API에서 발급받은 token입니다.",
+                example = "ev_q3JxFrSxYk4zJw2zq3ZpQh0a3z9q0x1y2z3A4b5C6dE"
+        )
+        @NotBlank(message = "emailVerificationToken은 비어 있을 수 없습니다.")
+        String emailVerificationToken,
+
+        @Schema(
+                description = "새 비밀번호입니다. 로그인 비밀번호 정책과 같은 길이 제약을 사용합니다.",
+                example = "N3wP@ssw0rd!",
+                minLength = Member.PASSWORD_MIN_SIZE,
+                maxLength = Member.PASSWORD_MAX_SIZE
+        )
+        @NotBlank(message = "newPassword는 비어 있을 수 없습니다.")
+        @Size(
+                min = Member.PASSWORD_MIN_SIZE,
+                max = Member.PASSWORD_MAX_SIZE,
+                message = "newPassword는 " + Member.PASSWORD_MIN_SIZE + "자 이상 " + Member.PASSWORD_MAX_SIZE + "자 이하여야 합니다."
+        )
+        String newPassword
+) {
+}

--- a/src/main/java/matchuri/backend/api/auth/dto/response/FindLoginIdResponse.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/response/FindLoginIdResponse.java
@@ -1,0 +1,10 @@
+package matchuri.backend.api.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "로그인 ID 찾기 응답입니다.")
+public record FindLoginIdResponse(
+        @Schema(description = "인증된 이메일에 연결된 자체 로그인 ID입니다.", example = "tester01")
+        String loginId
+) {
+}

--- a/src/main/java/matchuri/backend/api/auth/dto/response/ResetPasswordResponse.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/response/ResetPasswordResponse.java
@@ -1,0 +1,10 @@
+package matchuri.backend.api.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "비밀번호 재설정 응답입니다.")
+public record ResetPasswordResponse(
+        @Schema(description = "비밀번호 재설정 성공 여부입니다.", example = "true")
+        boolean reset
+) {
+}

--- a/src/main/java/matchuri/backend/api/auth/mapper/AuthMapper.java
+++ b/src/main/java/matchuri/backend/api/auth/mapper/AuthMapper.java
@@ -1,0 +1,35 @@
+package matchuri.backend.api.auth.mapper;
+
+import matchuri.backend.api.auth.dto.request.FindLoginIdRequest;
+import matchuri.backend.api.auth.dto.request.ResetPasswordRequest;
+import matchuri.backend.api.auth.dto.response.FindLoginIdResponse;
+import matchuri.backend.api.auth.dto.response.ResetPasswordResponse;
+import matchuri.backend.domain.auth.command.FindLoginIdCommand;
+import matchuri.backend.domain.auth.command.ResetPasswordCommand;
+import matchuri.backend.domain.auth.result.FindLoginIdResult;
+import matchuri.backend.domain.auth.result.ResetPasswordResult;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthMapper {
+
+    public FindLoginIdCommand toFindLoginIdCommand(FindLoginIdRequest request) {
+        return new FindLoginIdCommand(request.emailVerificationToken());
+    }
+
+    public FindLoginIdResponse toFindLoginIdResponse(FindLoginIdResult result) {
+        return new FindLoginIdResponse(result.loginId());
+    }
+
+    public ResetPasswordCommand toResetPasswordCommand(ResetPasswordRequest request) {
+        return new ResetPasswordCommand(
+                request.loginId(),
+                request.emailVerificationToken(),
+                request.newPassword()
+        );
+    }
+
+    public ResetPasswordResponse toResetPasswordResponse(ResetPasswordResult result) {
+        return new ResetPasswordResponse(result.reset());
+    }
+}

--- a/src/main/java/matchuri/backend/domain/auth/command/FindLoginIdCommand.java
+++ b/src/main/java/matchuri/backend/domain/auth/command/FindLoginIdCommand.java
@@ -1,0 +1,9 @@
+package matchuri.backend.domain.auth.command;
+
+public record FindLoginIdCommand(
+        String emailVerificationToken
+) {
+    public FindLoginIdCommand {
+        emailVerificationToken = emailVerificationToken == null ? null : emailVerificationToken.trim();
+    }
+}

--- a/src/main/java/matchuri/backend/domain/auth/command/ResetPasswordCommand.java
+++ b/src/main/java/matchuri/backend/domain/auth/command/ResetPasswordCommand.java
@@ -1,0 +1,12 @@
+package matchuri.backend.domain.auth.command;
+
+public record ResetPasswordCommand(
+        String loginId,
+        String emailVerificationToken,
+        String newPassword
+) {
+    public ResetPasswordCommand {
+        loginId = loginId == null ? null : loginId.trim();
+        emailVerificationToken = emailVerificationToken == null ? null : emailVerificationToken.trim();
+    }
+}

--- a/src/main/java/matchuri/backend/domain/auth/result/FindLoginIdResult.java
+++ b/src/main/java/matchuri/backend/domain/auth/result/FindLoginIdResult.java
@@ -1,0 +1,6 @@
+package matchuri.backend.domain.auth.result;
+
+public record FindLoginIdResult(
+        String loginId
+) {
+}

--- a/src/main/java/matchuri/backend/domain/auth/result/ResetPasswordResult.java
+++ b/src/main/java/matchuri/backend/domain/auth/result/ResetPasswordResult.java
@@ -1,0 +1,9 @@
+package matchuri.backend.domain.auth.result;
+
+public record ResetPasswordResult(
+        boolean reset
+) {
+    public static ResetPasswordResult success() {
+        return new ResetPasswordResult(true);
+    }
+}

--- a/src/main/java/matchuri/backend/domain/auth/service/AccountRecoveryService.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/AccountRecoveryService.java
@@ -1,0 +1,13 @@
+package matchuri.backend.domain.auth.service;
+
+import matchuri.backend.domain.auth.command.FindLoginIdCommand;
+import matchuri.backend.domain.auth.command.ResetPasswordCommand;
+import matchuri.backend.domain.auth.result.FindLoginIdResult;
+import matchuri.backend.domain.auth.result.ResetPasswordResult;
+
+public interface AccountRecoveryService {
+
+    FindLoginIdResult findLoginId(FindLoginIdCommand command);
+
+    ResetPasswordResult resetPassword(ResetPasswordCommand command);
+}

--- a/src/main/java/matchuri/backend/domain/auth/service/AccountRecoveryServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/AccountRecoveryServiceImpl.java
@@ -1,0 +1,70 @@
+package matchuri.backend.domain.auth.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import matchuri.backend.domain.auth.command.FindLoginIdCommand;
+import matchuri.backend.domain.auth.command.ResetPasswordCommand;
+import matchuri.backend.domain.auth.entity.AuthRefreshToken;
+import matchuri.backend.domain.auth.exception.AuthErrorCode;
+import matchuri.backend.domain.auth.repository.AuthRefreshTokenRepository;
+import matchuri.backend.domain.auth.result.FindLoginIdResult;
+import matchuri.backend.domain.auth.result.ResetPasswordResult;
+import matchuri.backend.domain.auth.support.verification.EmailVerificationTokenVerifier;
+import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.entity.MemberStatus;
+import matchuri.backend.domain.member.repository.MemberRepository;
+import matchuri.backend.global.exception.AuthenticationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AccountRecoveryServiceImpl implements AccountRecoveryService {
+
+    private final EmailVerificationTokenVerifier emailVerificationTokenVerifier;
+    private final MemberRepository memberRepository;
+    private final AuthRefreshTokenRepository authRefreshTokenRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public FindLoginIdResult findLoginId(FindLoginIdCommand command) {
+
+        String token = command.emailVerificationToken();
+        var verification = emailVerificationTokenVerifier.verifyFindLoginIdToken(token);
+        String email = verification.getEmail();
+
+        Member member = memberRepository.findByEmailAndSocialFalseAndStatus(email, MemberStatus.ACTIVE)
+                .orElseThrow(() -> new AuthenticationException(AuthErrorCode.EMAIL_VERIFICATION_FAILED));
+
+        return new FindLoginIdResult(member.getLoginId());
+    }
+
+    @Override
+    @Transactional
+    public ResetPasswordResult resetPassword(ResetPasswordCommand command) {
+
+        var verification = emailVerificationTokenVerifier.verifyResetPasswordToken(
+                command.loginId(),
+                command.emailVerificationToken()
+        );
+
+        Member member = memberRepository.findByLoginIdAndEmailAndSocialFalseAndStatus(
+                        command.loginId(),
+                        verification.getEmail(),
+                        MemberStatus.ACTIVE
+                )
+                .orElseThrow(() -> new AuthenticationException(AuthErrorCode.EMAIL_VERIFICATION_FAILED));
+
+        String newPassword = command.newPassword();
+        String encoded = passwordEncoder.encode(newPassword);
+        member.updatePasswordHash(encoded);
+
+        List<AuthRefreshToken> oldRefreshTokens = authRefreshTokenRepository.findByMemberId(member.getId());
+        authRefreshTokenRepository.deleteAll(oldRefreshTokens);
+
+        return ResetPasswordResult.success();
+    }
+}

--- a/src/main/java/matchuri/backend/domain/auth/support/verification/EmailVerificationTokenVerifier.java
+++ b/src/main/java/matchuri/backend/domain/auth/support/verification/EmailVerificationTokenVerifier.java
@@ -20,8 +20,7 @@ public class EmailVerificationTokenVerifier {
     public EmailVerification verifySignupToken(String email, String token) {
         String normalizedEmail = email == null ? null : email.trim().toLowerCase();
         LocalDateTime now = LocalDateTime.now();
-        EmailVerification verification = repository.findByVerificationTokenHash(tokenGenerator.hashToken(token))
-                .orElseThrow(() -> new AuthenticationException(AuthErrorCode.EMAIL_VERIFICATION_FAILED));
+        EmailVerification verification = findByToken(token);
 
         if (!isUsableSignupToken(verification, normalizedEmail, now)) {
             throw new AuthenticationException(AuthErrorCode.EMAIL_VERIFICATION_FAILED);
@@ -31,11 +30,55 @@ public class EmailVerificationTokenVerifier {
         return verification;
     }
 
+    public EmailVerification verifyFindLoginIdToken(String token) {
+        LocalDateTime now = LocalDateTime.now();
+        EmailVerification verification = findByToken(token);
+
+        if (!isUsableToken(verification, EmailVerificationPurpose.FIND_LOGIN_ID, now)) {
+            throw new AuthenticationException(AuthErrorCode.EMAIL_VERIFICATION_FAILED);
+        }
+
+        verification.markVerificationTokenUsed(now);
+        return verification;
+    }
+
+    public EmailVerification verifyResetPasswordToken(String loginId, String token) {
+        String normalizedLoginId = loginId == null ? null : loginId.trim();
+        LocalDateTime now = LocalDateTime.now();
+        EmailVerification verification = findByToken(token);
+
+        if (!isUsableResetPasswordToken(verification, normalizedLoginId, now)) {
+            throw new AuthenticationException(AuthErrorCode.EMAIL_VERIFICATION_FAILED);
+        }
+
+        verification.markVerificationTokenUsed(now);
+        return verification;
+    }
+
+    private EmailVerification findByToken(String token) {
+        return repository.findByVerificationTokenHash(tokenGenerator.hashToken(token))
+                .orElseThrow(() -> new AuthenticationException(AuthErrorCode.EMAIL_VERIFICATION_FAILED));
+    }
+
     private boolean isUsableSignupToken(EmailVerification verification, String email, LocalDateTime now) {
-        return verification.getStatus() == EmailVerificationStatus.VERIFIED
-                && verification.getPurpose() == EmailVerificationPurpose.SIGNUP
+        return isUsableToken(verification, EmailVerificationPurpose.SIGNUP, now)
                 && verification.getEmail().equals(email)
-                && verification.getLoginId() == null
+                && verification.getLoginId() == null;
+    }
+
+    private boolean isUsableResetPasswordToken(EmailVerification verification, String loginId, LocalDateTime now) {
+        return isUsableToken(verification, EmailVerificationPurpose.RESET_PASSWORD, now)
+                && verification.getLoginId() != null
+                && verification.getLoginId().equals(loginId);
+    }
+
+    private boolean isUsableToken(
+            EmailVerification verification,
+            EmailVerificationPurpose purpose,
+            LocalDateTime now
+    ) {
+        return verification.getStatus() == EmailVerificationStatus.VERIFIED
+                && verification.getPurpose() == purpose
                 && verification.getVerificationTokenHash() != null
                 && verification.getVerificationTokenExpiresAt() != null
                 && verification.getVerificationTokenExpiresAt().isAfter(now)

--- a/src/main/java/matchuri/backend/domain/member/entity/Member.java
+++ b/src/main/java/matchuri/backend/domain/member/entity/Member.java
@@ -147,10 +147,6 @@ public class Member extends BaseEntity {
         this.tasteProfile = tasteProfile;
     }
 
-    public void updateEmail(String email) {
-        this.email = email;
-    }
-
     public void updatePasswordHash(String passwordHash) {
         this.passwordHash = passwordHash;
     }

--- a/src/main/java/matchuri/backend/domain/member/entity/Member.java
+++ b/src/main/java/matchuri/backend/domain/member/entity/Member.java
@@ -56,7 +56,7 @@ public class Member extends BaseEntity {
     @Column(name = "login_id", length = LOGIN_ID_MAX_SIZE, comment = "로그인 아이디")
     private String loginId;
 
-    @Column(name = "password_hash", length = 255, comment = "비밀번호 해시")
+    @Column(name = "password_hash", comment = "비밀번호 해시")
     private String passwordHash;
 
     @Column(name = "nickname", length = NICKNAME_MAX_SIZE, comment = "닉네임 (자체 로그인은 수집)")

--- a/src/main/java/matchuri/backend/domain/member/entity/Member.java
+++ b/src/main/java/matchuri/backend/domain/member/entity/Member.java
@@ -112,14 +112,6 @@ public class Member extends BaseEntity {
         this.nicknameCompleted = !social;
     }
 
-    public static Member createWithEncodedPassword(String loginId, String passwordHash) {
-        return createWithEncodedPassword(loginId, passwordHash, null);
-    }
-
-    public static Member createWithEncodedPassword(String loginId, String passwordHash, String nickname) {
-        return createWithEncodedPassword(loginId, passwordHash, nickname, null);
-    }
-
     public static Member createWithEncodedPassword(String loginId, String passwordHash, String nickname, String email) {
         return Member.builder()
                 .loginId(loginId)

--- a/src/main/java/matchuri/backend/domain/member/entity/Member.java
+++ b/src/main/java/matchuri/backend/domain/member/entity/Member.java
@@ -159,6 +159,10 @@ public class Member extends BaseEntity {
         this.email = email;
     }
 
+    public void updatePasswordHash(String passwordHash) {
+        this.passwordHash = passwordHash;
+    }
+
     public void updateNickname(String nickname) {
         this.nickname = nickname;
         this.nicknameCompleted = true;

--- a/src/main/java/matchuri/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/matchuri/backend/domain/member/repository/MemberRepository.java
@@ -22,6 +22,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByLoginId(String loginId);
 
+    Optional<Member> findByEmailAndSocialFalseAndStatus(String email, MemberStatus status);
+
+    Optional<Member> findByLoginIdAndEmailAndSocialFalseAndStatus(String loginId, String email, MemberStatus status);
+
     Optional<Member> findBySocialProviderTypeAndSocialProviderUserId(
             SocialProviderType socialProviderType,
             String socialProviderUserId

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -69,6 +69,8 @@ matchuri:
       - /api/v1/auth/oauth2/exchange
       - /api/v1/auth/email
       - /api/v1/auth/email/confirm
+      - /api/v1/auth/recovery/login-id
+      - /api/v1/auth/recovery/password
     public-options-api-patterns:
       - /**
     cors:

--- a/src/test/java/matchuri/backend/api/auth/AccountRecoveryIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/auth/AccountRecoveryIntegrationTest.java
@@ -1,0 +1,285 @@
+package matchuri.backend.api.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.servlet.http.Cookie;
+import java.time.LocalDateTime;
+import matchuri.backend.domain.auth.entity.AuthRefreshToken;
+import matchuri.backend.domain.auth.entity.EmailVerification;
+import matchuri.backend.domain.auth.entity.EmailVerificationPurpose;
+import matchuri.backend.domain.auth.repository.AuthRefreshTokenRepository;
+import matchuri.backend.domain.auth.repository.EmailVerificationRepository;
+import matchuri.backend.domain.auth.support.verification.EmailVerificationTokenGenerator;
+import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.entity.MemberRole;
+import matchuri.backend.domain.member.entity.MemberStatus;
+import matchuri.backend.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AccountRecoveryIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private EmailVerificationRepository emailVerificationRepository;
+
+    @Autowired
+    private AuthRefreshTokenRepository authRefreshTokenRepository;
+
+    @Autowired
+    private EmailVerificationTokenGenerator emailVerificationTokenGenerator;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        authRefreshTokenRepository.deleteAll();
+        emailVerificationRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("로그인 ID 찾기 API는 FIND_LOGIN_ID token으로 단일 loginId를 반환하고 token을 사용 완료 처리한다")
+    void findLoginId() throws Exception {
+        memberRepository.save(new Member(
+                "tester01",
+                "hashed-password",
+                "tester@example.com",
+                false,
+                null,
+                null,
+                MemberRole.MEMBER,
+                MemberStatus.ACTIVE
+        ));
+        String token = issueFindLoginIdToken("tester@example.com");
+
+        mockMvc.perform(post("/api/v1/auth/recovery/login-id")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "emailVerificationToken": "%s"
+                                }
+                                """.formatted(token)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.loginId").value("tester01"));
+
+        assertThat(emailVerificationRepository.findByVerificationTokenHash(
+                emailVerificationTokenGenerator.hashToken(token)
+        )).isPresent()
+                .get()
+                .extracting(EmailVerification::getVerificationTokenUsedAt)
+                .isNotNull();
+    }
+
+    @Test
+    @DisplayName("로그인 ID 찾기 API는 SIGNUP 목적 token을 거절한다")
+    void findLoginIdRejectsSignupToken() throws Exception {
+        String token = issueToken("tester@example.com", EmailVerificationPurpose.SIGNUP);
+
+        mockMvc.perform(post("/api/v1/auth/recovery/login-id")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "emailVerificationToken": "%s"
+                                }
+                                """.formatted(token)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("AUTH_EMAIL_VERIFICATION_FAILED"));
+    }
+
+    @Test
+    @DisplayName("로그인 ID 찾기 API는 같은 token 재사용을 거절한다")
+    void findLoginIdRejectsUsedToken() throws Exception {
+        memberRepository.save(new Member(
+                "tester01",
+                "hashed-password",
+                "tester@example.com",
+                false,
+                null,
+                null,
+                MemberRole.MEMBER,
+                MemberStatus.ACTIVE
+        ));
+        String token = issueFindLoginIdToken("tester@example.com");
+
+        mockMvc.perform(post("/api/v1/auth/recovery/login-id")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "emailVerificationToken": "%s"
+                                }
+                                """.formatted(token)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/auth/recovery/login-id")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "emailVerificationToken": "%s"
+                                }
+                                """.formatted(token)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("AUTH_EMAIL_VERIFICATION_FAILED"));
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 API는 RESET_PASSWORD token으로 비밀번호를 교체하고 기존 refresh token을 모두 폐기한다")
+    void resetPassword() throws Exception {
+        Member member = memberRepository.save(new Member(
+                "tester01",
+                passwordEncoder.encode("OldP@ssw0rd!"),
+                "tester@example.com",
+                false,
+                null,
+                null,
+                MemberRole.MEMBER,
+                MemberStatus.ACTIVE
+        ));
+        authRefreshTokenRepository.save(AuthRefreshToken.issue(
+                member,
+                "old-refresh-token",
+                LocalDateTime.now().plusDays(7)
+        ));
+        String token = issueResetPasswordToken("tester@example.com", "tester01");
+
+        mockMvc.perform(post("/api/v1/auth/recovery/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "loginId": "tester01",
+                                  "emailVerificationToken": "%s",
+                                  "newPassword": "N3wP@ssw0rd!"
+                                }
+                                """.formatted(token)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.reset").value(true));
+
+        Member updatedMember = memberRepository.findByLoginId("tester01").orElseThrow();
+        assertThat(passwordEncoder.matches("N3wP@ssw0rd!", updatedMember.getPasswordHash())).isTrue();
+        assertThat(passwordEncoder.matches("OldP@ssw0rd!", updatedMember.getPasswordHash())).isFalse();
+        assertThat(authRefreshTokenRepository.findByMemberId(member.getId())).isEmpty();
+        assertThat(emailVerificationRepository.findByVerificationTokenHash(
+                emailVerificationTokenGenerator.hashToken(token)
+        )).isPresent()
+                .get()
+                .extracting(EmailVerification::getVerificationTokenUsedAt)
+                .isNotNull();
+
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .cookie(new Cookie("matchuri_refresh_token", "old-refresh-token")))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("AUTH_REFRESH_TOKEN_INVALID"));
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "loginId": "tester01",
+                                  "password": "OldP@ssw0rd!"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("AUTH_LOGIN_FAILED"));
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "loginId": "tester01",
+                                  "password": "N3wP@ssw0rd!"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").isString());
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 API는 loginId가 token의 loginId와 다르면 거절한다")
+    void resetPasswordRejectsLoginIdMismatch() throws Exception {
+        memberRepository.save(new Member(
+                "tester01",
+                passwordEncoder.encode("OldP@ssw0rd!"),
+                "tester@example.com",
+                false,
+                null,
+                null,
+                MemberRole.MEMBER,
+                MemberStatus.ACTIVE
+        ));
+        String token = issueResetPasswordToken("tester@example.com", "tester01");
+
+        mockMvc.perform(post("/api/v1/auth/recovery/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "loginId": "other-user",
+                                  "emailVerificationToken": "%s",
+                                  "newPassword": "N3wP@ssw0rd!"
+                                }
+                                """.formatted(token)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("AUTH_EMAIL_VERIFICATION_FAILED"));
+
+        assertThat(emailVerificationRepository.findByVerificationTokenHash(
+                emailVerificationTokenGenerator.hashToken(token)
+        )).isPresent()
+                .get()
+                .extracting(EmailVerification::getVerificationTokenUsedAt)
+                .isNull();
+    }
+
+    private String issueFindLoginIdToken(String email) {
+        return issueToken(email, EmailVerificationPurpose.FIND_LOGIN_ID);
+    }
+
+    private String issueResetPasswordToken(String email, String loginId) {
+        return issueToken(email, loginId, EmailVerificationPurpose.RESET_PASSWORD);
+    }
+
+    private String issueToken(String email, EmailVerificationPurpose purpose) {
+        return issueToken(email, null, purpose);
+    }
+
+    private String issueToken(String email, String loginId, EmailVerificationPurpose purpose) {
+        String token = "ev_test_" + purpose.name().toLowerCase()
+                + "_" + email.replace("@", "_").replace(".", "_")
+                + (loginId == null ? "" : "_" + loginId);
+        EmailVerification verification = EmailVerification.issue(
+                email,
+                loginId,
+                purpose,
+                "hashed-code",
+                LocalDateTime.now().plusMinutes(5),
+                LocalDateTime.now()
+        );
+        verification.verify(
+                emailVerificationTokenGenerator.hashToken(token),
+                LocalDateTime.now().plusMinutes(10),
+                LocalDateTime.now()
+        );
+        emailVerificationRepository.save(verification);
+        return token;
+    }
+}

--- a/src/test/java/matchuri/backend/domain/auth/service/AccountRecoveryServiceImplTest.java
+++ b/src/test/java/matchuri/backend/domain/auth/service/AccountRecoveryServiceImplTest.java
@@ -1,0 +1,149 @@
+package matchuri.backend.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import matchuri.backend.domain.auth.command.FindLoginIdCommand;
+import matchuri.backend.domain.auth.command.ResetPasswordCommand;
+import matchuri.backend.domain.auth.entity.EmailVerification;
+import matchuri.backend.domain.auth.entity.EmailVerificationPurpose;
+import matchuri.backend.domain.auth.exception.AuthErrorCode;
+import matchuri.backend.domain.auth.entity.AuthRefreshToken;
+import matchuri.backend.domain.auth.repository.AuthRefreshTokenRepository;
+import matchuri.backend.domain.auth.support.verification.EmailVerificationTokenVerifier;
+import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.entity.MemberRole;
+import matchuri.backend.domain.member.entity.MemberStatus;
+import matchuri.backend.domain.member.repository.MemberRepository;
+import matchuri.backend.global.exception.AuthenticationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class AccountRecoveryServiceImplTest {
+
+    @Mock
+    private EmailVerificationTokenVerifier emailVerificationTokenVerifier;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private AuthRefreshTokenRepository authRefreshTokenRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private AccountRecoveryServiceImpl accountRecoveryService;
+
+    @Test
+    @DisplayName("FIND_LOGIN_ID token의 이메일에 연결된 활성 자체 로그인 ID를 반환한다")
+    void findLoginIdReturnsLocalLoginId() {
+        EmailVerification verification = verifiedFindLoginIdVerification("tester@example.com");
+        Member member = new Member(
+                "tester01",
+                "hashed-password",
+                "tester@example.com",
+                false,
+                null,
+                null,
+                MemberRole.MEMBER,
+                MemberStatus.ACTIVE
+        );
+
+        when(emailVerificationTokenVerifier.verifyFindLoginIdToken("ev_find-token")).thenReturn(verification);
+        when(memberRepository.findByEmailAndSocialFalseAndStatus("tester@example.com", MemberStatus.ACTIVE))
+                .thenReturn(Optional.of(member));
+
+        var result = accountRecoveryService.findLoginId(new FindLoginIdCommand("ev_find-token"));
+
+        assertThat(result.loginId()).isEqualTo("tester01");
+    }
+
+    @Test
+    @DisplayName("token은 유효하지만 활성 자체 로그인 계정이 없으면 인증 실패로 처리한다")
+    void findLoginIdFailsWhenLocalMemberDoesNotExist() {
+        EmailVerification verification = verifiedFindLoginIdVerification("missing@example.com");
+
+        when(emailVerificationTokenVerifier.verifyFindLoginIdToken("ev_find-token")).thenReturn(verification);
+        when(memberRepository.findByEmailAndSocialFalseAndStatus("missing@example.com", MemberStatus.ACTIVE))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> accountRecoveryService.findLoginId(new FindLoginIdCommand("ev_find-token")))
+                .isInstanceOf(AuthenticationException.class)
+                .extracting("errorCode")
+                .isEqualTo(AuthErrorCode.EMAIL_VERIFICATION_FAILED);
+    }
+
+    @Test
+    @DisplayName("RESET_PASSWORD token의 계정 비밀번호를 교체하고 기존 refresh token을 모두 폐기한다")
+    void resetPasswordUpdatesPasswordAndRevokesRefreshTokens() {
+        EmailVerification verification = verifiedResetPasswordVerification("tester@example.com", "tester01");
+        Member member = new Member(
+                "tester01",
+                "old-hash",
+                "tester@example.com",
+                false,
+                null,
+                null,
+                MemberRole.MEMBER,
+                MemberStatus.ACTIVE
+        );
+        AuthRefreshToken refreshToken = AuthRefreshToken.issue(member, "old-refresh-token", LocalDateTime.now().plusDays(7));
+
+        when(emailVerificationTokenVerifier.verifyResetPasswordToken("tester01", "ev_reset-token"))
+                .thenReturn(verification);
+        when(memberRepository.findByLoginIdAndEmailAndSocialFalseAndStatus(
+                "tester01",
+                "tester@example.com",
+                MemberStatus.ACTIVE
+        )).thenReturn(Optional.of(member));
+        when(passwordEncoder.encode("N3wP@ssw0rd!")).thenReturn("new-hash");
+        when(authRefreshTokenRepository.findByMemberId(member.getId())).thenReturn(java.util.List.of(refreshToken));
+
+        var result = accountRecoveryService.resetPassword(new ResetPasswordCommand(
+                "tester01",
+                "ev_reset-token",
+                "N3wP@ssw0rd!"
+        ));
+
+        assertThat(result.reset()).isTrue();
+        assertThat(member.getPasswordHash()).isEqualTo("new-hash");
+        org.mockito.Mockito.verify(authRefreshTokenRepository).deleteAll(java.util.List.of(refreshToken));
+    }
+
+    private EmailVerification verifiedFindLoginIdVerification(String email) {
+        EmailVerification verification = EmailVerification.issue(
+                email,
+                null,
+                EmailVerificationPurpose.FIND_LOGIN_ID,
+                "hashed-code",
+                LocalDateTime.now().plusMinutes(5),
+                LocalDateTime.now()
+        );
+        verification.verify("hashed-token", LocalDateTime.now().plusMinutes(10), LocalDateTime.now());
+        return verification;
+    }
+
+    private EmailVerification verifiedResetPasswordVerification(String email, String loginId) {
+        EmailVerification verification = EmailVerification.issue(
+                email,
+                loginId,
+                EmailVerificationPurpose.RESET_PASSWORD,
+                "hashed-code",
+                LocalDateTime.now().plusMinutes(5),
+                LocalDateTime.now()
+        );
+        verification.verify("hashed-token", LocalDateTime.now().plusMinutes(10), LocalDateTime.now());
+        return verification;
+    }
+}

--- a/src/test/java/matchuri/backend/domain/auth/support/verification/EmailVerificationTokenVerifierTest.java
+++ b/src/test/java/matchuri/backend/domain/auth/support/verification/EmailVerificationTokenVerifierTest.java
@@ -57,11 +57,97 @@ class EmailVerificationTokenVerifierTest {
                 .isEqualTo(AuthErrorCode.EMAIL_VERIFICATION_FAILED);
     }
 
+    @Test
+    @DisplayName("FIND_LOGIN_ID token이 유효하면 사용 완료 시각을 기록한다")
+    void verifyFindLoginIdTokenMarksTokenUsed() {
+        EmailVerification verification = verifiedFindLoginIdVerification("tester@example.com", "hashed-token");
+        EmailVerificationTokenVerifier verifier = new EmailVerificationTokenVerifier(repository, tokenGenerator);
+
+        when(tokenGenerator.hashToken("ev_find-token")).thenReturn("hashed-token");
+        when(repository.findByVerificationTokenHash("hashed-token")).thenReturn(Optional.of(verification));
+
+        EmailVerification result = verifier.verifyFindLoginIdToken("ev_find-token");
+
+        assertThat(result).isSameAs(verification);
+        assertThat(verification.getVerificationTokenUsedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("SIGNUP token은 FIND_LOGIN_ID token으로 사용할 수 없다")
+    void verifyFindLoginIdTokenRejectsSignupPurpose() {
+        EmailVerification verification = verifiedSignupVerification("tester@example.com", "hashed-token");
+        EmailVerificationTokenVerifier verifier = new EmailVerificationTokenVerifier(repository, tokenGenerator);
+
+        when(tokenGenerator.hashToken("ev_signup-token")).thenReturn("hashed-token");
+        when(repository.findByVerificationTokenHash("hashed-token")).thenReturn(Optional.of(verification));
+
+        assertThatThrownBy(() -> verifier.verifyFindLoginIdToken("ev_signup-token"))
+                .isInstanceOf(AuthenticationException.class)
+                .extracting("errorCode")
+                .isEqualTo(AuthErrorCode.EMAIL_VERIFICATION_FAILED);
+    }
+
+    @Test
+    @DisplayName("RESET_PASSWORD token이 유효하면 사용 완료 시각을 기록한다")
+    void verifyResetPasswordTokenMarksTokenUsed() {
+        EmailVerification verification = verifiedResetPasswordVerification("tester@example.com", "tester01", "hashed-token");
+        EmailVerificationTokenVerifier verifier = new EmailVerificationTokenVerifier(repository, tokenGenerator);
+
+        when(tokenGenerator.hashToken("ev_reset-token")).thenReturn("hashed-token");
+        when(repository.findByVerificationTokenHash("hashed-token")).thenReturn(Optional.of(verification));
+
+        EmailVerification result = verifier.verifyResetPasswordToken("tester01", "ev_reset-token");
+
+        assertThat(result).isSameAs(verification);
+        assertThat(verification.getVerificationTokenUsedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("RESET_PASSWORD token의 loginId와 요청 loginId가 다르면 인증 실패로 거절한다")
+    void verifyResetPasswordTokenRejectsLoginIdMismatch() {
+        EmailVerification verification = verifiedResetPasswordVerification("tester@example.com", "tester01", "hashed-token");
+        EmailVerificationTokenVerifier verifier = new EmailVerificationTokenVerifier(repository, tokenGenerator);
+
+        when(tokenGenerator.hashToken("ev_reset-token")).thenReturn("hashed-token");
+        when(repository.findByVerificationTokenHash("hashed-token")).thenReturn(Optional.of(verification));
+
+        assertThatThrownBy(() -> verifier.verifyResetPasswordToken("other-user", "ev_reset-token"))
+                .isInstanceOf(AuthenticationException.class)
+                .extracting("errorCode")
+                .isEqualTo(AuthErrorCode.EMAIL_VERIFICATION_FAILED);
+    }
+
     private EmailVerification verifiedSignupVerification(String email, String tokenHash) {
         EmailVerification verification = EmailVerification.issue(
                 email,
                 null,
                 EmailVerificationPurpose.SIGNUP,
+                "hashed-code",
+                LocalDateTime.now().plusMinutes(5),
+                LocalDateTime.now()
+        );
+        verification.verify(tokenHash, LocalDateTime.now().plusMinutes(10), LocalDateTime.now());
+        return verification;
+    }
+
+    private EmailVerification verifiedFindLoginIdVerification(String email, String tokenHash) {
+        EmailVerification verification = EmailVerification.issue(
+                email,
+                null,
+                EmailVerificationPurpose.FIND_LOGIN_ID,
+                "hashed-code",
+                LocalDateTime.now().plusMinutes(5),
+                LocalDateTime.now()
+        );
+        verification.verify(tokenHash, LocalDateTime.now().plusMinutes(10), LocalDateTime.now());
+        return verification;
+    }
+
+    private EmailVerification verifiedResetPasswordVerification(String email, String loginId, String tokenHash) {
+        EmailVerification verification = EmailVerification.issue(
+                email,
+                loginId,
+                EmailVerificationPurpose.RESET_PASSWORD,
                 "hashed-code",
                 LocalDateTime.now().plusMinutes(5),
                 LocalDateTime.now()

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -87,6 +87,24 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/auth/email/confirm'].post.responses['401'].content['application/json'].examples.verificationFailed.value.error.code")
                         .value("AUTH_EMAIL_VERIFICATION_FAILED"))
+                .andExpect(jsonPath("$.paths['/api/v1/auth/recovery/login-id'].post.summary")
+                        .value("로그인 ID 찾기"))
+                .andExpect(jsonPath("$.paths['/api/v1/auth/recovery/login-id'].post.security").isEmpty())
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/auth/recovery/login-id'].post.responses['200'].content['application/json'].schema.$ref")
+                        .value("#/components/schemas/FindLoginIdApiResponse"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/auth/recovery/login-id'].post.responses['401'].content['application/json'].examples.emailVerificationFailed.value.error.code")
+                        .value("AUTH_EMAIL_VERIFICATION_FAILED"))
+                .andExpect(jsonPath("$.paths['/api/v1/auth/recovery/password'].post.summary")
+                        .value("비밀번호 재설정"))
+                .andExpect(jsonPath("$.paths['/api/v1/auth/recovery/password'].post.security").isEmpty())
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/auth/recovery/password'].post.responses['200'].content['application/json'].schema.$ref")
+                        .value("#/components/schemas/ResetPasswordApiResponse"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/auth/recovery/password'].post.responses['401'].content['application/json'].examples.emailVerificationFailed.value.error.code")
+                        .value("AUTH_EMAIL_VERIFICATION_FAILED"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/auth/oauth2/exchange'].post.responses['400'].content['application/json'].examples.providerNotSupported.value.error.code")
                         .value("AUTH_OAUTH2_PROVIDER_NOT_SUPPORTED"))

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -53,6 +53,8 @@ matchuri:
       - /api/v1/auth/oauth2/exchange
       - /api/v1/auth/email
       - /api/v1/auth/email/confirm
+      - /api/v1/auth/recovery/login-id
+      - /api/v1/auth/recovery/password
     public-options-api-patterns:
       - /**
     cors:


### PR DESCRIPTION
## 관련 이슈
Closes #112 

## 📝 작업 내용
- `POST /api/v1/auth/recovery/login-id`
- `POST /api/v1/auth/recovery/password`

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항

### 유저 플로우
- 아이디 찾기: 이메일 입력 -> 인증코드 입력 -> 아이디 조회
- 비밀번호 변경: 이메일, 아이디 입력 -> 인증코드 입력 -> 신규 비밀번호 입력