### PR TITLE
[Feat] 관리자용 메뉴 리스트 조회 API 구현

### DIFF
--- a/src/main/java/matchuri/backend/api/menu/MenuAdminReferenceApi.java
+++ b/src/main/java/matchuri/backend/api/menu/MenuAdminReferenceApi.java
@@ -13,12 +13,14 @@ import matchuri.backend.api.menu.dto.docs.AdminAttributeCategoryApiResponse;
 import matchuri.backend.api.menu.dto.docs.AdminAttributeCategoryListApiResponse;
 import matchuri.backend.api.menu.dto.docs.AdminIngredientApiResponse;
 import matchuri.backend.api.menu.dto.docs.AdminIngredientListApiResponse;
+import matchuri.backend.api.menu.dto.docs.AdminMenuItemListApiResponse;
 import matchuri.backend.api.menu.dto.request.CreateAdminAttributeCategoryRequest;
 import matchuri.backend.api.menu.dto.request.CreateAdminIngredientRequest;
 import matchuri.backend.api.menu.dto.request.UpdateAdminAttributeCategoryRequest;
 import matchuri.backend.api.menu.dto.request.UpdateAdminIngredientRequest;
 import matchuri.backend.api.menu.dto.response.AdminAttributeCategoryResponse;
 import matchuri.backend.api.menu.dto.response.AdminIngredientResponse;
+import matchuri.backend.api.menu.dto.response.AdminMenuItemResponse;
 import matchuri.backend.global.api.ApiResponse;
 
 @Tag(name = "Menu Admin Reference", description = "참조 데이터 운영 관리를 위한 관리자 전용 API")
@@ -179,6 +181,75 @@ public interface MenuAdminReferenceApi {
             )
     })
     ApiResponse<List<AdminIngredientResponse>> getAdminIngredients();
+
+    @Operation(
+            summary = "관리자 메뉴 목록 조회",
+            description = """
+                    운영 관리용 `menu item` 목록을 조회합니다.
+                    
+                    - `ADMIN` 권한이 필요합니다.
+                    - 활성/비활성 메뉴를 모두 반환합니다.
+                    - 별도 `includeInactive` 파라미터 없이 전체 운영 상태를 기본 노출합니다.
+                    - 정렬 기준은 `id` 오름차순입니다.
+                    - 응답에는 `description`, `isActive`를 함께 포함합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = AdminMenuItemListApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "data": [
+                                                {
+                                                  "id": 1001,
+                                                  "code": "PORK_CUTLET",
+                                                  "name": "돈까스",
+                                                  "description": "돼지고기를 튀겨 소스와 함께 먹는 바삭한 메뉴입니다.",
+                                                  "isActive": true
+                                                },
+                                                {
+                                                  "id": 1002,
+                                                  "code": "SUSHI",
+                                                  "name": "초밥",
+                                                  "description": "초밥용 밥 위에 생선이나 재료를 올린 메뉴입니다.",
+                                                  "isActive": false
+                                                }
+                                              ],
+                                              "error": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken이 없거나 유효하지 않거나 만료됨",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "tokenMissing", value = ErrorExamples.AUTH_TOKEN_MISSING),
+                                    @ExampleObject(name = "tokenInvalid", value = ErrorExamples.AUTH_TOKEN_INVALID),
+                                    @ExampleObject(name = "tokenExpired", value = ErrorExamples.AUTH_TOKEN_EXPIRED)
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "관리자 권한 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(name = "forbidden", value = ErrorExamples.AUTH_FORBIDDEN)
+                    )
+            )
+    })
+    ApiResponse<List<AdminMenuItemResponse>> getAdminMenuItems();
 
     @Operation(
             summary = "관리자 ingredient 생성",

--- a/src/main/java/matchuri/backend/api/menu/MenuAdminReferenceController.java
+++ b/src/main/java/matchuri/backend/api/menu/MenuAdminReferenceController.java
@@ -9,6 +9,7 @@ import matchuri.backend.api.menu.dto.request.UpdateAdminAttributeCategoryRequest
 import matchuri.backend.api.menu.dto.request.UpdateAdminIngredientRequest;
 import matchuri.backend.api.menu.dto.response.AdminAttributeCategoryResponse;
 import matchuri.backend.api.menu.dto.response.AdminIngredientResponse;
+import matchuri.backend.api.menu.dto.response.AdminMenuItemResponse;
 import matchuri.backend.api.menu.mapper.MenuReferenceMapper;
 import matchuri.backend.domain.menu.service.MenuAdminReferenceService;
 import matchuri.backend.global.api.ApiResponse;
@@ -45,6 +46,16 @@ public class MenuAdminReferenceController implements MenuAdminReferenceApi {
 
         var results = menuAdminReferenceService.getIngredients();
         var responses = menuReferenceMapper.toAdminIngredientResponses(results);
+
+        return ApiResponse.success(responses);
+    }
+
+    @Override
+    @GetMapping("/menu-items")
+    public ApiResponse<List<AdminMenuItemResponse>> getAdminMenuItems() {
+
+        var results = menuAdminReferenceService.getMenuItems();
+        var responses = menuReferenceMapper.toAdminMenuItemResponses(results);
 
         return ApiResponse.success(responses);
     }

--- a/src/main/java/matchuri/backend/api/menu/dto/docs/AdminMenuItemListApiResponse.java
+++ b/src/main/java/matchuri/backend/api/menu/dto/docs/AdminMenuItemListApiResponse.java
@@ -1,0 +1,19 @@
+package matchuri.backend.api.menu.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import matchuri.backend.api.menu.dto.response.AdminMenuItemResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "관리자 메뉴 목록 조회 API의 공통 응답 envelope입니다.")
+public record AdminMenuItemListApiResponse(
+        @Schema(description = "요청 성공 여부입니다.", example = "true")
+        boolean success,
+
+        @Schema(description = "성공 시 반환되는 관리자 메뉴 목록입니다.")
+        List<AdminMenuItemResponse> data,
+
+        @Schema(description = "실패 시 반환되는 에러 정보입니다.")
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/menu/dto/response/AdminMenuItemResponse.java
+++ b/src/main/java/matchuri/backend/api/menu/dto/response/AdminMenuItemResponse.java
@@ -1,0 +1,21 @@
+package matchuri.backend.api.menu.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AdminMenuItemResponse(
+        @Schema(description = "메뉴 ID입니다.", example = "1001")
+        Long id,
+
+        @Schema(description = "메뉴 코드입니다.", example = "PORK_CUTLET")
+        String code,
+
+        @Schema(description = "메뉴 표시 이름입니다.", example = "돈까스")
+        String name,
+
+        @Schema(description = "메뉴 설명입니다.", example = "돼지고기를 튀겨 소스와 함께 먹는 바삭한 메뉴입니다.")
+        String description,
+
+        @Schema(description = "운영 기준 활성 여부입니다.", example = "true")
+        boolean isActive
+) {
+}

--- a/src/main/java/matchuri/backend/api/menu/mapper/MenuReferenceMapper.java
+++ b/src/main/java/matchuri/backend/api/menu/mapper/MenuReferenceMapper.java
@@ -7,6 +7,7 @@ import matchuri.backend.api.menu.dto.request.UpdateAdminAttributeCategoryRequest
 import matchuri.backend.api.menu.dto.request.UpdateAdminIngredientRequest;
 import matchuri.backend.api.menu.dto.response.AdminAttributeCategoryResponse;
 import matchuri.backend.api.menu.dto.response.AdminIngredientResponse;
+import matchuri.backend.api.menu.dto.response.AdminMenuItemResponse;
 import matchuri.backend.api.menu.dto.response.AttributeCategoryResponse;
 import matchuri.backend.api.menu.dto.response.MenuItemDetailResponse;
 import matchuri.backend.api.menu.dto.response.MenuItemSummaryResponse;
@@ -21,6 +22,7 @@ import matchuri.backend.domain.menu.command.UpdateAdminIngredientCommand;
 import matchuri.backend.domain.menu.entity.CategoryType;
 import matchuri.backend.domain.menu.result.AdminAttributeCategoryResult;
 import matchuri.backend.domain.menu.result.AdminIngredientResult;
+import matchuri.backend.domain.menu.result.AdminMenuItemResult;
 import matchuri.backend.domain.menu.result.AttributeCategoryResult;
 import matchuri.backend.domain.menu.result.MenuItemDetailResult;
 import matchuri.backend.domain.menu.result.MenuItemSummaryResult;
@@ -108,6 +110,12 @@ public class MenuReferenceMapper {
                 .toList();
     }
 
+    public List<AdminMenuItemResponse> toAdminMenuItemResponses(List<AdminMenuItemResult> results) {
+        return results.stream()
+                .map(this::toAdminMenuItemResponse)
+                .toList();
+    }
+
     public List<AttributeCategoryResponse> toAttributeCategoryResponses(List<AttributeCategoryResult> results) {
         return results.stream()
                 .map(this::toAttributeCategoryResponse)
@@ -166,6 +174,16 @@ public class MenuReferenceMapper {
                 result.name(),
                 result.allergen(),
                 result.sortOrder(),
+                result.isActive()
+        );
+    }
+
+    public AdminMenuItemResponse toAdminMenuItemResponse(AdminMenuItemResult result) {
+        return new AdminMenuItemResponse(
+                result.id(),
+                result.code(),
+                result.name(),
+                result.description(),
                 result.isActive()
         );
     }

--- a/src/main/java/matchuri/backend/domain/menu/repository/MenuItemRepository.java
+++ b/src/main/java/matchuri/backend/domain/menu/repository/MenuItemRepository.java
@@ -16,6 +16,8 @@ public interface MenuItemRepository extends JpaRepository<MenuItem, Long> {
 
     Optional<MenuItem> findByCode(String code);
 
+    List<MenuItem> findAllByOrderByIdAsc();
+
     List<MenuItem> findAllByIdInAndActiveTrue(Collection<Long> ids);
 
     Optional<MenuItem> findByIdAndActiveTrue(Long id);

--- a/src/main/java/matchuri/backend/domain/menu/result/AdminMenuItemResult.java
+++ b/src/main/java/matchuri/backend/domain/menu/result/AdminMenuItemResult.java
@@ -1,0 +1,22 @@
+package matchuri.backend.domain.menu.result;
+
+import matchuri.backend.domain.menu.entity.MenuItem;
+
+public record AdminMenuItemResult(
+        Long id,
+        String code,
+        String name,
+        String description,
+        boolean isActive
+) {
+
+    public static AdminMenuItemResult from(MenuItem menuItem) {
+        return new AdminMenuItemResult(
+                menuItem.getId(),
+                menuItem.getCode(),
+                menuItem.getName(),
+                menuItem.getDescription(),
+                menuItem.isActive()
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/domain/menu/service/MenuAdminReferenceService.java
+++ b/src/main/java/matchuri/backend/domain/menu/service/MenuAdminReferenceService.java
@@ -7,12 +7,15 @@ import matchuri.backend.domain.menu.command.UpdateAdminAttributeCategoryCommand;
 import matchuri.backend.domain.menu.command.UpdateAdminIngredientCommand;
 import matchuri.backend.domain.menu.result.AdminAttributeCategoryResult;
 import matchuri.backend.domain.menu.result.AdminIngredientResult;
+import matchuri.backend.domain.menu.result.AdminMenuItemResult;
 
 public interface MenuAdminReferenceService {
 
     List<AdminAttributeCategoryResult> getAttributeCategories();
 
     List<AdminIngredientResult> getIngredients();
+
+    List<AdminMenuItemResult> getMenuItems();
 
     AdminAttributeCategoryResult createAttributeCategory(CreateAdminAttributeCategoryCommand command);
 

--- a/src/main/java/matchuri/backend/domain/menu/service/MenuAdminReferenceServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/menu/service/MenuAdminReferenceServiceImpl.java
@@ -11,8 +11,10 @@ import matchuri.backend.domain.menu.entity.AttributeCategory;
 import matchuri.backend.domain.menu.entity.Ingredient;
 import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
 import matchuri.backend.domain.menu.repository.IngredientRepository;
+import matchuri.backend.domain.menu.repository.MenuItemRepository;
 import matchuri.backend.domain.menu.result.AdminAttributeCategoryResult;
 import matchuri.backend.domain.menu.result.AdminIngredientResult;
+import matchuri.backend.domain.menu.result.AdminMenuItemResult;
 import matchuri.backend.global.exception.BusinessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +26,7 @@ public class MenuAdminReferenceServiceImpl implements MenuAdminReferenceService 
 
     private final AttributeCategoryRepository attributeCategoryRepository;
     private final IngredientRepository ingredientRepository;
+    private final MenuItemRepository menuItemRepository;
 
     @Override
     public List<AdminAttributeCategoryResult> getAttributeCategories() {
@@ -36,6 +39,13 @@ public class MenuAdminReferenceServiceImpl implements MenuAdminReferenceService 
     public List<AdminIngredientResult> getIngredients() {
         return ingredientRepository.findAllByOrderBySortOrderAscIdAsc().stream()
                 .map(AdminIngredientResult::from)
+                .toList();
+    }
+
+    @Override
+    public List<AdminMenuItemResult> getMenuItems() {
+        return menuItemRepository.findAllByOrderByIdAsc().stream()
+                .map(AdminMenuItemResult::from)
                 .toList();
     }
 

--- a/src/test/java/matchuri/backend/api/menu/MenuAdminReferenceIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/menu/MenuAdminReferenceIntegrationTest.java
@@ -23,8 +23,10 @@ import matchuri.backend.domain.member.support.agreement.RequiredAgreementVersion
 import matchuri.backend.domain.menu.entity.AttributeCategory;
 import matchuri.backend.domain.menu.entity.CategoryType;
 import matchuri.backend.domain.menu.entity.Ingredient;
+import matchuri.backend.domain.menu.entity.MenuItem;
 import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
 import matchuri.backend.domain.menu.repository.IngredientRepository;
+import matchuri.backend.domain.menu.repository.MenuItemRepository;
 import matchuri.backend.global.config.MatchuriProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -52,6 +54,9 @@ class MenuAdminReferenceIntegrationTest {
     private IngredientRepository ingredientRepository;
 
     @Autowired
+    private MenuItemRepository menuItemRepository;
+
+    @Autowired
     private MemberRepository memberRepository;
 
     @Autowired
@@ -59,6 +64,7 @@ class MenuAdminReferenceIntegrationTest {
 
     @BeforeEach
     void setUp() {
+        menuItemRepository.deleteAll();
         attributeCategoryRepository.deleteAll();
         ingredientRepository.deleteAll();
         memberRepository.deleteAll();
@@ -142,6 +148,42 @@ class MenuAdminReferenceIntegrationTest {
     }
 
     @Test
+    @DisplayName("관리자 메뉴 목록 조회는 활성과 비활성 메뉴를 함께 정렬해서 반환한다")
+    void getAdminMenuItemsReturnsAllRowsInSortedOrder() throws Exception {
+        Member admin = memberRepository.save(new Member(
+                "admin-menu-user",
+                "hashed-password",
+                null,
+                false,
+                null,
+                null,
+                MemberRole.ADMIN,
+                MemberStatus.ACTIVE
+        ));
+        MenuItem kimchiStew = menuItemRepository.save(
+                new MenuItem("KIMCHI_STEW", "김치찌개", "김치와 돼지고기를 넣고 끓인 찌개"));
+        MenuItem sushi = new MenuItem("SUSHI", "초밥", "초밥용 밥 위에 생선을 올린 메뉴");
+        sushi.deactivate();
+        sushi = menuItemRepository.save(sushi);
+
+        mockMvc.perform(get("/api/v1/admin/menu-items")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(admin)))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.error").value(nullValue()))
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].id").value(kimchiStew.getId()))
+                .andExpect(jsonPath("$.data[0].code").value("KIMCHI_STEW"))
+                .andExpect(jsonPath("$.data[0].name").value("김치찌개"))
+                .andExpect(jsonPath("$.data[0].description").value("김치와 돼지고기를 넣고 끓인 찌개"))
+                .andExpect(jsonPath("$.data[0].isActive").value(true))
+                .andExpect(jsonPath("$.data[1].id").value(sushi.getId()))
+                .andExpect(jsonPath("$.data[1].code").value("SUSHI"))
+                .andExpect(jsonPath("$.data[1].isActive").value(false));
+    }
+
+    @Test
     @DisplayName("일반 회원은 관리자 attribute category 목록 조회에 접근할 수 없다")
     void getAdminAttributeCategoriesRejectsNonAdminMember() throws Exception {
         Member member = memberRepository.save(new Member(
@@ -178,6 +220,28 @@ class MenuAdminReferenceIntegrationTest {
         ));
 
         mockMvc.perform(get("/api/v1/admin/ingredients")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member)))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("AUTH_FORBIDDEN"));
+    }
+
+    @Test
+    @DisplayName("일반 회원은 관리자 메뉴 목록 조회에 접근할 수 없다")
+    void getAdminMenuItemsRejectsNonAdminMember() throws Exception {
+        Member member = memberRepository.save(new Member(
+                "member-menu-user",
+                "hashed-password",
+                null,
+                false,
+                null,
+                null,
+                MemberRole.MEMBER,
+                MemberStatus.ACTIVE
+        ));
+
+        mockMvc.perform(get("/api/v1/admin/menu-items")
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member)))
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isForbidden())

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -273,6 +273,18 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/admin/ingredients'].get.responses['403'].content['application/json'].examples.forbidden.value.error.code")
                         .value("AUTH_FORBIDDEN"))
+                .andExpect(jsonPath("$.paths['/api/v1/admin/menu-items'].get.summary")
+                        .value("관리자 메뉴 목록 조회"))
+                .andExpect(jsonPath("$.paths['/api/v1/admin/menu-items'].get.security[0].bearerAuth").exists())
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/admin/menu-items'].get.responses['200'].content['application/json'].schema.$ref")
+                        .value("#/components/schemas/AdminMenuItemListApiResponse"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/admin/menu-items'].get.responses['401'].content['application/json'].examples.tokenMissing.value.error.code")
+                        .value("AUTH_TOKEN_MISSING"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/admin/menu-items'].get.responses['403'].content['application/json'].examples.forbidden.value.error.code")
+                        .value("AUTH_FORBIDDEN"))
                 .andExpect(jsonPath("$.paths['/api/v1/admin/ingredients'].post.summary")
                         .value("관리자 ingredient 생성"))
                 .andExpect(jsonPath("$.paths['/api/v1/admin/ingredients'].post.security[0].bearerAuth").exists())
@@ -330,6 +342,8 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath("$.components.schemas.UpdateAdminIngredientRequest.properties.isActive.description")
                         .value("수정할 활성 여부입니다. null이면 활성 상태를 변경하지 않습니다."))
                 .andExpect(jsonPath("$.components.schemas.AdminIngredientResponse.properties.isActive.description")
+                        .value("운영 기준 활성 여부입니다."))
+                .andExpect(jsonPath("$.components.schemas.AdminMenuItemResponse.properties.isActive.description")
                         .value("운영 기준 활성 여부입니다."))
                 .andExpect(
                         jsonPath("$.components.schemas.AdminAttributeCategoryResponse.properties.isActive.description")


### PR DESCRIPTION
## 관련 이슈
Closes #151 

## 📝 작업 내용
- 어드민 전용 조회 API 입니다.

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
