### PR TITLE
[Feat] 관리자용 메뉴 정보 비활성화 API 구현

### DIFF
--- a/src/main/java/matchuri/backend/api/menu/MenuAdminReferenceApi.java
+++ b/src/main/java/matchuri/backend/api/menu/MenuAdminReferenceApi.java
@@ -339,6 +339,88 @@ public interface MenuAdminReferenceApi {
     );
 
     @Operation(
+            summary = "관리자 메뉴 비활성화",
+            description = """
+                    운영 관리용 `menu item`을 비활성화합니다.
+                    
+                    - `ADMIN` 권한이 필요합니다.
+                    - 물리 삭제가 아니라 `isActive=false` 비활성화로 처리합니다.
+                    - 이미 비활성 상태여도 실패시키지 않고 현재 상태를 그대로 반환합니다.
+                    - 공개 메뉴 목록/상세 조회와 취향 프로필 저장 검증에서는 비활성 메뉴가 제외됩니다.
+                    - 성공 시 최신 단건 상태를 반환합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "비활성화 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = AdminMenuItemApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "data": {
+                                                "id": 1001,
+                                                "code": "PORK_CUTLET",
+                                                "name": "돈까스",
+                                                "description": "돼지고기를 튀겨 소스와 함께 먹는 바삭한 메뉴입니다.",
+                                                "isActive": false
+                                              },
+                                              "error": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 메뉴",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "notFound",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "data": null,
+                                              "error": {
+                                                "status": 404,
+                                                "code": "MENU_NOT_FOUND",
+                                                "message": "메뉴를 찾을 수 없습니다. menuId : 999",
+                                                "details": []
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken이 없거나 유효하지 않거나 만료됨",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "tokenMissing", value = ErrorExamples.AUTH_TOKEN_MISSING),
+                                    @ExampleObject(name = "tokenInvalid", value = ErrorExamples.AUTH_TOKEN_INVALID),
+                                    @ExampleObject(name = "tokenExpired", value = ErrorExamples.AUTH_TOKEN_EXPIRED)
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "관리자 권한 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(name = "forbidden", value = ErrorExamples.AUTH_FORBIDDEN)
+                    )
+            )
+    })
+    ApiResponse<AdminMenuItemResponse> deactivateAdminMenuItem(Long menuItemId);
+
+    @Operation(
             summary = "관리자 ingredient 생성",
             description = """
                     운영 관리용 `ingredient`를 새로 생성합니다.

--- a/src/main/java/matchuri/backend/api/menu/MenuAdminReferenceController.java
+++ b/src/main/java/matchuri/backend/api/menu/MenuAdminReferenceController.java
@@ -76,6 +76,17 @@ public class MenuAdminReferenceController implements MenuAdminReferenceApi {
     }
 
     @Override
+    @DeleteMapping("/menu-items/{menuItemId}")
+    public ApiResponse<AdminMenuItemResponse> deactivateAdminMenuItem(
+            @PathVariable Long menuItemId
+    ) {
+        var result = menuAdminReferenceService.deactivateMenuItem(menuItemId);
+        var response = menuReferenceMapper.toAdminMenuItemResponse(result);
+
+        return ApiResponse.success(response);
+    }
+
+    @Override
     @PostMapping("/ingredients")
     public ApiResponse<AdminIngredientResponse> createAdminIngredient(
             @Valid @RequestBody CreateAdminIngredientRequest request

--- a/src/main/java/matchuri/backend/domain/menu/service/MenuAdminReferenceService.java
+++ b/src/main/java/matchuri/backend/domain/menu/service/MenuAdminReferenceService.java
@@ -28,6 +28,8 @@ public interface MenuAdminReferenceService {
 
     AdminMenuItemResult updateMenuItem(UpdateAdminMenuItemCommand command);
 
+    AdminMenuItemResult deactivateMenuItem(Long menuItemId);
+
     AdminAttributeCategoryResult deactivateAttributeCategory(Long attributeCategoryId);
 
     AdminIngredientResult deactivateIngredient(Long ingredientId);

--- a/src/main/java/matchuri/backend/domain/menu/service/MenuAdminReferenceServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/menu/service/MenuAdminReferenceServiceImpl.java
@@ -167,6 +167,19 @@ public class MenuAdminReferenceServiceImpl implements MenuAdminReferenceService 
 
     @Override
     @Transactional
+    public AdminMenuItemResult deactivateMenuItem(Long menuItemId) {
+        MenuItem menuItem = menuItemRepository.findById(menuItemId)
+                .orElseThrow(() -> new BusinessException(MenuErrorCode.NOT_FOUND, menuItemId));
+
+        if (menuItem.isActive()) {
+            menuItem.deactivate();
+        }
+
+        return AdminMenuItemResult.from(menuItem);
+    }
+
+    @Override
+    @Transactional
     public AdminAttributeCategoryResult deactivateAttributeCategory(Long attributeCategoryId) {
         AttributeCategory attributeCategory = attributeCategoryRepository.findById(attributeCategoryId)
                 .orElseThrow(() -> new BusinessException(

--- a/src/test/java/matchuri/backend/api/menu/MenuAdminReferenceIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/menu/MenuAdminReferenceIntegrationTest.java
@@ -383,6 +383,174 @@ class MenuAdminReferenceIntegrationTest {
     }
 
     @Test
+    @DisplayName("관리자는 메뉴를 비활성화할 수 있다")
+    void deactivateAdminMenuItem() throws Exception {
+        Member admin = memberRepository.save(new Member(
+                "admin-delete-menu-user",
+                "hashed-password",
+                null,
+                false,
+                null,
+                null,
+                MemberRole.ADMIN,
+                MemberStatus.ACTIVE
+        ));
+        MenuItem menuItem = menuItemRepository.save(
+                new MenuItem("PORK_CUTLET", "돈까스", "돼지고기를 튀긴 메뉴")
+        );
+
+        mockMvc.perform(delete("/api/v1/admin/menu-items/{menuItemId}", menuItem.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(admin)))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.error").value(nullValue()))
+                .andExpect(jsonPath("$.data.id").value(menuItem.getId()))
+                .andExpect(jsonPath("$.data.code").value("PORK_CUTLET"))
+                .andExpect(jsonPath("$.data.name").value("돈까스"))
+                .andExpect(jsonPath("$.data.isActive").value(false));
+
+        MenuItem deactivated = menuItemRepository.findById(menuItem.getId()).orElseThrow();
+        assertThat(deactivated.isActive()).isFalse();
+        assertThat(deactivated.getCode()).isEqualTo("PORK_CUTLET");
+        assertThat(deactivated.getName()).isEqualTo("돈까스");
+    }
+
+    @Test
+    @DisplayName("관리자 메뉴 비활성화는 이미 비활성 상태여도 현재 상태를 반환한다")
+    void deactivateAdminMenuItemReturnsCurrentStateWhenAlreadyInactive() throws Exception {
+        Member admin = memberRepository.save(new Member(
+                "admin-delete-inactive-menu-user",
+                "hashed-password",
+                null,
+                false,
+                null,
+                null,
+                MemberRole.ADMIN,
+                MemberStatus.ACTIVE
+        ));
+        MenuItem menuItem = new MenuItem("SUSHI", "초밥", "초밥용 밥 위에 생선을 올린 메뉴");
+        menuItem.deactivate();
+        menuItem = menuItemRepository.save(menuItem);
+
+        mockMvc.perform(delete("/api/v1/admin/menu-items/{menuItemId}", menuItem.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(admin)))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(menuItem.getId()))
+                .andExpect(jsonPath("$.data.code").value("SUSHI"))
+                .andExpect(jsonPath("$.data.name").value("초밥"))
+                .andExpect(jsonPath("$.data.isActive").value(false));
+    }
+
+    @Test
+    @DisplayName("관리자 메뉴 비활성화는 존재하지 않는 대상을 거절한다")
+    void deactivateAdminMenuItemRejectsNotFound() throws Exception {
+        Member admin = memberRepository.save(new Member(
+                "admin-delete-not-found-menu-user",
+                "hashed-password",
+                null,
+                false,
+                null,
+                null,
+                MemberRole.ADMIN,
+                MemberStatus.ACTIVE
+        ));
+
+        mockMvc.perform(delete("/api/v1/admin/menu-items/{menuItemId}", 999L)
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(admin)))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("MENU_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("일반 회원은 관리자 메뉴 비활성화에 접근할 수 없다")
+    void deactivateAdminMenuItemRejectsNonAdminMember() throws Exception {
+        Member member = memberRepository.save(new Member(
+                "member-delete-menu-user",
+                "hashed-password",
+                null,
+                false,
+                null,
+                null,
+                MemberRole.MEMBER,
+                MemberStatus.ACTIVE
+        ));
+        MenuItem menuItem = menuItemRepository.save(
+                new MenuItem("KIMCHI_STEW", "김치찌개", "김치와 돼지고기를 넣고 끓인 찌개")
+        );
+
+        mockMvc.perform(delete("/api/v1/admin/menu-items/{menuItemId}", menuItem.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member)))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("AUTH_FORBIDDEN"));
+    }
+
+    @Test
+    @DisplayName("관리자 비활성화 이후 메뉴는 공개 조회에서 제외되고 취향 프로필 저장도 거절된다")
+    void deactivatedMenuItemIsExcludedFromPublicListAndRejectedByTasteProfileSave() throws Exception {
+        Member admin = memberRepository.save(new Member(
+                "admin-public-menu-user",
+                "hashed-password",
+                null,
+                false,
+                null,
+                null,
+                MemberRole.ADMIN,
+                MemberStatus.ACTIVE
+        ));
+        Member member = memberRepository.save(new Member(
+                "member-public-menu-user",
+                "hashed-password",
+                null,
+                false,
+                null,
+                null,
+                MemberRole.MEMBER,
+                MemberStatus.ACTIVE
+        ));
+        MenuItem menuItem = menuItemRepository.save(
+                new MenuItem("PORK_CUTLET", "돈까스", "돼지고기를 튀긴 메뉴")
+        );
+
+        mockMvc.perform(delete("/api/v1/admin/menu-items/{menuItemId}", menuItem.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(admin)))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(menuItem.getId()))
+                .andExpect(jsonPath("$.data.isActive").value(false));
+
+        mockMvc.perform(get("/api/v1/menu-items")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.length()").value(0));
+
+        mockMvc.perform(get("/api/v1/menu-items/{menuItemId}", menuItem.getId())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("MENU_NOT_FOUND"));
+
+        mockMvc.perform(patch("/api/v1/members/me/taste-profile")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "attributeCategoryIds": [],
+                                  "restrictionIngredientIds": [],
+                                  "dislikedMenuItemIds": [%d]
+                                }
+                                """.formatted(menuItem.getId())))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("MEMBER_INVALID_TASTE_DISLIKED_MENU_ITEM"));
+    }
+
+    @Test
     @DisplayName("관리자는 ingredient를 생성할 수 있다")
     void createAdminIngredient() throws Exception {
         Member admin = memberRepository.save(new Member(

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -295,6 +295,16 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/admin/menu-items/{menuItemId}'].patch.responses['404'].content['application/json'].examples.notFound.value.error.code")
                         .value("MENU_NOT_FOUND"))
+                .andExpect(jsonPath("$.paths['/api/v1/admin/menu-items/{menuItemId}'].delete.summary")
+                        .value("관리자 메뉴 비활성화"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/admin/menu-items/{menuItemId}'].delete.security[0].bearerAuth").exists())
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/admin/menu-items/{menuItemId}'].delete.responses['200'].content['application/json'].schema.$ref")
+                        .value("#/components/schemas/AdminMenuItemApiResponse"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/admin/menu-items/{menuItemId}'].delete.responses['404'].content['application/json'].examples.notFound.value.error.code")
+                        .value("MENU_NOT_FOUND"))
                 .andExpect(jsonPath("$.paths['/api/v1/admin/ingredients'].post.summary")
                         .value("관리자 ingredient 생성"))
                 .andExpect(jsonPath("$.paths['/api/v1/admin/ingredients'].post.security[0].bearerAuth").exists())


### PR DESCRIPTION
## 관련 이슈
Closes #117 

## 📝 작업 내용
- 어드민용 API 입니다.

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
