### PR TITLE
[Feat] local 환경에서는 어드민 계정을 주입

### DIFF
--- a/src/main/java/matchuri/backend/bootstrap/DevSampleDataInitializer.java
+++ b/src/main/java/matchuri/backend/bootstrap/DevSampleDataInitializer.java
@@ -8,6 +8,9 @@ import matchuri.backend.domain.member.entity.MemberStatus;
 import matchuri.backend.domain.member.repository.MemberRepository;
 import matchuri.backend.global.config.MatchuriProperties;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,8 +20,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DevSampleDataInitializer {
 
+    static final String ADMIN_LOGIN_ID = "admin01";
+    static final String ADMIN_PASSWORD = "Admin123!";
+
     private final MemberRepository memberRepository;
     private final MatchuriProperties matchuriProperties;
+    private final PasswordEncoder passwordEncoder;
+    private final Environment environment;
 
     @Transactional
     public int initialize() {
@@ -35,6 +43,7 @@ public class DevSampleDataInitializer {
         int createdCount = 0;
         createdCount += createSampleMemberIfAbsent("tester01", "tester01@example.com");
         createdCount += createSampleMemberIfAbsent("tester02", "tester02@example.com");
+        createdCount += createLocalAdminMemberIfAbsent();
         return createdCount;
     }
 
@@ -55,6 +64,33 @@ public class DevSampleDataInitializer {
                 MemberStatus.ACTIVE
         ));
         log.info("Sample member created. loginId={}", loginId);
+        return 1;
+    }
+
+    private int createLocalAdminMemberIfAbsent() {
+        if (!environment.acceptsProfiles(Profiles.of("local"))) {
+            log.info("Sample admin member seed skipped because local profile is not active. loginId={}", ADMIN_LOGIN_ID);
+            return 0;
+        }
+
+        if (memberRepository.existsByLoginId(ADMIN_LOGIN_ID)) {
+            log.info("Sample admin member already exists. loginId={}", ADMIN_LOGIN_ID);
+            return 0;
+        }
+
+        memberRepository.save(Member.builder()
+                .loginId(ADMIN_LOGIN_ID)
+                .passwordHash(passwordEncoder.encode(ADMIN_PASSWORD))
+                .nickname("matchuri-admin")
+                .nicknameCompleted(true)
+                .email("admin01@example.com")
+                .social(false)
+                .socialProviderType(null)
+                .socialProviderUserId(null)
+                .memberRole(MemberRole.ADMIN)
+                .status(MemberStatus.ACTIVE)
+                .build());
+        log.info("Sample admin member created. loginId={}", ADMIN_LOGIN_ID);
         return 1;
     }
 }

--- a/src/main/java/matchuri/backend/bootstrap/DevSampleDataInitializer.java
+++ b/src/main/java/matchuri/backend/bootstrap/DevSampleDataInitializer.java
@@ -2,10 +2,14 @@ package matchuri.backend.bootstrap;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import matchuri.backend.domain.member.entity.AgreementType;
 import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.entity.MemberAgreement;
 import matchuri.backend.domain.member.entity.MemberRole;
 import matchuri.backend.domain.member.entity.MemberStatus;
+import matchuri.backend.domain.member.repository.MemberAgreementRepository;
 import matchuri.backend.domain.member.repository.MemberRepository;
+import matchuri.backend.domain.member.support.agreement.RequiredAgreementVersions;
 import matchuri.backend.global.config.MatchuriProperties;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
@@ -22,8 +26,11 @@ public class DevSampleDataInitializer {
 
     static final String ADMIN_LOGIN_ID = "admin01";
     static final String ADMIN_PASSWORD = "Admin123!";
+    static final String SAMPLE_MEMBER_PASSWORD = "Password123!";
+    private static final String LEGACY_SAMPLE_PASSWORD_HASH = "seed-password-hash";
 
     private final MemberRepository memberRepository;
+    private final MemberAgreementRepository memberAgreementRepository;
     private final MatchuriProperties matchuriProperties;
     private final PasswordEncoder passwordEncoder;
     private final Environment environment;
@@ -41,30 +48,52 @@ public class DevSampleDataInitializer {
         }
 
         int createdCount = 0;
-        createdCount += createSampleMemberIfAbsent("tester01", "tester01@example.com");
-        createdCount += createSampleMemberIfAbsent("tester02", "tester02@example.com");
+        createdCount += createSampleMemberIfAbsent("tester01", "테스터일", "tester01@example.com");
+        createdCount += createSampleMemberIfAbsent("tester02", "테스터이", "tester02@example.com");
         createdCount += createLocalAdminMemberIfAbsent();
         return createdCount;
     }
 
-    private int createSampleMemberIfAbsent(String loginId, String email) {
-        if (memberRepository.existsByLoginId(loginId)) {
-            log.info("Sample member already exists. loginId={}", loginId);
-            return 0;
-        }
+    private int createSampleMemberIfAbsent(String loginId, String nickname, String email) {
+        return memberRepository.findByLoginId(loginId)
+                .map(member -> updateSampleMemberOnboardingIfNeeded(member, nickname))
+                .orElseGet(() -> createSampleMember(loginId, nickname, email));
+    }
 
-        memberRepository.save(new Member(
+    private int createSampleMember(String loginId, String nickname, String email) {
+        Member member = Member.createWithEncodedPassword(
                 loginId,
-                "seed-password-hash",
-                email,
-                false,
-                null,
-                null,
-                MemberRole.MEMBER,
-                MemberStatus.ACTIVE
-        ));
+                passwordEncoder.encode(SAMPLE_MEMBER_PASSWORD),
+                nickname,
+                email
+        );
+        memberRepository.save(member);
+        createRequiredAgreementConsentsIfAbsent(member);
         log.info("Sample member created. loginId={}", loginId);
         return 1;
+    }
+
+    private int updateSampleMemberOnboardingIfNeeded(Member member, String nickname) {
+        int updatedCount = 0;
+        if (!member.isNicknameCompleted() || member.getNickname() == null) {
+            member.updateNickname(nickname);
+            updatedCount++;
+        }
+
+        if (LEGACY_SAMPLE_PASSWORD_HASH.equals(member.getPasswordHash())) {
+            member.updatePasswordHash(passwordEncoder.encode(SAMPLE_MEMBER_PASSWORD));
+            updatedCount++;
+        }
+
+        updatedCount += createRequiredAgreementConsentsIfAbsent(member);
+        if (updatedCount == 0) {
+            log.info("Sample member already exists. loginId={}", member.getLoginId());
+        } else {
+            log.info("Sample member onboarding seed updated. loginId={}, updatedCount={}",
+                    member.getLoginId(), updatedCount);
+        }
+
+        return updatedCount;
     }
 
     private int createLocalAdminMemberIfAbsent() {
@@ -74,11 +103,18 @@ public class DevSampleDataInitializer {
         }
 
         if (memberRepository.existsByLoginId(ADMIN_LOGIN_ID)) {
-            log.info("Sample admin member already exists. loginId={}", ADMIN_LOGIN_ID);
-            return 0;
+            Member admin = memberRepository.findByLoginId(ADMIN_LOGIN_ID).orElseThrow();
+            int updatedCount = createRequiredAgreementConsentsIfAbsent(admin);
+            if (updatedCount == 0) {
+                log.info("Sample admin member already exists. loginId={}", ADMIN_LOGIN_ID);
+            } else {
+                log.info("Sample admin member onboarding seed updated. loginId={}, updatedCount={}",
+                        ADMIN_LOGIN_ID, updatedCount);
+            }
+            return updatedCount;
         }
 
-        memberRepository.save(Member.builder()
+        Member admin = Member.builder()
                 .loginId(ADMIN_LOGIN_ID)
                 .passwordHash(passwordEncoder.encode(ADMIN_PASSWORD))
                 .nickname("matchuri-admin")
@@ -89,8 +125,26 @@ public class DevSampleDataInitializer {
                 .socialProviderUserId(null)
                 .memberRole(MemberRole.ADMIN)
                 .status(MemberStatus.ACTIVE)
-                .build());
+                .build();
+        memberRepository.save(admin);
+        createRequiredAgreementConsentsIfAbsent(admin);
         log.info("Sample admin member created. loginId={}", ADMIN_LOGIN_ID);
         return 1;
+    }
+
+    private int createRequiredAgreementConsentsIfAbsent(Member member) {
+        int createdCount = 0;
+        for (AgreementType agreementType : RequiredAgreementVersions.requiredTypes()) {
+            String agreementVersion = RequiredAgreementVersions.getRequiredVersion(agreementType);
+            if (!memberAgreementRepository.existsByMemberIdAndAgreementTypeAndAgreementVersion(
+                    member.getId(),
+                    agreementType,
+                    agreementVersion
+            )) {
+                memberAgreementRepository.save(MemberAgreement.create(member, agreementType, agreementVersion));
+                createdCount++;
+            }
+        }
+        return createdCount;
     }
 }

--- a/src/test/java/matchuri/backend/bootstrap/DevSampleDataInitializerTest.java
+++ b/src/test/java/matchuri/backend/bootstrap/DevSampleDataInitializerTest.java
@@ -1,0 +1,104 @@
+package matchuri.backend.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.repository.MemberRepository;
+import matchuri.backend.global.config.MatchuriProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class DevSampleDataInitializerTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private Environment environment;
+
+    @Test
+    @DisplayName("local 프로필이 아니면 고정 관리자 계정 시드를 생성하지 않는다")
+    void skipsAdminSeedWhenLocalProfileIsNotActive() {
+        MatchuriProperties properties = seedProperties(true, true);
+        when(memberRepository.existsByLoginId("tester01")).thenReturn(false);
+        when(memberRepository.existsByLoginId("tester02")).thenReturn(false);
+        when(environment.acceptsProfiles(any(Profiles.class))).thenReturn(false);
+
+        DevSampleDataInitializer initializer = new DevSampleDataInitializer(
+                memberRepository,
+                properties,
+                passwordEncoder,
+                environment
+        );
+
+        int createdCount = initializer.initialize();
+
+        assertThat(createdCount).isEqualTo(2);
+        verify(memberRepository, never()).existsByLoginId(DevSampleDataInitializer.ADMIN_LOGIN_ID);
+        verify(passwordEncoder, never()).encode(anyString());
+
+        ArgumentCaptor<Member> memberCaptor = ArgumentCaptor.forClass(Member.class);
+        verify(memberRepository, times(2)).save(memberCaptor.capture());
+        assertThat(memberCaptor.getAllValues())
+                .extracting(Member::getLoginId)
+                .containsExactly("tester01", "tester02");
+    }
+
+    @Test
+    @DisplayName("local 프로필이면 Swagger 수동 테스트용 관리자 계정 시드를 생성한다")
+    void createsAdminSeedWhenLocalProfileIsActive() {
+        MatchuriProperties properties = seedProperties(true, true);
+        when(memberRepository.existsByLoginId("tester01")).thenReturn(true);
+        when(memberRepository.existsByLoginId("tester02")).thenReturn(true);
+        when(environment.acceptsProfiles(any(Profiles.class))).thenReturn(true);
+        when(memberRepository.existsByLoginId(DevSampleDataInitializer.ADMIN_LOGIN_ID)).thenReturn(false);
+        when(passwordEncoder.encode(DevSampleDataInitializer.ADMIN_PASSWORD)).thenReturn("encoded-admin-password");
+
+        DevSampleDataInitializer initializer = new DevSampleDataInitializer(
+                memberRepository,
+                properties,
+                passwordEncoder,
+                environment
+        );
+
+        int createdCount = initializer.initialize();
+
+        assertThat(createdCount).isEqualTo(1);
+        verify(memberRepository).existsByLoginId(eq(DevSampleDataInitializer.ADMIN_LOGIN_ID));
+        verify(passwordEncoder).encode(DevSampleDataInitializer.ADMIN_PASSWORD);
+
+        ArgumentCaptor<Member> memberCaptor = ArgumentCaptor.forClass(Member.class);
+        verify(memberRepository).save(memberCaptor.capture());
+        Member admin = memberCaptor.getValue();
+        assertThat(admin.getLoginId()).isEqualTo(DevSampleDataInitializer.ADMIN_LOGIN_ID);
+        assertThat(admin.getPasswordHash()).isEqualTo("encoded-admin-password");
+        assertThat(admin.getMemberRole().name()).isEqualTo("ADMIN");
+    }
+
+    private MatchuriProperties seedProperties(boolean enabled, boolean sampleMembersEnabled) {
+        MatchuriProperties properties = new MatchuriProperties();
+        MatchuriProperties.Seed seed = new MatchuriProperties.Seed();
+        seed.setEnabled(enabled);
+        seed.setSampleMembersEnabled(sampleMembersEnabled);
+        properties.setSeed(seed);
+        return properties;
+    }
+}

--- a/src/test/java/matchuri/backend/bootstrap/DevSampleDataInitializerTest.java
+++ b/src/test/java/matchuri/backend/bootstrap/DevSampleDataInitializerTest.java
@@ -9,8 +9,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+import matchuri.backend.domain.member.entity.AgreementType;
 import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.entity.MemberAgreement;
+import matchuri.backend.domain.member.repository.MemberAgreementRepository;
 import matchuri.backend.domain.member.repository.MemberRepository;
+import matchuri.backend.domain.member.support.agreement.RequiredAgreementVersions;
 import matchuri.backend.global.config.MatchuriProperties;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,6 +34,9 @@ class DevSampleDataInitializerTest {
     private MemberRepository memberRepository;
 
     @Mock
+    private MemberAgreementRepository memberAgreementRepository;
+
+    @Mock
     private PasswordEncoder passwordEncoder;
 
     @Mock
@@ -38,12 +46,15 @@ class DevSampleDataInitializerTest {
     @DisplayName("local 프로필이 아니면 고정 관리자 계정 시드를 생성하지 않는다")
     void skipsAdminSeedWhenLocalProfileIsNotActive() {
         MatchuriProperties properties = seedProperties(true, true);
-        when(memberRepository.existsByLoginId("tester01")).thenReturn(false);
-        when(memberRepository.existsByLoginId("tester02")).thenReturn(false);
+        when(memberRepository.findByLoginId("tester01")).thenReturn(Optional.empty());
+        when(memberRepository.findByLoginId("tester02")).thenReturn(Optional.empty());
+        when(passwordEncoder.encode(DevSampleDataInitializer.SAMPLE_MEMBER_PASSWORD))
+                .thenReturn("encoded-sample-password");
         when(environment.acceptsProfiles(any(Profiles.class))).thenReturn(false);
 
         DevSampleDataInitializer initializer = new DevSampleDataInitializer(
                 memberRepository,
+                memberAgreementRepository,
                 properties,
                 passwordEncoder,
                 environment
@@ -53,27 +64,40 @@ class DevSampleDataInitializerTest {
 
         assertThat(createdCount).isEqualTo(2);
         verify(memberRepository, never()).existsByLoginId(DevSampleDataInitializer.ADMIN_LOGIN_ID);
-        verify(passwordEncoder, never()).encode(anyString());
+        verify(passwordEncoder, times(2)).encode(DevSampleDataInitializer.SAMPLE_MEMBER_PASSWORD);
 
         ArgumentCaptor<Member> memberCaptor = ArgumentCaptor.forClass(Member.class);
         verify(memberRepository, times(2)).save(memberCaptor.capture());
         assertThat(memberCaptor.getAllValues())
                 .extracting(Member::getLoginId)
                 .containsExactly("tester01", "tester02");
+        assertThat(memberCaptor.getAllValues())
+                .extracting(Member::getNickname)
+                .containsExactly("테스터일", "테스터이");
+        verify(memberAgreementRepository, times(RequiredAgreementVersions.requiredTypes().size() * 2))
+                .save(any(MemberAgreement.class));
     }
 
     @Test
     @DisplayName("local 프로필이면 Swagger 수동 테스트용 관리자 계정 시드를 생성한다")
     void createsAdminSeedWhenLocalProfileIsActive() {
         MatchuriProperties properties = seedProperties(true, true);
-        when(memberRepository.existsByLoginId("tester01")).thenReturn(true);
-        when(memberRepository.existsByLoginId("tester02")).thenReturn(true);
+        when(memberRepository.findByLoginId("tester01")).thenReturn(Optional.of(sampleMember("tester01", "테스터일")));
+        when(memberRepository.findByLoginId("tester02")).thenReturn(Optional.of(sampleMember("tester02", "테스터이")));
+        for (AgreementType agreementType : RequiredAgreementVersions.requiredTypes()) {
+            when(memberAgreementRepository.existsByMemberIdAndAgreementTypeAndAgreementVersion(
+                    any(),
+                    eq(agreementType),
+                    eq(RequiredAgreementVersions.getRequiredVersion(agreementType))
+            )).thenReturn(true);
+        }
         when(environment.acceptsProfiles(any(Profiles.class))).thenReturn(true);
         when(memberRepository.existsByLoginId(DevSampleDataInitializer.ADMIN_LOGIN_ID)).thenReturn(false);
         when(passwordEncoder.encode(DevSampleDataInitializer.ADMIN_PASSWORD)).thenReturn("encoded-admin-password");
 
         DevSampleDataInitializer initializer = new DevSampleDataInitializer(
                 memberRepository,
+                memberAgreementRepository,
                 properties,
                 passwordEncoder,
                 environment
@@ -91,6 +115,10 @@ class DevSampleDataInitializerTest {
         assertThat(admin.getLoginId()).isEqualTo(DevSampleDataInitializer.ADMIN_LOGIN_ID);
         assertThat(admin.getPasswordHash()).isEqualTo("encoded-admin-password");
         assertThat(admin.getMemberRole().name()).isEqualTo("ADMIN");
+    }
+
+    private Member sampleMember(String loginId, String nickname) {
+        return Member.createWithEncodedPassword(loginId, "encoded-sample-password", nickname, loginId + "@example.com");
     }
 
     private MatchuriProperties seedProperties(boolean enabled, boolean sampleMembersEnabled) {

--- a/src/test/java/matchuri/backend/bootstrap/SeedDataInitializerTest.java
+++ b/src/test/java/matchuri/backend/bootstrap/SeedDataInitializerTest.java
@@ -3,8 +3,11 @@ package matchuri.backend.bootstrap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.entity.AgreementType;
 import matchuri.backend.domain.member.entity.MemberRole;
+import matchuri.backend.domain.member.repository.MemberAgreementRepository;
 import matchuri.backend.domain.member.repository.MemberRepository;
+import matchuri.backend.domain.member.support.agreement.RequiredAgreementVersions;
 import matchuri.backend.domain.menu.entity.CategoryType;
 import matchuri.backend.domain.menu.entity.Ingredient;
 import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
@@ -34,6 +37,9 @@ class SeedDataInitializerTest {
     private MemberRepository memberRepository;
 
     @Autowired
+    private MemberAgreementRepository memberAgreementRepository;
+
+    @Autowired
     private PasswordEncoder passwordEncoder;
 
     @Autowired
@@ -55,6 +61,7 @@ class SeedDataInitializerTest {
     @DisplayName("local 프로필에서는 참조 데이터와 샘플 회원 시드가 멱등하게 초기화된다")
     void initializesReferenceAndSampleDataIdempotently() throws Exception {
         long initialCount = memberRepository.count();
+        long initialAgreementCount = memberAgreementRepository.count();
         long initialAttributeCategoryCount = attributeCategoryRepository.count();
         long initialIngredientCount = ingredientRepository.count();
         long initialMenuItemCount = menuItemRepository.count();
@@ -64,10 +71,22 @@ class SeedDataInitializerTest {
         assertThat(memberRepository.existsByLoginId("tester01")).isTrue();
         assertThat(memberRepository.existsByLoginId("tester02")).isTrue();
         assertThat(memberRepository.existsByLoginId("admin01")).isTrue();
+        Member tester01 = memberByLoginId("tester01");
+        Member tester02 = memberByLoginId("tester02");
+        assertThat(tester01.getNickname()).isEqualTo("테스터일");
+        assertThat(tester01.isNicknameCompleted()).isTrue();
+        assertThat(passwordEncoder.matches("Password123!", tester01.getPasswordHash())).isTrue();
+        assertThat(tester02.getNickname()).isEqualTo("테스터이");
+        assertThat(tester02.isNicknameCompleted()).isTrue();
+        assertThat(passwordEncoder.matches("Password123!", tester02.getPasswordHash())).isTrue();
         Member admin = memberByLoginId("admin01");
         assertThat(admin.getMemberRole()).isEqualTo(MemberRole.ADMIN);
         assertThat(admin.getNickname()).isEqualTo("matchuri-admin");
+        assertThat(admin.isNicknameCompleted()).isTrue();
         assertThat(passwordEncoder.matches("Admin123!", admin.getPasswordHash())).isTrue();
+        assertRequiredAgreementsCompleted(tester01);
+        assertRequiredAgreementsCompleted(tester02);
+        assertRequiredAgreementsCompleted(admin);
         assertThat(attributeCategoryRepository.existsByCategoryTypeAndCode(CategoryType.FLAVOR, "SPICY")).isTrue();
         assertThat(attributeCategoryRepository.existsByCategoryTypeAndCode(CategoryType.FLAVOR, "RICH")).isTrue();
         assertThat(attributeCategoryRepository.existsByCategoryTypeAndCode(CategoryType.COOKING_METHOD, "STIR_FRIED"))
@@ -106,6 +125,7 @@ class SeedDataInitializerTest {
         seedDataInitializer.run(new DefaultApplicationArguments(new String[0]));
 
         assertThat(memberRepository.count()).isEqualTo(initialCount);
+        assertThat(memberAgreementRepository.count()).isEqualTo(initialAgreementCount);
         assertThat(attributeCategoryRepository.count()).isEqualTo(initialAttributeCategoryCount);
         assertThat(ingredientRepository.count()).isEqualTo(initialIngredientCount);
         assertThat(menuItemRepository.count()).isEqualTo(initialMenuItemCount);
@@ -122,6 +142,16 @@ class SeedDataInitializerTest {
     private Member memberByLoginId(String loginId) {
         return memberRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new AssertionError("Expected member seed. loginId=" + loginId));
+    }
+
+    private void assertRequiredAgreementsCompleted(Member member) {
+        for (AgreementType agreementType : RequiredAgreementVersions.requiredTypes()) {
+            assertThat(memberAgreementRepository.existsByMemberIdAndAgreementTypeAndAgreementVersion(
+                    member.getId(),
+                    agreementType,
+                    RequiredAgreementVersions.getRequiredVersion(agreementType)
+            )).isTrue();
+        }
     }
 
     private Ingredient ingredientByCode(String code) {

--- a/src/test/java/matchuri/backend/bootstrap/SeedDataInitializerTest.java
+++ b/src/test/java/matchuri/backend/bootstrap/SeedDataInitializerTest.java
@@ -2,6 +2,8 @@ package matchuri.backend.bootstrap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.entity.MemberRole;
 import matchuri.backend.domain.member.repository.MemberRepository;
 import matchuri.backend.domain.menu.entity.CategoryType;
 import matchuri.backend.domain.menu.entity.Ingredient;
@@ -15,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.DefaultApplicationArguments;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(properties = {
@@ -29,6 +32,9 @@ class SeedDataInitializerTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
     @Autowired
     private AttributeCategoryRepository attributeCategoryRepository;
@@ -57,6 +63,11 @@ class SeedDataInitializerTest {
 
         assertThat(memberRepository.existsByLoginId("tester01")).isTrue();
         assertThat(memberRepository.existsByLoginId("tester02")).isTrue();
+        assertThat(memberRepository.existsByLoginId("admin01")).isTrue();
+        Member admin = memberByLoginId("admin01");
+        assertThat(admin.getMemberRole()).isEqualTo(MemberRole.ADMIN);
+        assertThat(admin.getNickname()).isEqualTo("matchuri-admin");
+        assertThat(passwordEncoder.matches("Admin123!", admin.getPasswordHash())).isTrue();
         assertThat(attributeCategoryRepository.existsByCategoryTypeAndCode(CategoryType.FLAVOR, "SPICY")).isTrue();
         assertThat(attributeCategoryRepository.existsByCategoryTypeAndCode(CategoryType.FLAVOR, "RICH")).isTrue();
         assertThat(attributeCategoryRepository.existsByCategoryTypeAndCode(CategoryType.COOKING_METHOD, "STIR_FRIED"))
@@ -102,9 +113,15 @@ class SeedDataInitializerTest {
         assertThat(menuIngredientRepository.count()).isEqualTo(initialMenuIngredientCount);
         assertThat(memberRepository.existsByLoginId("tester01")).isTrue();
         assertThat(memberRepository.existsByLoginId("tester02")).isTrue();
+        assertThat(memberRepository.existsByLoginId("admin01")).isTrue();
         assertThat(attributeCategoryRepository.existsByCategoryTypeAndCode(CategoryType.FLAVOR, "SPICY")).isTrue();
         assertThat(ingredientRepository.existsByCode("PEANUT")).isTrue();
         assertThat(menuItemRepository.existsByCode("KIMCHI_STEW")).isTrue();
+    }
+
+    private Member memberByLoginId(String loginId) {
+        return memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new AssertionError("Expected member seed. loginId=" + loginId));
     }
 
     private Ingredient ingredientByCode(String code) {


### PR DESCRIPTION
## 관련 이슈
Closes #155 

## 📝 작업 내용
- 개발 편의성을 위해 어드민 계정 추가
- 로컬 환경에서만 이니셜라이즈
- 배포 환경에서 어떻게 운영할지 추후 운영정책 전략을 확정할 필요가 있음

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
