### PR TITLE
[Feat] 카테고리 타입에 MEAL_TIME 추가

### DIFF
--- a/src/main/java/matchuri/backend/bootstrap/ReferenceDataInitializer.java
+++ b/src/main/java/matchuri/backend/bootstrap/ReferenceDataInitializer.java
@@ -98,6 +98,11 @@ public class ReferenceDataInitializer {
         createdCount += createAttributeCategoryIfAbsent(CategoryType.TEMPERATURE, "HOT", "뜨거움", 10);
         createdCount += createAttributeCategoryIfAbsent(CategoryType.TEMPERATURE, "COLD", "차가움", 20);
 
+        createdCount += createAttributeCategoryIfAbsent(CategoryType.MEAL_TIME, "BREAKFAST", "아침", 10);
+        createdCount += createAttributeCategoryIfAbsent(CategoryType.MEAL_TIME, "LUNCH", "점심", 20);
+        createdCount += createAttributeCategoryIfAbsent(CategoryType.MEAL_TIME, "DINNER", "저녁", 30);
+        createdCount += createAttributeCategoryIfAbsent(CategoryType.MEAL_TIME, "NIGHT_SNACK", "야식", 40);
+
         return createdCount;
     }
 

--- a/src/main/java/matchuri/backend/domain/menu/entity/CategoryType.java
+++ b/src/main/java/matchuri/backend/domain/menu/entity/CategoryType.java
@@ -5,5 +5,6 @@ public enum CategoryType {
     COOKING_METHOD,
     FOOD_CATEGORY,
     TEXTURE,
-    TEMPERATURE
+    TEMPERATURE,
+    MEAL_TIME
 }


### PR DESCRIPTION
## 관련 이슈
Closes #157 

## 📝 작업 내용

```java
public enum CategoryType {
    FLAVOR,
    COOKING_METHOD,
    FOOD_CATEGORY,
    TEXTURE,
    TEMPERATURE,
    MEAL_TIME // 추가
}
```

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [x] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항

- 식사 시간대로 범위가 좁혀졌기에 `MEAL_TIME`으로 작명했습니다.
- 카테고리 조회시 json 응답값은 다음과 같습니다.

```json
{
  "success": true,
  "data": [
    {
      "id": 27,
      "categoryType": "MEAL_TIME",
      "code": "BREAKFAST",
      "name": "아침",
      "sortOrder": 10
    },
    {
      "id": 28,
      "categoryType": "MEAL_TIME",
      "code": "LUNCH",
      "name": "점심",
      "sortOrder": 20
    },
    {
      "id": 29,
      "categoryType": "MEAL_TIME",
      "code": "DINNER",
      "name": "저녁",
      "sortOrder": 30
    },
    {
      "id": 30,
      "categoryType": "MEAL_TIME",
      "code": "NIGHT_SNACK",
      "name": "야식",
      "sortOrder": 40
    }
  ],
  "error": null
}
```
