### PR TITLE
[Refactor] 내 프로필 조회 API 응답값에 email 추가

### DIFF
--- a/src/main/java/matchuri/backend/api/auth/dto/request/LoginRequest.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/request/LoginRequest.java
@@ -8,7 +8,7 @@ import matchuri.backend.domain.member.entity.Member;
 public record LoginRequest(
         @Schema(
                 description = "일반 로그인에 사용하는 loginId입니다.",
-                example = "tester01",
+                example = "admin01",
                 maxLength = Member.LOGIN_ID_MAX_SIZE
         )
         @NotBlank(message = "loginId는 비어 있을 수 없습니다.")
@@ -17,7 +17,7 @@ public record LoginRequest(
 
         @Schema(
                 description = "일반 로그인 비밀번호입니다. 평문은 요청 시에만 사용되며 서버에는 해시로 저장됩니다.",
-                example = "P@ssw0rd!",
+                example = "Admin123!",
                 minLength = Member.PASSWORD_MIN_SIZE,
                 maxLength = Member.PASSWORD_MAX_SIZE
         )

--- a/src/main/java/matchuri/backend/api/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/matchuri/backend/api/member/dto/response/MemberProfileResponse.java
@@ -10,6 +10,9 @@ public record MemberProfileResponse(
         String nickname,
 
         @Schema(description = "현재 로그인한 회원의 소셜 여부입니다.", example = "true")
-        boolean isSocial
+        boolean isSocial,
+
+        @Schema(description = "현재 로그인한 회원의 이메일입니다.", example = "test01@example.com")
+        String email
 ) {
 }

--- a/src/main/java/matchuri/backend/api/member/mapper/MemberMapper.java
+++ b/src/main/java/matchuri/backend/api/member/mapper/MemberMapper.java
@@ -103,7 +103,7 @@ public class MemberMapper {
     }
 
     public MemberProfileResponse toMemberProfileResponse(MemberProfileResult result) {
-        return new MemberProfileResponse(result.id(), result.nickname(), result.isSocial());
+        return new MemberProfileResponse(result.id(), result.nickname(), result.isSocial(), result.email());
     }
 
     public MemberTasteProfileSummaryResponse toMemberTasteProfileSummaryResponse(

--- a/src/main/java/matchuri/backend/domain/member/result/MemberProfileResult.java
+++ b/src/main/java/matchuri/backend/domain/member/result/MemberProfileResult.java
@@ -5,14 +5,16 @@ import matchuri.backend.domain.member.entity.Member;
 public record MemberProfileResult(
         Long id,
         String nickname,
-        boolean isSocial
+        boolean isSocial,
+        String email
 ) {
 
     public static MemberProfileResult from(Member member) {
         return new MemberProfileResult(
                 member.getId(),
                 member.getNickname(),
-                member.isSocial()
+                member.isSocial(),
+                member.getEmail()
         );
     }
 }


### PR DESCRIPTION
## 관련 이슈
Closes #158 

## 📝 작업 내용
- `GET /api/v1/members/me`에 `email`도 응답하도록 수정

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항

```json
{
  "success": true,
  "data": {
    "id": 3,
    "nickname": "matchuri-admin",
    "isSocial": false,
    "email": "admin01@example.com"
  },
  "error": null
}
```
