### PR TITLE
[Feat] 비밀번호 변경 API 구현

### DIFF
--- a/src/main/java/matchuri/backend/api/auth/AccountRecoveryApi.java
+++ b/src/main/java/matchuri/backend/api/auth/AccountRecoveryApi.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import matchuri.backend.api.auth.dto.docs.FindLoginIdApiResponse;
 import matchuri.backend.api.auth.dto.docs.ResetPasswordApiResponse;
@@ -115,6 +116,7 @@ public interface AccountRecoveryApi {
                     - token의 `loginId`, `email`이 요청 계정과 일치해야 합니다.
                     - 성공 시 token은 사용 완료 처리되어 재사용할 수 없습니다.
                     - 성공 시 해당 회원의 기존 refresh token 전체를 폐기합니다.
+                    - 성공 시 현재 응답의 refresh token cookie도 만료시킵니다.
                     - 비밀번호 재설정 후 자동 로그인하거나 access token을 발급하지 않습니다.
                     """
     )
@@ -191,5 +193,8 @@ public interface AccountRecoveryApi {
                     )
             )
     })
-    ApiResponse<ResetPasswordResponse> resetPassword(@Valid @RequestBody ResetPasswordRequest request);
+    ApiResponse<ResetPasswordResponse> resetPassword(
+                    @Valid @RequestBody ResetPasswordRequest request,
+            HttpServletResponse httpResponse
+    );
 }

--- a/src/main/java/matchuri/backend/api/auth/AccountRecoveryController.java
+++ b/src/main/java/matchuri/backend/api/auth/AccountRecoveryController.java
@@ -1,13 +1,15 @@
 package matchuri.backend.api.auth;
 
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import matchuri.backend.api.auth.mapper.AuthMapper;
 import matchuri.backend.api.auth.dto.request.FindLoginIdRequest;
 import matchuri.backend.api.auth.dto.request.ResetPasswordRequest;
 import matchuri.backend.api.auth.dto.response.FindLoginIdResponse;
 import matchuri.backend.api.auth.dto.response.ResetPasswordResponse;
+import matchuri.backend.api.auth.mapper.AuthMapper;
 import matchuri.backend.domain.auth.service.AccountRecoveryService;
+import matchuri.backend.domain.auth.support.token.RefreshTokenCookieService;
 import matchuri.backend.global.api.ApiResponse;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,6 +23,7 @@ public class AccountRecoveryController implements AccountRecoveryApi {
 
     private final AccountRecoveryService accountRecoveryService;
     private final AuthMapper authMapper;
+    private final RefreshTokenCookieService refreshTokenCookieService;
 
     @Override
     @PostMapping("/login-id")
@@ -32,9 +35,13 @@ public class AccountRecoveryController implements AccountRecoveryApi {
 
     @Override
     @PostMapping("/password")
-    public ApiResponse<ResetPasswordResponse> resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
+    public ApiResponse<ResetPasswordResponse> resetPassword(
+            @Valid @RequestBody ResetPasswordRequest request,
+            HttpServletResponse httpResponse
+    ) {
         var command = authMapper.toResetPasswordCommand(request);
         var result = accountRecoveryService.resetPassword(command);
+        refreshTokenCookieService.clearRefreshToken(httpResponse);
         return ApiResponse.success(authMapper.toResetPasswordResponse(result));
     }
 }

--- a/src/main/java/matchuri/backend/api/member/MemberApi.java
+++ b/src/main/java/matchuri/backend/api/member/MemberApi.java
@@ -15,9 +15,11 @@ import matchuri.backend.api.member.dto.docs.MemberProfileApiResponse;
 import matchuri.backend.api.member.dto.docs.MemberTasteProfileSummaryApiResponse;
 import matchuri.backend.api.member.dto.docs.NicknameExistsApiResponse;
 import matchuri.backend.api.member.dto.docs.RegisterLocalMemberApiResponse;
+import matchuri.backend.api.member.dto.docs.UpdateMemberPasswordApiResponse;
 import matchuri.backend.api.member.dto.request.CreateMemberRequest;
 import matchuri.backend.api.member.dto.request.RegisterLocalMemberRequest;
 import matchuri.backend.api.member.dto.request.UpdateMemberBasicInfoRequest;
+import matchuri.backend.api.member.dto.request.UpdateMemberPasswordRequest;
 import matchuri.backend.api.member.dto.request.UpdateMemberTasteProfileRequest;
 import matchuri.backend.api.member.dto.response.CreateMemberResponse;
 import matchuri.backend.api.member.dto.response.LoginIdExistsResponse;
@@ -25,6 +27,7 @@ import matchuri.backend.api.member.dto.response.MemberProfileResponse;
 import matchuri.backend.api.member.dto.response.MemberTasteProfileSummaryResponse;
 import matchuri.backend.api.member.dto.response.NicknameExistsResponse;
 import matchuri.backend.api.member.dto.response.RegisterLocalMemberResponse;
+import matchuri.backend.api.member.dto.response.UpdateMemberPasswordResponse;
 import matchuri.backend.api.member.dto.response.UpdateMemberResponse;
 import matchuri.backend.api.member.dto.response.WithdrawMemberResponse;
 import matchuri.backend.global.api.ApiResponse;
@@ -564,6 +567,73 @@ public interface MemberApi {
                     - 성공 시 최신 수정 시각(`updatedAt`)을 반환합니다.
                     """)
     ApiResponse<UpdateMemberResponse> updateMyProfile(UpdateMemberBasicInfoRequest request);
+
+    @Operation(
+            summary = "내 비밀번호 변경",
+            description = """
+                    현재 로그인한 자체 로그인 회원의 비밀번호를 변경합니다.
+                    
+                    - `currentPassword`가 현재 비밀번호와 일치해야 합니다.
+                    - 성공 시 현재 access token과 refresh token은 유지됩니다.
+                    - 계정 복구용 비밀번호 재설정과 달리 모든 세션을 로그아웃시키지 않습니다.
+                    - 소셜 로그인 전용 회원은 현재 단계에서 비밀번호 변경 대상이 아닙니다.
+                    """)
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "비밀번호 변경 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = UpdateMemberPasswordApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "data": {
+                                                "passwordChanged": true
+                                              },
+                                              "error": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "요청 바디 형식 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(name = "invalidBodyField", value = ErrorExamples.COMMON_INVALID_BODY_FIELD)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken이 없거나 현재 비밀번호가 일치하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "tokenMissing", value = ErrorExamples.AUTH_TOKEN_MISSING),
+                                    @ExampleObject(
+                                            name = "invalidPassword",
+                                            value = """
+                                                    {
+                                                      "success": false,
+                                                      "data": null,
+                                                      "error": {
+                                                        "status": 401,
+                                                        "code": "MEMBER_INVALID_PASSWORD",
+                                                        "message": "비밀번호가 일치하지 않습니다.",
+                                                        "details": []
+                                                      }
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+    })
+    ApiResponse<UpdateMemberPasswordResponse> updateMyPassword(UpdateMemberPasswordRequest request);
 
     @Operation(
             summary = "내 취향 프로필 전체 교체 저장",

--- a/src/main/java/matchuri/backend/api/member/MemberController.java
+++ b/src/main/java/matchuri/backend/api/member/MemberController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import matchuri.backend.api.member.dto.request.CreateMemberRequest;
 import matchuri.backend.api.member.dto.request.RegisterLocalMemberRequest;
 import matchuri.backend.api.member.dto.request.UpdateMemberBasicInfoRequest;
+import matchuri.backend.api.member.dto.request.UpdateMemberPasswordRequest;
 import matchuri.backend.api.member.dto.request.UpdateMemberTasteProfileRequest;
 import matchuri.backend.api.member.dto.response.CreateMemberResponse;
 import matchuri.backend.api.member.dto.response.LoginIdExistsResponse;
@@ -12,6 +13,7 @@ import matchuri.backend.api.member.dto.response.MemberProfileResponse;
 import matchuri.backend.api.member.dto.response.MemberTasteProfileSummaryResponse;
 import matchuri.backend.api.member.dto.response.NicknameExistsResponse;
 import matchuri.backend.api.member.dto.response.RegisterLocalMemberResponse;
+import matchuri.backend.api.member.dto.response.UpdateMemberPasswordResponse;
 import matchuri.backend.api.member.dto.response.UpdateMemberResponse;
 import matchuri.backend.api.member.dto.response.WithdrawMemberResponse;
 import matchuri.backend.api.member.mapper.MemberMapper;
@@ -104,6 +106,18 @@ public class MemberController implements MemberApi {
         var command = memberMapper.toUpdateMemberBasicInfoCommand(request.nickname());
         var result = memberService.updateMyProfile(command);
         UpdateMemberResponse response = memberMapper.toUpdateMemberResponse(result);
+
+        return ApiResponse.success(response);
+    }
+
+    @Override
+    @PatchMapping("/me/password")
+    public ApiResponse<UpdateMemberPasswordResponse> updateMyPassword(
+            @Valid @RequestBody UpdateMemberPasswordRequest request
+    ) {
+        var command = memberMapper.toUpdateMemberPasswordCommand(request);
+        var result = memberService.updateMyPassword(command);
+        UpdateMemberPasswordResponse response = memberMapper.toUpdateMemberPasswordResponse(result);
 
         return ApiResponse.success(response);
     }

--- a/src/main/java/matchuri/backend/api/member/dto/docs/UpdateMemberPasswordApiResponse.java
+++ b/src/main/java/matchuri/backend/api/member/dto/docs/UpdateMemberPasswordApiResponse.java
@@ -1,0 +1,18 @@
+package matchuri.backend.api.member.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.member.dto.response.UpdateMemberPasswordResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "내 비밀번호 변경 API의 공통 응답 envelope입니다.")
+public record UpdateMemberPasswordApiResponse(
+        @Schema(description = "요청 성공 여부입니다.", example = "true")
+        boolean success,
+
+        @Schema(description = "성공 시 반환되는 비밀번호 변경 payload입니다.")
+        UpdateMemberPasswordResponse data,
+
+        @Schema(description = "실패 시 반환되는 에러 정보입니다.")
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/member/dto/request/UpdateMemberPasswordRequest.java
+++ b/src/main/java/matchuri/backend/api/member/dto/request/UpdateMemberPasswordRequest.java
@@ -1,0 +1,53 @@
+package matchuri.backend.api.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import matchuri.backend.domain.member.entity.Member;
+
+@Schema(
+        name = "UpdateMemberPasswordRequest",
+        example = """
+                {
+                  "currentPassword": "P@ssw0rd!",
+                  "newPassword": "N3wP@ssw0rd!"
+                }
+                """
+)
+public record UpdateMemberPasswordRequest(
+        @Schema(
+                description = "현재 사용 중인 비밀번호입니다.",
+                example = "P@ssw0rd!",
+                minLength = Member.PASSWORD_MIN_SIZE,
+                maxLength = Member.PASSWORD_MAX_SIZE
+        )
+        @NotBlank(message = "currentPassword는 비어 있을 수 없습니다.")
+        @Size(
+                min = Member.PASSWORD_MIN_SIZE,
+                max = Member.PASSWORD_MAX_SIZE,
+                message = "currentPassword는 " + Member.PASSWORD_MIN_SIZE + "자 이상 "
+                        + Member.PASSWORD_MAX_SIZE + "자 이하여야 합니다."
+        )
+        String currentPassword,
+
+        @Schema(
+                description = "새 비밀번호입니다. 영문자, 숫자, 특수문자를 각각 1개 이상 포함해야 합니다.",
+                example = "N3wP@ssw0rd!",
+                minLength = Member.PASSWORD_MIN_SIZE,
+                maxLength = Member.PASSWORD_MAX_SIZE
+        )
+        @NotBlank(message = "newPassword는 비어 있을 수 없습니다.")
+        @Size(
+                min = Member.PASSWORD_MIN_SIZE,
+                max = Member.PASSWORD_MAX_SIZE,
+                message = "newPassword는 " + Member.PASSWORD_MIN_SIZE + "자 이상 "
+                        + Member.PASSWORD_MAX_SIZE + "자 이하여야 합니다."
+        )
+        @Pattern(
+                regexp = Member.PASSWORD_PATTERN,
+                message = "비밀번호는 " + Member.PASSWORD_MIN_SIZE + "자 이상이며 영문자, 숫자, 특수문자를 각각 1개 이상 포함해야 합니다."
+        )
+        String newPassword
+) {
+}

--- a/src/main/java/matchuri/backend/api/member/dto/response/UpdateMemberPasswordResponse.java
+++ b/src/main/java/matchuri/backend/api/member/dto/response/UpdateMemberPasswordResponse.java
@@ -1,0 +1,10 @@
+package matchuri.backend.api.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "비밀번호 변경 응답입니다.")
+public record UpdateMemberPasswordResponse(
+        @Schema(description = "비밀번호 변경 성공 여부입니다.", example = "true")
+        boolean passwordChanged
+) {
+}

--- a/src/main/java/matchuri/backend/api/member/mapper/MemberMapper.java
+++ b/src/main/java/matchuri/backend/api/member/mapper/MemberMapper.java
@@ -4,6 +4,7 @@ import matchuri.backend.api.auth.dto.response.LoginResponse;
 import matchuri.backend.api.auth.dto.response.LogoutResponse;
 import matchuri.backend.api.common.dto.OnboardingStatusResponse;
 import matchuri.backend.api.member.dto.request.RegisterLocalMemberRequest;
+import matchuri.backend.api.member.dto.request.UpdateMemberPasswordRequest;
 import matchuri.backend.api.member.dto.request.UpdateMemberTasteProfileRequest;
 import matchuri.backend.api.member.dto.response.CreateMemberResponse;
 import matchuri.backend.api.member.dto.response.LoginIdExistsResponse;
@@ -14,6 +15,7 @@ import matchuri.backend.api.member.dto.response.MemberTasteProfileSummaryRespons
 import matchuri.backend.api.member.dto.response.MemberTasteRestrictionIngredientResponse;
 import matchuri.backend.api.member.dto.response.NicknameExistsResponse;
 import matchuri.backend.api.member.dto.response.RegisterLocalMemberResponse;
+import matchuri.backend.api.member.dto.response.UpdateMemberPasswordResponse;
 import matchuri.backend.api.member.dto.response.UpdateMemberResponse;
 import matchuri.backend.api.member.dto.response.WithdrawMemberResponse;
 import matchuri.backend.domain.auth.command.LoginCommand;
@@ -24,6 +26,7 @@ import matchuri.backend.domain.member.command.CreateMemberCommand;
 import matchuri.backend.domain.member.command.RegisterLocalMemberCommand;
 import matchuri.backend.domain.member.command.SubmitRequiredAgreementsCommand;
 import matchuri.backend.domain.member.command.UpdateMemberBasicInfoCommand;
+import matchuri.backend.domain.member.command.UpdateMemberPasswordCommand;
 import matchuri.backend.domain.member.command.UpdateMemberTasteProfileCommand;
 import matchuri.backend.domain.member.entity.SocialProviderType;
 import matchuri.backend.domain.member.result.CreateMemberResult;
@@ -31,6 +34,7 @@ import matchuri.backend.domain.member.result.MemberProfileResult;
 import matchuri.backend.domain.member.result.MemberTasteProfileSummaryResult;
 import matchuri.backend.domain.member.result.OnboardingStatusResult;
 import matchuri.backend.domain.member.result.RegisterLocalMemberResult;
+import matchuri.backend.domain.member.result.UpdateMemberPasswordResult;
 import matchuri.backend.domain.member.result.UpdateMemberResult;
 import matchuri.backend.domain.member.result.WithdrawMemberResult;
 import org.springframework.stereotype.Component;
@@ -142,6 +146,14 @@ public class MemberMapper {
 
     public UpdateMemberBasicInfoCommand toUpdateMemberBasicInfoCommand(String nickname) {
         return new UpdateMemberBasicInfoCommand(nickname);
+    }
+
+    public UpdateMemberPasswordCommand toUpdateMemberPasswordCommand(UpdateMemberPasswordRequest request) {
+        return new UpdateMemberPasswordCommand(request.currentPassword(), request.newPassword());
+    }
+
+    public UpdateMemberPasswordResponse toUpdateMemberPasswordResponse(UpdateMemberPasswordResult result) {
+        return new UpdateMemberPasswordResponse(result.passwordChanged());
     }
 
     public UpdateMemberTasteProfileCommand toUpdateMemberTasteProfileCommand(UpdateMemberTasteProfileRequest request) {

--- a/src/main/java/matchuri/backend/domain/member/command/UpdateMemberPasswordCommand.java
+++ b/src/main/java/matchuri/backend/domain/member/command/UpdateMemberPasswordCommand.java
@@ -1,0 +1,7 @@
+package matchuri.backend.domain.member.command;
+
+public record UpdateMemberPasswordCommand(
+        String currentPassword,
+        String newPassword
+) {
+}

--- a/src/main/java/matchuri/backend/domain/member/result/UpdateMemberPasswordResult.java
+++ b/src/main/java/matchuri/backend/domain/member/result/UpdateMemberPasswordResult.java
@@ -1,0 +1,10 @@
+package matchuri.backend.domain.member.result;
+
+public record UpdateMemberPasswordResult(
+        boolean passwordChanged
+) {
+
+    public static UpdateMemberPasswordResult success() {
+        return new UpdateMemberPasswordResult(true);
+    }
+}

--- a/src/main/java/matchuri/backend/domain/member/service/MemberService.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberService.java
@@ -3,11 +3,13 @@ package matchuri.backend.domain.member.service;
 import matchuri.backend.domain.member.command.CreateMemberCommand;
 import matchuri.backend.domain.member.command.RegisterLocalMemberCommand;
 import matchuri.backend.domain.member.command.UpdateMemberBasicInfoCommand;
+import matchuri.backend.domain.member.command.UpdateMemberPasswordCommand;
 import matchuri.backend.domain.member.command.UpdateMemberTasteProfileCommand;
 import matchuri.backend.domain.member.result.CreateMemberResult;
 import matchuri.backend.domain.member.result.MemberProfileResult;
 import matchuri.backend.domain.member.result.MemberTasteProfileSummaryResult;
 import matchuri.backend.domain.member.result.RegisterLocalMemberResult;
+import matchuri.backend.domain.member.result.UpdateMemberPasswordResult;
 import matchuri.backend.domain.member.result.UpdateMemberResult;
 import matchuri.backend.domain.member.result.WithdrawMemberResult;
 
@@ -26,6 +28,8 @@ public interface MemberService {
     MemberTasteProfileSummaryResult getMyTasteProfile();
 
     UpdateMemberResult updateMyProfile(UpdateMemberBasicInfoCommand command);
+
+    UpdateMemberPasswordResult updateMyPassword(UpdateMemberPasswordCommand command);
 
     MemberTasteProfileSummaryResult updateMyTasteProfile(UpdateMemberTasteProfileCommand command);
 

--- a/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
@@ -10,6 +10,7 @@ import matchuri.backend.domain.auth.support.verification.EmailVerificationTokenV
 import matchuri.backend.domain.member.command.CreateMemberCommand;
 import matchuri.backend.domain.member.command.RegisterLocalMemberCommand;
 import matchuri.backend.domain.member.command.UpdateMemberBasicInfoCommand;
+import matchuri.backend.domain.member.command.UpdateMemberPasswordCommand;
 import matchuri.backend.domain.member.command.UpdateMemberTasteProfileCommand;
 import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.entity.MemberAgreement;
@@ -29,6 +30,7 @@ import matchuri.backend.domain.member.result.CreateMemberResult;
 import matchuri.backend.domain.member.result.MemberProfileResult;
 import matchuri.backend.domain.member.result.MemberTasteProfileSummaryResult;
 import matchuri.backend.domain.member.result.RegisterLocalMemberResult;
+import matchuri.backend.domain.member.result.UpdateMemberPasswordResult;
 import matchuri.backend.domain.member.result.UpdateMemberResult;
 import matchuri.backend.domain.member.result.WithdrawMemberResult;
 import matchuri.backend.domain.member.support.agreement.RequiredAgreementRequestValidator;
@@ -151,6 +153,20 @@ public class MemberServiceImpl implements MemberService {
         }
 
         return UpdateMemberResult.from(member, onboardingStatusResolver.resolve(member));
+    }
+
+    @Override
+    @Transactional
+    public UpdateMemberPasswordResult updateMyPassword(UpdateMemberPasswordCommand command) {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+
+        if (member.getPasswordHash() == null
+                || !passwordEncoder.matches(command.currentPassword(), member.getPasswordHash())) {
+            throw new BusinessException(MemberErrorCode.INVALID_PASSWORD);
+        }
+
+        member.updatePasswordHash(passwordEncoder.encode(command.newPassword()));
+        return UpdateMemberPasswordResult.success();
     }
 
     @Override

--- a/src/test/java/matchuri/backend/api/auth/AccountRecoveryIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/auth/AccountRecoveryIntegrationTest.java
@@ -1,7 +1,9 @@
 package matchuri.backend.api.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -23,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
@@ -164,6 +167,7 @@ class AccountRecoveryIntegrationTest {
         String token = issueResetPasswordToken("tester@example.com", "tester01");
 
         mockMvc.perform(post("/api/v1/auth/recovery/password")
+                        .cookie(new Cookie("matchuri_refresh_token", "old-refresh-token"))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
@@ -173,6 +177,8 @@ class AccountRecoveryIntegrationTest {
                                 }
                                 """.formatted(token)))
                 .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("matchuri_refresh_token=")))
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("Max-Age=0")))
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.reset").value(true));
 

--- a/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
@@ -361,6 +361,89 @@ class MemberAuthIntegrationTest {
     }
 
     @Test
+    @DisplayName("로그인 상태 비밀번호 변경 API는 현재 세션을 유지한 채 비밀번호만 교체한다")
+    void updateMyPasswordKeepsCurrentSession() throws Exception {
+        createMemberThroughApi("password-user", "P@ssw0rd!");
+        AuthSession authSession = login("password-user", "P@ssw0rd!");
+        String accessToken = submitRequiredAgreements(authSession.accessToken());
+        String refreshToken = authSession.refreshTokenCookie().getValue();
+
+        mockMvc.perform(patch("/api/v1/members/me/password")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "currentPassword": "P@ssw0rd!",
+                                  "newPassword": "N3wP@ssw0rd!"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.passwordChanged").value(true))
+                .andExpect(header().doesNotExist(HttpHeaders.SET_COOKIE));
+
+        assertThat(authRefreshTokenRepository.findByToken(refreshToken)).isPresent();
+
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .cookie(authSession.refreshTokenCookie()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").isString());
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "loginId": "password-user",
+                                  "password": "P@ssw0rd!"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("AUTH_LOGIN_FAILED"));
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "loginId": "password-user",
+                                  "password": "N3wP@ssw0rd!"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").isString());
+    }
+
+    @Test
+    @DisplayName("로그인 상태 비밀번호 변경 API는 현재 비밀번호가 다르면 거절한다")
+    void updateMyPasswordRejectsWrongCurrentPassword() throws Exception {
+        createMemberThroughApi("password-fail-user", "P@ssw0rd!");
+        AuthSession authSession = login("password-fail-user", "P@ssw0rd!");
+        String accessToken = submitRequiredAgreements(authSession.accessToken());
+
+        mockMvc.perform(patch("/api/v1/members/me/password")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "currentPassword": "Wr0ngP@ss!",
+                                  "newPassword": "N3wP@ssw0rd!"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("MEMBER_INVALID_PASSWORD"));
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "loginId": "password-fail-user",
+                                  "password": "P@ssw0rd!"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").isString());
+    }
+
+    @Test
     @DisplayName("로그아웃은 refresh token만 폐기하고 access token은 만료 전까지 유지된다")
     void memberAuthLifecycle() throws Exception {
         createMemberThroughApi("tester01", "P@ssw0rd!");


### PR DESCRIPTION
## 관련 이슈
Closes #166 

## 📝 작업 내용
- `GET /api/v1/members/me/password` 구현

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항

