### PR TITLE
[Docs] 마이페이지 API 변경점에 대한 명세 수정 및 테스트 보강

### DIFF
--- a/src/main/java/matchuri/backend/api/member/MemberApi.java
+++ b/src/main/java/matchuri/backend/api/member/MemberApi.java
@@ -395,8 +395,9 @@ public interface MemberApi {
                     현재 로그인한 회원의 기본 프로필 정보를 조회합니다.
                     
                     - `Authorization: Bearer <accessToken>` 헤더가 필요합니다.
-                    - 현재 단계에서는 최소 프로필과 로그인 유형 판단에 필요한 `id`, `nickname`, `isSocial`, `email`을 반환합니다.
-                    - `loginId`, 취향 프로필 상세 필드는 이 응답에 포함되지 않습니다.
+                    - 현재 단계에서는 최소 프로필과 로그인 유형 판단에 필요한 `id`, `loginId`, `nickname`, `isSocial`, `email`을 반환합니다.
+                    - 소셜 로그인 전용 회원은 `loginId`가 `null`일 수 있습니다.
+                    - 취향 프로필 상세 필드는 이 응답에 포함되지 않습니다.
                     """)
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -412,8 +413,9 @@ public interface MemberApi {
                                               "success": true,
                                               "data": {
                                                 "id": 1,
+                                                "loginId": "tester01",
                                                 "nickname": "점심탐험가",
-                                                "isSocial": true,
+                                                "isSocial": false,
                                                 "email": "tester@example.com"
                                               },
                                               "error": null

--- a/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
@@ -189,6 +189,7 @@ class MemberAuthIntegrationTest {
         mockMvc.perform(get("/api/v1/members/me")
                         .header(HttpHeaders.AUTHORIZATION, bearer(authSession.accessToken())))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.loginId").value("signup-user"))
                 .andExpect(jsonPath("$.data.nickname").value("점심탐험가"))
                 .andExpect(jsonPath("$.data.isSocial").value(false))
                 .andExpect(jsonPath("$.data.email").value("signup@example.com"));
@@ -464,7 +465,7 @@ class MemberAuthIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.id").isNumber())
                 .andExpect(jsonPath("$.data.nickname").value(nullValue()))
-                .andExpect(jsonPath("$.data.loginId").doesNotExist())
+                .andExpect(jsonPath("$.data.loginId").value("tester01"))
                 .andExpect(jsonPath("$.data.email").doesNotExist())
                 .andExpect(jsonPath("$.data.memberTasteProfile").doesNotExist());
 
@@ -991,6 +992,7 @@ class MemberAuthIntegrationTest {
         mockMvc.perform(get("/api/v1/members/me")
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken)))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.loginId").value(nullValue()))
                 .andExpect(jsonPath("$.data.nickname").value("점심결정러"))
                 .andExpect(jsonPath("$.data.isSocial").value(true));
     }

--- a/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
+++ b/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
@@ -33,6 +33,7 @@ import matchuri.backend.domain.member.repository.MemberTasteProfileCategoryRepos
 import matchuri.backend.domain.member.repository.MemberTasteProfileDislikedMenuItemRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileRestrictionIngredientRepository;
+import matchuri.backend.domain.member.result.MemberProfileResult;
 import matchuri.backend.domain.member.result.MemberTasteProfileSummaryResult;
 import matchuri.backend.domain.member.result.OnboardingNextStep;
 import matchuri.backend.domain.member.result.OnboardingStatusResult;
@@ -213,6 +214,30 @@ class MemberServiceImplTest {
         assertThat(result.onboarding().nextStep()).isEqualTo(OnboardingNextStep.READY);
         assertThat(member.getNickname()).isEqualTo("현재닉네임");
         verify(memberRepository).flush();
+    }
+
+    @Test
+    @DisplayName("내 프로필 조회는 현재 회원의 loginId를 함께 반환한다")
+    void getMyProfileReturnsLoginId() {
+        Member member = Member.builder()
+                .id(1L)
+                .loginId("tester01")
+                .nickname("점심탐험가")
+                .email("tester@example.com")
+                .memberRole(MemberRole.MEMBER)
+                .status(MemberStatus.ACTIVE)
+                .social(false)
+                .build();
+
+        when(activeMemberReader.getCurrentAuthenticatedActiveMember()).thenReturn(member);
+
+        MemberProfileResult result = memberService.getMyProfile();
+
+        assertThat(result.id()).isEqualTo(1L);
+        assertThat(result.loginId()).isEqualTo("tester01");
+        assertThat(result.nickname()).isEqualTo("점심탐험가");
+        assertThat(result.isSocial()).isFalse();
+        assertThat(result.email()).isEqualTo("tester@example.com");
     }
 
     @Test

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -160,8 +160,14 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/members/me'].get.responses['200'].content['application/json'].examples.success.value.data.email")
                         .value("tester@example.com"))
                 .andExpect(jsonPath(
+                        "$.paths['/api/v1/members/me'].get.responses['200'].content['application/json'].examples.success.value.data.loginId")
+                        .value("tester01"))
+                .andExpect(jsonPath(
                         "$.paths['/api/v1/members/me'].get.responses['401'].content['application/json'].examples.tokenMissing.value.error.code")
                         .value("AUTH_TOKEN_MISSING"))
+                .andExpect(jsonPath(
+                        "$.components.schemas.MemberProfileResponse.properties.loginId.description")
+                        .value(org.hamcrest.Matchers.containsString("현재 로그인한 회원의 로그인 ID")))
                 .andExpect(jsonPath(
                         "$.components.schemas.MemberProfileResponse.properties.email.description")
                         .value(org.hamcrest.Matchers.containsString("현재 로그인한 회원의 이메일")))


### PR DESCRIPTION
## 관련 이슈
Closes #172 

## 📝 작업 내용
- GET /api/v1/members/me 응답에 loginId를 포함하도록 런타임 응답 DTO, 도메인 result, mapper를 갱신했습니다.
- Swagger UI/OpenAPI 문서에 loginId 필드 설명과 성공 응답 예시를 반영했습니다.
- members/me 계약 변경에 맞춰 API 문서(docs/api/member-profile.md)와 완료 실행 기록 문서를 갱신했습니다.
- 로컬/소셜 회원 케이스 및 OpenAPI 산출물 검증 테스트를 보강했습니다.

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분: loginId가 로컬 로그인 회원에서는 값으로, 소셜 로그인 전용 회원에서는 null 가능 필드로 문서화/검증된 점이 의도와 맞는지 확인 부탁드립니다.
- 알려진 제한 사항: DB 구조 변경은 없으며, 기존 members.login_id 값을 그대로 응답에 노출합니다.
