### PR TITLE
[Feat] 주요 엔티티 정의

### DIFF
--- a/src/main/java/matchuri/backend/domain/auth/entity/AuthExchangeCode.java
+++ b/src/main/java/matchuri/backend/domain/auth/entity/AuthExchangeCode.java
@@ -8,10 +8,10 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -24,9 +24,8 @@ import matchuri.backend.domain.member.entity.SocialProviderType;
 @Entity
 @Table(
         name = "auth_exchange_codes",
-        indexes = {
-                @Index(name = "idx_auth_exchange_codes_code", columnList = "code", unique = true),
-                @Index(name = "idx_auth_exchange_codes_member", columnList = "member_id")
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_auth_exchange_codes_code", columnNames = "code")
         }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/matchuri/backend/domain/auth/entity/AuthRefreshToken.java
+++ b/src/main/java/matchuri/backend/domain/auth/entity/AuthRefreshToken.java
@@ -6,10 +6,10 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -21,9 +21,8 @@ import matchuri.backend.domain.member.entity.Member;
 @Entity
 @Table(
         name = "auth_refresh_tokens",
-        indexes = {
-                @Index(name = "idx_auth_refresh_tokens_member", columnList = "member_id"),
-                @Index(name = "idx_auth_refresh_tokens_token", columnList = "token", unique = true)
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_auth_refresh_tokens_token", columnNames = "token")
         }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/matchuri/backend/domain/auth/entity/EmailVerification.java
+++ b/src/main/java/matchuri/backend/domain/auth/entity/EmailVerification.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
@@ -21,11 +20,6 @@ import matchuri.backend.domain.common.BaseEntity;
 @Entity
 @Table(
         name = "auth_email_verifications",
-        indexes = {
-                @Index(name = "idx_auth_email_verifications_email_purpose", columnList = "email,purpose"),
-                @Index(name = "idx_auth_email_verifications_login_id", columnList = "login_id"),
-                @Index(name = "idx_auth_email_verifications_status_expires_at", columnList = "status,expires_at")
-        },
         uniqueConstraints = {
                 @UniqueConstraint(
                         name = "uk_auth_email_verifications_token_hash",

--- a/src/main/java/matchuri/backend/domain/behavior/entity/ActionType.java
+++ b/src/main/java/matchuri/backend/domain/behavior/entity/ActionType.java
@@ -1,0 +1,9 @@
+package matchuri.backend.domain.behavior.entity;
+
+public enum ActionType {
+    CLICK,
+    LIKE,
+    DISLIKE,
+    CHOOSE,
+    SKIP
+}

--- a/src/main/java/matchuri/backend/domain/behavior/entity/MemberMenuAction.java
+++ b/src/main/java/matchuri/backend/domain/behavior/entity/MemberMenuAction.java
@@ -8,7 +8,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -24,12 +23,7 @@ import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
 @Entity
 @Table(
         name = "member_menu_actions",
-        comment = "회원 메뉴 행동 로그",
-        indexes = {
-                @Index(name = "idx_member_menu_actions_member_created_at", columnList = "member_id,created_at"),
-                @Index(name = "idx_member_menu_actions_menu_action", columnList = "menu_id,action_type"),
-                @Index(name = "idx_member_menu_actions_personal_recommendation", columnList = "personal_recommendation_id")
-        }
+        comment = "회원 메뉴 행동 로그"
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberMenuAction extends CreatedAtEntity {

--- a/src/main/java/matchuri/backend/domain/behavior/entity/MemberMenuAction.java
+++ b/src/main/java/matchuri/backend/domain/behavior/entity/MemberMenuAction.java
@@ -1,0 +1,69 @@
+package matchuri.backend.domain.behavior.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import matchuri.backend.domain.common.CreatedAtEntity;
+import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.menu.entity.MenuItem;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
+
+@Getter
+@Entity
+@Table(
+        name = "member_menu_actions",
+        comment = "회원 메뉴 행동 로그",
+        indexes = {
+                @Index(name = "idx_member_menu_actions_member_created_at", columnList = "member_id,created_at"),
+                @Index(name = "idx_member_menu_actions_menu_action", columnList = "menu_id,action_type"),
+                @Index(name = "idx_member_menu_actions_personal_recommendation", columnList = "personal_recommendation_id")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberMenuAction extends CreatedAtEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(comment = "회원 메뉴 행동 로그 ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false, comment = "회원 ID")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "menu_id", nullable = false, comment = "메뉴 ID")
+    private MenuItem menuItem;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "personal_recommendation_id", comment = "개인 추천 ID")
+    private PersonalRecommendation personalRecommendation;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "action_type", nullable = false, length = 20, comment = "행동 유형")
+    private ActionType actionType;
+
+    public MemberMenuAction(
+            Member member,
+            MenuItem menuItem,
+            PersonalRecommendation personalRecommendation,
+            ActionType actionType
+    ) {
+        this.member = member;
+        this.menuItem = menuItem;
+        this.personalRecommendation = personalRecommendation;
+        this.actionType = actionType;
+    }
+}

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupInvite.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupInvite.java
@@ -1,0 +1,79 @@
+package matchuri.backend.domain.group.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import matchuri.backend.domain.common.BaseEntity;
+import matchuri.backend.domain.member.entity.Member;
+
+@Getter
+@Entity
+@Table(
+        name = "group_invites",
+        comment = "그룹 초대",
+        indexes = {
+                @Index(name = "idx_group_invites_room_status", columnList = "room_id,status"),
+                @Index(name = "idx_group_invites_expires_at", columnList = "expires_at")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_group_invites_invite_code", columnNames = "invite_code")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GroupInvite extends BaseEntity {
+
+    public static final int INVITE_CODE_MAX_LENGTH = 64;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(comment = "그룹 초대 ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "room_id", nullable = false, comment = "그룹 방 ID")
+    private GroupRoom room;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "created_by_member_id", nullable = false, comment = "초대 생성 회원 ID")
+    private Member createdByMember;
+
+    @Column(name = "invite_code", nullable = false, length = INVITE_CODE_MAX_LENGTH, comment = "초대 코드")
+    private String inviteCode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20, comment = "초대 상태")
+    private GroupInviteStatus status;
+
+    @Column(name = "expires_at", comment = "만료 시각")
+    private LocalDateTime expiresAt;
+
+    public GroupInvite(GroupRoom room, Member createdByMember, String inviteCode, LocalDateTime expiresAt) {
+        this.room = room;
+        this.createdByMember = createdByMember;
+        this.inviteCode = inviteCode;
+        this.expiresAt = expiresAt;
+        this.status = GroupInviteStatus.ACTIVE;
+    }
+
+    public void expire() {
+        this.status = GroupInviteStatus.EXPIRED;
+    }
+
+    public void revoke() {
+        this.status = GroupInviteStatus.REVOKED;
+    }
+}

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupInvite.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupInvite.java
@@ -8,7 +8,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -25,10 +24,6 @@ import matchuri.backend.domain.member.entity.Member;
 @Table(
         name = "group_invites",
         comment = "그룹 초대",
-        indexes = {
-                @Index(name = "idx_group_invites_room_status", columnList = "room_id,status"),
-                @Index(name = "idx_group_invites_expires_at", columnList = "expires_at")
-        },
         uniqueConstraints = {
                 @UniqueConstraint(name = "uk_group_invites_invite_code", columnNames = "invite_code")
         }

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupInviteStatus.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupInviteStatus.java
@@ -1,0 +1,7 @@
+package matchuri.backend.domain.group.entity;
+
+public enum GroupInviteStatus {
+    ACTIVE,
+    EXPIRED,
+    REVOKED
+}

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupMemberRole.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupMemberRole.java
@@ -1,0 +1,6 @@
+package matchuri.backend.domain.group.entity;
+
+public enum GroupMemberRole {
+    OWNER,
+    MEMBER
+}

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupMemberStatus.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupMemberStatus.java
@@ -1,0 +1,7 @@
+package matchuri.backend.domain.group.entity;
+
+public enum GroupMemberStatus {
+    ACTIVE,
+    LEFT,
+    KICKED
+}

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupPresenceEvent.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupPresenceEvent.java
@@ -1,0 +1,67 @@
+package matchuri.backend.domain.group.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import matchuri.backend.domain.common.CreatedAtEntity;
+import matchuri.backend.domain.member.entity.Member;
+
+@Getter
+@Entity
+@Table(
+        name = "group_presence_events",
+        comment = "그룹 입퇴장 이벤트",
+        indexes = {
+                @Index(name = "idx_group_presence_events_room_created_at", columnList = "room_id,created_at"),
+                @Index(name = "idx_group_presence_events_member_created_at", columnList = "member_id,created_at")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GroupPresenceEvent extends CreatedAtEntity {
+
+    public static final int WEBSOCKET_SESSION_ID_MAX_LENGTH = 100;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(comment = "그룹 입퇴장 이벤트 ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "room_id", nullable = false, comment = "그룹 방 ID")
+    private GroupRoom room;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false, comment = "회원 ID")
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false, length = 20, comment = "입퇴장 이벤트 유형")
+    private GroupPresenceEventType eventType;
+
+    @Column(name = "websocket_session_id", length = WEBSOCKET_SESSION_ID_MAX_LENGTH, comment = "웹소켓 세션 ID")
+    private String websocketSessionId;
+
+    public GroupPresenceEvent(
+            GroupRoom room,
+            Member member,
+            GroupPresenceEventType eventType,
+            String websocketSessionId
+    ) {
+        this.room = room;
+        this.member = member;
+        this.eventType = eventType;
+        this.websocketSessionId = websocketSessionId;
+    }
+}

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupPresenceEvent.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupPresenceEvent.java
@@ -8,7 +8,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -22,11 +21,7 @@ import matchuri.backend.domain.member.entity.Member;
 @Entity
 @Table(
         name = "group_presence_events",
-        comment = "그룹 입퇴장 이벤트",
-        indexes = {
-                @Index(name = "idx_group_presence_events_room_created_at", columnList = "room_id,created_at"),
-                @Index(name = "idx_group_presence_events_member_created_at", columnList = "member_id,created_at")
-        }
+        comment = "그룹 입퇴장 이벤트"
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GroupPresenceEvent extends CreatedAtEntity {

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupPresenceEventType.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupPresenceEventType.java
@@ -1,0 +1,6 @@
+package matchuri.backend.domain.group.entity;
+
+public enum GroupPresenceEventType {
+    JOIN,
+    LEAVE
+}

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendation.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendation.java
@@ -1,0 +1,86 @@
+package matchuri.backend.domain.group.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import matchuri.backend.domain.common.BaseEntity;
+
+@Getter
+@Entity
+@Table(
+        name = "group_recommendations",
+        comment = "그룹 추천",
+        indexes = {
+                @Index(name = "idx_group_recommendations_room_status", columnList = "room_id,status"),
+                @Index(name = "idx_group_recommendations_started_at", columnList = "started_at")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GroupRecommendation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(comment = "그룹 추천 ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "room_id", nullable = false, comment = "그룹 방 ID")
+    private GroupRoom room;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20, comment = "그룹 추천 상태")
+    private GroupRecommendationStatus status;
+
+    @Column(name = "started_at", nullable = false, comment = "시작 시각")
+    private LocalDateTime startedAt;
+
+    @Column(name = "ended_at", comment = "종료 시각")
+    private LocalDateTime endedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "selected_candidate_id", comment = "최종 선택 후보 ID")
+    private GroupRecommendationCandidate selectedCandidate;
+
+    @Column(name = "context_json", columnDefinition = "json", comment = "그룹 추천 컨텍스트 JSON")
+    private String contextJson;
+
+    @Column(name = "result_json", columnDefinition = "json", comment = "그룹 추천 결과 요약 JSON")
+    private String resultJson;
+
+    public GroupRecommendation(GroupRoom room, String contextJson, LocalDateTime startedAt) {
+        this.room = room;
+        this.contextJson = contextJson;
+        this.startedAt = startedAt;
+        this.status = GroupRecommendationStatus.OPEN;
+    }
+
+    public void close(LocalDateTime endedAt) {
+        this.status = GroupRecommendationStatus.CLOSED;
+        this.endedAt = endedAt;
+    }
+
+    public void finalizeWith(GroupRecommendationCandidate selectedCandidate, String resultJson, LocalDateTime endedAt) {
+        this.status = GroupRecommendationStatus.FINALIZED;
+        this.selectedCandidate = selectedCandidate;
+        this.resultJson = resultJson;
+        this.endedAt = endedAt;
+    }
+
+    public void cancel(LocalDateTime endedAt) {
+        this.status = GroupRecommendationStatus.CANCELED;
+        this.endedAt = endedAt;
+    }
+}

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendation.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendation.java
@@ -8,7 +8,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -22,11 +21,7 @@ import matchuri.backend.domain.common.BaseEntity;
 @Entity
 @Table(
         name = "group_recommendations",
-        comment = "그룹 추천",
-        indexes = {
-                @Index(name = "idx_group_recommendations_room_status", columnList = "room_id,status"),
-                @Index(name = "idx_group_recommendations_started_at", columnList = "started_at")
-        }
+        comment = "그룹 추천"
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GroupRecommendation extends BaseEntity {

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationCandidate.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationCandidate.java
@@ -6,7 +6,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -22,13 +21,6 @@ import matchuri.backend.domain.menu.entity.MenuItem;
 @Table(
         name = "group_recommendation_candidates",
         comment = "그룹 추천 후보",
-        indexes = {
-                @Index(
-                        name = "idx_group_recommendation_candidates_recommendation_rank",
-                        columnList = "group_recommendation_id,rank_no"
-                ),
-                @Index(name = "idx_group_recommendation_candidates_menu", columnList = "menu_id")
-        },
         uniqueConstraints = {
                 @UniqueConstraint(
                         name = "uk_group_recommendation_candidate_menu",

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationCandidate.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationCandidate.java
@@ -1,0 +1,74 @@
+package matchuri.backend.domain.group.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import matchuri.backend.domain.common.BaseEntity;
+import matchuri.backend.domain.menu.entity.MenuItem;
+
+@Getter
+@Entity
+@Table(
+        name = "group_recommendation_candidates",
+        comment = "그룹 추천 후보",
+        indexes = {
+                @Index(
+                        name = "idx_group_recommendation_candidates_recommendation_rank",
+                        columnList = "group_recommendation_id,rank_no"
+                ),
+                @Index(name = "idx_group_recommendation_candidates_menu", columnList = "menu_id")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_group_recommendation_candidate_menu",
+                        columnNames = {"group_recommendation_id", "menu_id"}
+                )
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GroupRecommendationCandidate extends BaseEntity {
+
+    public static final int REASON_SUMMARY_MAX_LENGTH = 300;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(comment = "그룹 추천 후보 ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "group_recommendation_id", nullable = false, comment = "그룹 추천 ID")
+    private GroupRecommendation groupRecommendation;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "menu_id", nullable = false, comment = "메뉴 ID")
+    private MenuItem menuItem;
+
+    @Column(name = "rank_no", nullable = false, comment = "후보 순위")
+    private int rankNo;
+
+    @Column(name = "reason_summary", length = REASON_SUMMARY_MAX_LENGTH, comment = "추천 사유 요약")
+    private String reasonSummary;
+
+    public GroupRecommendationCandidate(
+            GroupRecommendation groupRecommendation,
+            MenuItem menuItem,
+            int rankNo,
+            String reasonSummary
+    ) {
+        this.groupRecommendation = groupRecommendation;
+        this.menuItem = menuItem;
+        this.rankNo = rankNo;
+        this.reasonSummary = reasonSummary;
+    }
+}

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationStatus.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationStatus.java
@@ -1,0 +1,8 @@
+package matchuri.backend.domain.group.entity;
+
+public enum GroupRecommendationStatus {
+    OPEN,
+    CLOSED,
+    FINALIZED,
+    CANCELED
+}

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationVote.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationVote.java
@@ -1,0 +1,68 @@
+package matchuri.backend.domain.group.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import matchuri.backend.domain.common.CreatedAtEntity;
+import matchuri.backend.domain.member.entity.Member;
+
+@Getter
+@Entity
+@Table(
+        name = "group_recommendation_votes",
+        comment = "그룹 추천 투표",
+        indexes = {
+                @Index(
+                        name = "idx_group_recommendation_votes_recommendation_candidate",
+                        columnList = "group_recommendation_id,candidate_id"
+                ),
+                @Index(name = "idx_group_recommendation_votes_member", columnList = "member_id")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_group_recommendation_vote_member",
+                        columnNames = {"group_recommendation_id", "member_id"}
+                )
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GroupRecommendationVote extends CreatedAtEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(comment = "그룹 추천 투표 ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "group_recommendation_id", nullable = false, comment = "그룹 추천 ID")
+    private GroupRecommendation groupRecommendation;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "candidate_id", nullable = false, comment = "그룹 추천 후보 ID")
+    private GroupRecommendationCandidate candidate;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false, comment = "투표 회원 ID")
+    private Member member;
+
+    public GroupRecommendationVote(
+            GroupRecommendation groupRecommendation,
+            GroupRecommendationCandidate candidate,
+            Member member
+    ) {
+        this.groupRecommendation = groupRecommendation;
+        this.candidate = candidate;
+        this.member = member;
+    }
+}

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationVote.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationVote.java
@@ -6,7 +6,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -22,13 +21,6 @@ import matchuri.backend.domain.member.entity.Member;
 @Table(
         name = "group_recommendation_votes",
         comment = "그룹 추천 투표",
-        indexes = {
-                @Index(
-                        name = "idx_group_recommendation_votes_recommendation_candidate",
-                        columnList = "group_recommendation_id,candidate_id"
-                ),
-                @Index(name = "idx_group_recommendation_votes_member", columnList = "member_id")
-        },
         uniqueConstraints = {
                 @UniqueConstraint(
                         name = "uk_group_recommendation_vote_member",

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRoom.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRoom.java
@@ -1,0 +1,74 @@
+package matchuri.backend.domain.group.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import matchuri.backend.domain.common.BaseEntity;
+import matchuri.backend.domain.member.entity.Member;
+
+@Getter
+@Entity
+@Table(
+        name = "group_rooms",
+        comment = "그룹 방",
+        indexes = {
+                @Index(name = "idx_group_rooms_host_member", columnList = "host_member_id"),
+                @Index(name = "idx_group_rooms_status", columnList = "status")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GroupRoom extends BaseEntity {
+
+    public static final int NAME_MAX_LENGTH = 100;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(comment = "그룹 방 ID")
+    private Long id;
+
+    @Column(nullable = false, length = NAME_MAX_LENGTH, comment = "그룹명")
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "host_member_id", nullable = false, comment = "방장 회원 ID")
+    private Member hostMember;
+
+    @Column(precision = 10, scale = 7, comment = "위도")
+    private BigDecimal latitude;
+
+    @Column(precision = 10, scale = 7, comment = "경도")
+    private BigDecimal longitude;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20, comment = "그룹 방 상태")
+    private GroupRoomStatus status;
+
+    public GroupRoom(String name, Member hostMember, BigDecimal latitude, BigDecimal longitude) {
+        this.name = name;
+        this.hostMember = hostMember;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.status = GroupRoomStatus.ACTIVE;
+    }
+
+    public void close() {
+        this.status = GroupRoomStatus.CLOSED;
+    }
+
+    public void delete() {
+        this.status = GroupRoomStatus.DELETED;
+    }
+}

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRoom.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRoom.java
@@ -8,7 +8,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -23,11 +22,7 @@ import matchuri.backend.domain.member.entity.Member;
 @Entity
 @Table(
         name = "group_rooms",
-        comment = "그룹 방",
-        indexes = {
-                @Index(name = "idx_group_rooms_host_member", columnList = "host_member_id"),
-                @Index(name = "idx_group_rooms_status", columnList = "status")
-        }
+        comment = "그룹 방"
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GroupRoom extends BaseEntity {

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRoomMember.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRoomMember.java
@@ -1,0 +1,83 @@
+package matchuri.backend.domain.group.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import matchuri.backend.domain.common.BaseEntity;
+import matchuri.backend.domain.member.entity.Member;
+
+@Getter
+@Entity
+@Table(
+        name = "group_room_members",
+        comment = "그룹 방 멤버",
+        indexes = {
+                @Index(name = "idx_group_room_members_room_status", columnList = "room_id,status"),
+                @Index(name = "idx_group_room_members_member_status", columnList = "member_id,status")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_group_room_member", columnNames = {"room_id", "member_id"})
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GroupRoomMember extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(comment = "그룹 방 멤버 ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "room_id", nullable = false, comment = "그룹 방 ID")
+    private GroupRoom room;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false, comment = "회원 ID")
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20, comment = "그룹 멤버 역할")
+    private GroupMemberRole role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20, comment = "그룹 멤버 상태")
+    private GroupMemberStatus status;
+
+    @Column(name = "joined_at", nullable = false, comment = "참여 시각")
+    private LocalDateTime joinedAt;
+
+    @Column(name = "left_at", comment = "퇴장 시각")
+    private LocalDateTime leftAt;
+
+    public GroupRoomMember(GroupRoom room, Member member, GroupMemberRole role, LocalDateTime joinedAt) {
+        this.room = room;
+        this.member = member;
+        this.role = role;
+        this.joinedAt = joinedAt;
+        this.status = GroupMemberStatus.ACTIVE;
+    }
+
+    public void leave(LocalDateTime leftAt) {
+        this.status = GroupMemberStatus.LEFT;
+        this.leftAt = leftAt;
+    }
+
+    public void kick(LocalDateTime leftAt) {
+        this.status = GroupMemberStatus.KICKED;
+        this.leftAt = leftAt;
+    }
+}

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRoomMember.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRoomMember.java
@@ -8,7 +8,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -25,10 +24,6 @@ import matchuri.backend.domain.member.entity.Member;
 @Table(
         name = "group_room_members",
         comment = "그룹 방 멤버",
-        indexes = {
-                @Index(name = "idx_group_room_members_room_status", columnList = "room_id,status"),
-                @Index(name = "idx_group_room_members_member_status", columnList = "member_id,status")
-        },
         uniqueConstraints = {
                 @UniqueConstraint(name = "uk_group_room_member", columnNames = {"room_id", "member_id"})
         }

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRoomStatus.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRoomStatus.java
@@ -1,0 +1,7 @@
+package matchuri.backend.domain.group.entity;
+
+public enum GroupRoomStatus {
+    ACTIVE,
+    CLOSED,
+    DELETED
+}

--- a/src/main/java/matchuri/backend/domain/member/entity/Member.java
+++ b/src/main/java/matchuri/backend/domain/member/entity/Member.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
@@ -23,11 +22,6 @@ import matchuri.backend.domain.common.BaseEntity;
 @Table(
         name = "members",
         comment = "회원",
-        indexes = {
-                @Index(name = "idx_members_email", columnList = "email"),
-                @Index(name = "idx_members_social_provider", columnList = "is_social,social_provider_type"),
-                @Index(name = "idx_members_nickname", columnList = "nickname")
-        },
         uniqueConstraints = {
                 @UniqueConstraint(name = "uk_members_login_id", columnNames = "login_id"),
                 @UniqueConstraint(name = "uk_members_nickname", columnNames = "nickname"),

--- a/src/main/java/matchuri/backend/domain/member/entity/MemberAgreement.java
+++ b/src/main/java/matchuri/backend/domain/member/entity/MemberAgreement.java
@@ -8,7 +8,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -26,10 +25,6 @@ import matchuri.backend.domain.common.BaseEntity;
 @Table(
         name = "member_agreements",
         comment = "회원 약관 동의 이력",
-        indexes = {
-                @Index(name = "idx_member_agreements_member_id", columnList = "member_id"),
-                @Index(name = "idx_member_agreements_member_type", columnList = "member_id,agreement_type")
-        },
         uniqueConstraints = {
                 @UniqueConstraint(
                         name = "uk_member_agreements_member_type_version",

--- a/src/main/java/matchuri/backend/domain/member/entity/MemberTasteProfileCategory.java
+++ b/src/main/java/matchuri/backend/domain/member/entity/MemberTasteProfileCategory.java
@@ -6,7 +6,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -22,10 +21,6 @@ import matchuri.backend.domain.menu.entity.AttributeCategory;
 @Table(
         name = "member_taste_profile_categories",
         comment = "회원 취향 프로필-속성 카테고리 매핑",
-        indexes = {
-                @Index(name = "idx_member_taste_profile_categories_profile_id", columnList = "profile_id"),
-                @Index(name = "idx_member_taste_profile_categories_attribute_category_id", columnList = "attribute_category_id")
-        },
         uniqueConstraints = {
                 @UniqueConstraint(
                         name = "uk_member_taste_profile_category",

--- a/src/main/java/matchuri/backend/domain/member/entity/MemberTasteProfileDislikedMenuItem.java
+++ b/src/main/java/matchuri/backend/domain/member/entity/MemberTasteProfileDislikedMenuItem.java
@@ -6,7 +6,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -22,10 +21,6 @@ import matchuri.backend.domain.menu.entity.MenuItem;
 @Table(
         name = "member_taste_profile_disliked_menu_items",
         comment = "회원 취향 프로필 비선호 메뉴 매핑",
-        indexes = {
-                @Index(name = "idx_member_profile_disliked_menu_profile", columnList = "profile_id"),
-                @Index(name = "idx_member_profile_disliked_menu_menu", columnList = "menu_id")
-        },
         uniqueConstraints = {
                 @UniqueConstraint(
                         name = "uk_member_profile_disliked_menu_item",

--- a/src/main/java/matchuri/backend/domain/member/entity/MemberTasteProfileRestrictionIngredient.java
+++ b/src/main/java/matchuri/backend/domain/member/entity/MemberTasteProfileRestrictionIngredient.java
@@ -6,7 +6,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -22,10 +21,6 @@ import matchuri.backend.domain.menu.entity.Ingredient;
 @Table(
         name = "member_taste_profile_restriction_ingredients",
         comment = "회원 취향 프로필 제한 재료 매핑",
-        indexes = {
-                @Index(name = "idx_member_profile_restrictions_profile", columnList = "profile_id"),
-                @Index(name = "idx_member_profile_restrictions_ingredient", columnList = "ingredient_id")
-        },
         uniqueConstraints = {
                 @UniqueConstraint(
                         name = "uk_member_profile_restriction_ingredient",

--- a/src/main/java/matchuri/backend/domain/menu/entity/AttributeCategory.java
+++ b/src/main/java/matchuri/backend/domain/menu/entity/AttributeCategory.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
@@ -20,10 +19,6 @@ import matchuri.backend.domain.common.BaseEntity;
 @Table(
         name = "attribute_categories",
         comment = "공통 속성 카테고리",
-        indexes = {
-                @Index(name = "idx_attribute_categories_active", columnList = "is_active"),
-                @Index(name = "idx_attribute_categories_type_active", columnList = "category_type,is_active")
-        },
         uniqueConstraints = {
                 @UniqueConstraint(name = "uk_attribute_categories_type_code", columnNames = {"category_type", "code"})
         }

--- a/src/main/java/matchuri/backend/domain/menu/entity/Ingredient.java
+++ b/src/main/java/matchuri/backend/domain/menu/entity/Ingredient.java
@@ -5,7 +5,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
@@ -18,9 +17,6 @@ import matchuri.backend.domain.common.BaseEntity;
 @Table(
         name = "ingredients",
         comment = "재료",
-        indexes = {
-                @Index(name = "idx_ingredients_active", columnList = "is_active")
-        },
         uniqueConstraints = {
                 @UniqueConstraint(name = "uk_ingredients_code", columnNames = "code")
         }

--- a/src/main/java/matchuri/backend/domain/menu/entity/MenuAttributeCategory.java
+++ b/src/main/java/matchuri/backend/domain/menu/entity/MenuAttributeCategory.java
@@ -6,7 +6,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -21,10 +20,6 @@ import matchuri.backend.domain.common.BaseEntity;
 @Table(
         name = "menu_attribute_categories",
         comment = "메뉴-속성 카테고리 매핑",
-        indexes = {
-                @Index(name = "idx_menu_attr_categories_menu_id", columnList = "menu_id"),
-                @Index(name = "idx_menu_attr_categories_category_id", columnList = "attribute_category_id")
-        },
         uniqueConstraints = {
                 @UniqueConstraint(name = "uk_menu_attribute_category", columnNames = {"menu_id",
                         "attribute_category_id"})

--- a/src/main/java/matchuri/backend/domain/menu/entity/MenuIngredient.java
+++ b/src/main/java/matchuri/backend/domain/menu/entity/MenuIngredient.java
@@ -6,7 +6,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -21,10 +20,6 @@ import matchuri.backend.domain.common.BaseEntity;
 @Table(
         name = "menu_ingredients",
         comment = "메뉴-재료 매핑",
-        indexes = {
-                @Index(name = "idx_menu_ingredients_menu_id", columnList = "menu_id"),
-                @Index(name = "idx_menu_ingredients_ingredient_id", columnList = "ingredient_id")
-        },
         uniqueConstraints = {
                 @UniqueConstraint(name = "uk_menu_ingredient", columnNames = {"menu_id", "ingredient_id"})
         }

--- a/src/main/java/matchuri/backend/domain/menu/entity/MenuItem.java
+++ b/src/main/java/matchuri/backend/domain/menu/entity/MenuItem.java
@@ -5,7 +5,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
@@ -18,9 +17,6 @@ import matchuri.backend.domain.common.BaseEntity;
 @Table(
         name = "menu_items",
         comment = "메뉴",
-        indexes = {
-                @Index(name = "idx_menu_items_active", columnList = "is_active")
-        },
         uniqueConstraints = {
                 @UniqueConstraint(name = "uk_menu_items_code", columnNames = "code")
         }

--- a/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendation.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendation.java
@@ -8,7 +8,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -23,11 +22,7 @@ import matchuri.backend.domain.member.entity.Member;
 @Entity
 @Table(
         name = "personal_recommendations",
-        comment = "개인 추천",
-        indexes = {
-                @Index(name = "idx_personal_recommendations_member", columnList = "member_id"),
-                @Index(name = "idx_personal_recommendations_status_requested_at", columnList = "status,requested_at")
-        }
+        comment = "개인 추천"
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PersonalRecommendation extends BaseEntity {

--- a/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendation.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendation.java
@@ -1,0 +1,89 @@
+package matchuri.backend.domain.recommendation.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import matchuri.backend.domain.common.BaseEntity;
+import matchuri.backend.domain.member.entity.Member;
+
+@Getter
+@Entity
+@Table(
+        name = "personal_recommendations",
+        comment = "개인 추천",
+        indexes = {
+                @Index(name = "idx_personal_recommendations_member", columnList = "member_id"),
+                @Index(name = "idx_personal_recommendations_status_requested_at", columnList = "status,requested_at")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PersonalRecommendation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(comment = "개인 추천 ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false, comment = "회원 ID")
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20, comment = "개인 추천 상태")
+    private PersonalRecommendationStatus status;
+
+    @Column(name = "requested_at", nullable = false, comment = "추천 실행 시각")
+    private LocalDateTime requestedAt;
+
+    @Column(name = "context_json", columnDefinition = "json", comment = "개인 추천 컨텍스트 JSON")
+    private String contextJson;
+
+    @Column(name = "result_json", columnDefinition = "json", comment = "개인 추천 결과 요약 JSON")
+    private String resultJson;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "selected_candidate_id", comment = "최종 선택 후보 ID")
+    private PersonalRecommendationCandidate selectedCandidate;
+
+    public PersonalRecommendation(Member member, String contextJson, LocalDateTime requestedAt) {
+        this.member = member;
+        this.contextJson = contextJson;
+        this.requestedAt = requestedAt;
+        this.status = PersonalRecommendationStatus.REQUESTED;
+    }
+
+    public void markFiltered() {
+        this.status = PersonalRecommendationStatus.FILTERED;
+    }
+
+    public void markScored() {
+        this.status = PersonalRecommendationStatus.SCORED;
+    }
+
+    public void complete(String resultJson) {
+        this.status = PersonalRecommendationStatus.COMPLETED;
+        this.resultJson = resultJson;
+    }
+
+    public void fail(String resultJson) {
+        this.status = PersonalRecommendationStatus.FAILED;
+        this.resultJson = resultJson;
+    }
+
+    public void select(PersonalRecommendationCandidate selectedCandidate) {
+        this.selectedCandidate = selectedCandidate;
+    }
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendationCandidate.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendationCandidate.java
@@ -6,7 +6,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -23,13 +22,6 @@ import matchuri.backend.domain.menu.entity.MenuItem;
 @Table(
         name = "personal_recommendation_candidates",
         comment = "개인 추천 후보",
-        indexes = {
-                @Index(
-                        name = "idx_personal_recommendation_candidates_recommendation_rank",
-                        columnList = "personal_recommendation_id,rank_no"
-                ),
-                @Index(name = "idx_personal_recommendation_candidates_menu", columnList = "menu_id")
-        },
         uniqueConstraints = {
                 @UniqueConstraint(
                         name = "uk_personal_recommendation_candidate_menu",

--- a/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendationCandidate.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendationCandidate.java
@@ -1,0 +1,85 @@
+package matchuri.backend.domain.recommendation.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import matchuri.backend.domain.common.BaseEntity;
+import matchuri.backend.domain.menu.entity.MenuItem;
+
+@Getter
+@Entity
+@Table(
+        name = "personal_recommendation_candidates",
+        comment = "개인 추천 후보",
+        indexes = {
+                @Index(
+                        name = "idx_personal_recommendation_candidates_recommendation_rank",
+                        columnList = "personal_recommendation_id,rank_no"
+                ),
+                @Index(name = "idx_personal_recommendation_candidates_menu", columnList = "menu_id")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_personal_recommendation_candidate_menu",
+                        columnNames = {"personal_recommendation_id", "menu_id"}
+                )
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PersonalRecommendationCandidate extends BaseEntity {
+
+    public static final int REASON_SUMMARY_MAX_LENGTH = 300;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(comment = "개인 추천 후보 ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "personal_recommendation_id", nullable = false, comment = "개인 추천 ID")
+    private PersonalRecommendation personalRecommendation;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "menu_id", nullable = false, comment = "메뉴 ID")
+    private MenuItem menuItem;
+
+    @Column(name = "rank_no", nullable = false, comment = "후보 순위")
+    private int rankNo;
+
+    @Column(precision = 10, scale = 4, comment = "추천 점수")
+    private BigDecimal score;
+
+    @Column(name = "reason_summary", length = REASON_SUMMARY_MAX_LENGTH, comment = "추천 사유 요약")
+    private String reasonSummary;
+
+    @Column(name = "candidate_meta_json", columnDefinition = "json", comment = "후보 메타 JSON")
+    private String candidateMetaJson;
+
+    public PersonalRecommendationCandidate(
+            PersonalRecommendation personalRecommendation,
+            MenuItem menuItem,
+            int rankNo,
+            BigDecimal score,
+            String reasonSummary,
+            String candidateMetaJson
+    ) {
+        this.personalRecommendation = personalRecommendation;
+        this.menuItem = menuItem;
+        this.rankNo = rankNo;
+        this.score = score;
+        this.reasonSummary = reasonSummary;
+        this.candidateMetaJson = candidateMetaJson;
+    }
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendationStatus.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendationStatus.java
@@ -1,0 +1,9 @@
+package matchuri.backend.domain.recommendation.entity;
+
+public enum PersonalRecommendationStatus {
+    REQUESTED,
+    FILTERED,
+    SCORED,
+    COMPLETED,
+    FAILED
+}


### PR DESCRIPTION
## 관련 이슈
Closes #174

## 📝 작업 내용
- API Mocking 선행 작업으로 개인 추천, 그룹 추천, 투표, 그룹 방, 초대, 행동 로그 관련 JPA Entity를 사전 정의했습니다.
- `Request`, `Session` 키워드를 제거한 테이블명 기준으로 문서와 구현을 정리했습니다.
  - `personal_recommendations`
  - `personal_recommendation_candidates`
  - `member_menu_actions`
  - `group_rooms`
  - `group_room_members`
  - `group_invites`
  - `group_recommendations`
  - `group_recommendation_candidates`
  - `group_recommendation_votes`
  - `group_presence_events`
- 성능 개선 시점에 인덱스 추가 전후를 비교할 수 있도록 기존/신규 Entity의 명시 보조 인덱스(`@Index`, `idx_*`)를 제거했습니다.
- PK, FK, unique 제약은 데이터 무결성 목적이므로 유지했습니다.
- 변경된 테이블명, Entity 사전 정의 범위, 인덱스 운영 기준이 코드와 맞도록 데이터/설계/실행 계획 문서를 최신화했습니다.

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [x] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [ ] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
  - 새로 정의한 추천/그룹/행동 Entity의 테이블명과 연관관계가 문서 기준과 일치하는지
  - 그룹 투표가 후보 1개 선택 방식으로 제약되어 있는지
  - 명시 보조 인덱스 제거 범위가 의도대로 적용되었는지
- 알려진 제한 사항:
  - 이번 작업은 API Mocking 선행을 위한 Entity 사전 정의이며, Repository/Service/API 구현은 포함하지 않습니다.
  - DB 초기화 후에도 PK, FK, unique 제약을 위한 DB 내부 인덱스는 생성될 수 있습니다. 이번 제거 대상은 JPA Entity에 명시한 조회용 보조 인덱스입니다.
  - 로컬 테스트 실행은 진행 중 중단되어 완료 확인이 필요합니다.
