### PR TITLE
[Feat] Mock API 추가

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -1,0 +1,301 @@
+package matchuri.backend.api.group;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import matchuri.backend.api.group.dto.docs.CreateGroupApiResponse;
+import matchuri.backend.api.group.dto.docs.CreateGroupInviteApiResponse;
+import matchuri.backend.api.group.dto.docs.CreateGroupRecommendationApiResponse;
+import matchuri.backend.api.group.dto.docs.FinalizeGroupRecommendationApiResponse;
+import matchuri.backend.api.group.dto.docs.GroupDetailApiResponse;
+import matchuri.backend.api.group.dto.docs.GroupRecommendationCandidateListApiResponse;
+import matchuri.backend.api.group.dto.docs.GroupRecommendationSessionApiResponse;
+import matchuri.backend.api.group.dto.docs.GroupSummaryPageApiResponse;
+import matchuri.backend.api.group.dto.docs.GroupVoteApiResponse;
+import matchuri.backend.api.group.dto.docs.JoinGroupApiResponse;
+import matchuri.backend.api.group.dto.docs.LeaveGroupApiResponse;
+import matchuri.backend.api.group.dto.request.CreateGroupRecommendationRequest;
+import matchuri.backend.api.group.dto.request.CreateGroupRequest;
+import matchuri.backend.api.group.dto.request.JoinGroupRequest;
+import matchuri.backend.api.group.dto.request.VoteGroupRecommendationRequest;
+import matchuri.backend.api.group.dto.response.CreateGroupInviteResponse;
+import matchuri.backend.api.group.dto.response.CreateGroupRecommendationResponse;
+import matchuri.backend.api.group.dto.response.CreateGroupResponse;
+import matchuri.backend.api.group.dto.response.FinalizeGroupRecommendationResponse;
+import matchuri.backend.api.group.dto.response.GroupDetailResponse;
+import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateListResponse;
+import matchuri.backend.api.group.dto.response.GroupRecommendationSessionResponse;
+import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
+import matchuri.backend.api.group.dto.response.GroupVoteResponse;
+import matchuri.backend.api.group.dto.response.JoinGroupResponse;
+import matchuri.backend.api.group.dto.response.LeaveGroupResponse;
+import matchuri.backend.global.api.ApiResponse;
+import matchuri.backend.global.api.PageResponse;
+
+@Tag(name = "Group Decision", description = "그룹 점심 메뉴 의사결정 API")
+public interface GroupApi {
+
+    @Operation(
+            summary = "그룹 생성 (Mock API)",
+            description = """
+                    그룹 방을 생성합니다.
+
+                    Mock API 상태:
+                    - request body validation만 수행합니다.
+                    - DB 저장, 생성자 멤버 등록, 권한 검증은 아직 수행하지 않습니다.
+                    - 실제 저장 테이블은 `group_rooms`, `group_room_members` 기준입니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "그룹 생성 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CreateGroupApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "data": {
+                                                "groupId": 3001,
+                                                "status": "ACTIVE"
+                                              },
+                                              "error": null
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ApiResponse<CreateGroupResponse> createGroup(CreateGroupRequest request);
+
+    @Operation(
+            summary = "내 그룹 목록 조회 (Mock API)",
+            description = """
+                    내가 속한 그룹 목록을 조회합니다.
+
+                    Mock API 상태:
+                    - query parameter는 받지만 필터링과 페이징은 아직 수행하지 않습니다.
+                    - 항상 같은 그룹 목록 더미 응답을 반환합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = GroupSummaryPageApiResponse.class)
+                    )
+            )
+    })
+    ApiResponse<PageResponse<GroupSummaryResponse>> getMyGroups(String status, Integer page, Integer size);
+
+    @Operation(
+            summary = "그룹 상세 조회 (Mock API)",
+            description = """
+                    그룹 방 상세와 현재 멤버, 진행 중인 그룹 추천 상태를 조회합니다.
+
+                    Mock API 상태:
+                    - `groupId` 존재 여부와 멤버 권한 검증은 아직 수행하지 않습니다.
+                    - 최신 스키마의 그룹 추천 저장 책임은 `group_recommendations` 기준입니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = GroupDetailApiResponse.class)
+                    )
+            )
+    })
+    ApiResponse<GroupDetailResponse> getGroup(Long groupId);
+
+    @Operation(
+            summary = "그룹 초대 코드 생성 (Mock API)",
+            description = """
+                    그룹에 참여할 수 있는 초대 코드를 생성합니다.
+
+                    Mock API 상태:
+                    - 그룹 멤버 권한과 만료 정책 저장은 아직 수행하지 않습니다.
+                    - 실제 저장 테이블은 `group_invites` 기준입니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "초대 코드 생성 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CreateGroupInviteApiResponse.class)
+                    )
+            )
+    })
+    ApiResponse<CreateGroupInviteResponse> createInvite(Long groupId);
+
+    @Operation(
+            summary = "초대 코드로 그룹 참여 (Mock API)",
+            description = """
+                    초대 코드로 그룹에 참여합니다.
+
+                    Mock API 상태:
+                    - 초대 코드 존재 여부, 만료 여부, 중복 가입 검증은 아직 수행하지 않습니다.
+                    - request body validation만 수행합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "그룹 참여 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = JoinGroupApiResponse.class)
+                    )
+            )
+    })
+    ApiResponse<JoinGroupResponse> joinGroup(JoinGroupRequest request);
+
+    @Operation(
+            summary = "그룹 탈퇴 (Mock API)",
+            description = """
+                    현재 회원이 그룹에서 탈퇴합니다.
+
+                    Mock API 상태:
+                    - 그룹 멤버 여부와 소유자 탈퇴 정책은 아직 검증하지 않습니다.
+                    - 실제 저장 테이블은 `group_room_members` 기준입니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "그룹 탈퇴 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = LeaveGroupApiResponse.class)
+                    )
+            )
+    })
+    ApiResponse<LeaveGroupResponse> leaveGroup(Long groupId);
+
+    @Operation(
+            summary = "그룹 추천 시작 (Mock API)",
+            description = """
+                    그룹 추천을 시작하고 후보 메뉴를 생성합니다.
+
+                    Mock API 상태:
+                    - request body validation만 수행합니다.
+                    - 그룹 취향 집계와 후보 생성 알고리즘은 아직 수행하지 않습니다.
+                    - API 경로는 사용자 흐름상 `recommendation-sessions`를 사용하지만, 최신 저장 테이블은 `group_recommendations` 기준입니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "그룹 추천 시작 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CreateGroupRecommendationApiResponse.class)
+                    )
+            )
+    })
+    ApiResponse<CreateGroupRecommendationResponse> createRecommendation(
+            Long groupId,
+            CreateGroupRecommendationRequest request
+    );
+
+    @Operation(
+            summary = "그룹 추천 세션 상세 조회 (Mock API)",
+            description = """
+                    그룹 추천 상태, 후보, 투표 진행률, 최종 후보를 조회합니다.
+
+                    Mock API 상태:
+                    - `groupId`, `sessionId` 존재 여부와 접근 권한은 아직 검증하지 않습니다.
+                    - `sessionId`는 API 표현 이름이며 저장 모델은 `group_recommendations.id`로 해석합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = GroupRecommendationSessionApiResponse.class)
+                    )
+            )
+    })
+    ApiResponse<GroupRecommendationSessionResponse> getRecommendation(Long groupId, Long sessionId);
+
+    @Operation(
+            summary = "그룹 추천 후보 목록 조회 (Mock API)",
+            description = """
+                    그룹 추천 후보 메뉴 목록만 조회합니다.
+
+                    Mock API 상태:
+                    - 후보 3개와 현재 투표수를 고정 응답으로 반환합니다.
+                    - 실제 저장 테이블은 `group_recommendation_candidates` 기준입니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = GroupRecommendationCandidateListApiResponse.class)
+                    )
+            )
+    })
+    ApiResponse<GroupRecommendationCandidateListResponse> getRecommendationCandidates(Long groupId, Long sessionId);
+
+    @Operation(
+            summary = "그룹 추천 후보 투표 (Mock API)",
+            description = """
+                    그룹 추천 후보에 투표합니다.
+
+                    Mock API 상태:
+                    - request body validation만 수행합니다.
+                    - 중복 투표, 후보 소속, 세션 상태 검증은 아직 수행하지 않습니다.
+                    - 실제 저장 테이블은 `group_recommendation_votes` 기준입니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "투표 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = GroupVoteApiResponse.class)
+                    )
+            )
+    })
+    ApiResponse<GroupVoteResponse> vote(Long groupId, Long sessionId, VoteGroupRecommendationRequest request);
+
+    @Operation(
+            summary = "그룹 추천 최종 메뉴 확정 (Mock API)",
+            description = """
+                    투표 결과를 바탕으로 그룹의 최종 메뉴를 확정합니다.
+
+                    Mock API 상태:
+                    - 실제 투표 집계와 동률 처리 정책은 아직 수행하지 않습니다.
+                    - 항상 1순위 후보를 최종 후보로 반환합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "확정 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = FinalizeGroupRecommendationApiResponse.class)
+                    )
+            )
+    })
+    ApiResponse<FinalizeGroupRecommendationResponse> finalizeRecommendation(Long groupId, Long sessionId);
+}

--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -10,6 +10,7 @@ import matchuri.backend.api.group.dto.docs.CreateGroupApiResponse;
 import matchuri.backend.api.group.dto.docs.CreateGroupInviteApiResponse;
 import matchuri.backend.api.group.dto.docs.CreateGroupRecommendationApiResponse;
 import matchuri.backend.api.group.dto.docs.FinalizeGroupRecommendationApiResponse;
+import matchuri.backend.api.group.dto.docs.GroupApiExamples;
 import matchuri.backend.api.group.dto.docs.GroupDetailApiResponse;
 import matchuri.backend.api.group.dto.docs.GroupRecommendationCandidateListApiResponse;
 import matchuri.backend.api.group.dto.docs.GroupRecommendationSessionApiResponse;
@@ -58,16 +59,7 @@ public interface GroupApi {
                             schema = @Schema(implementation = CreateGroupApiResponse.class),
                             examples = @ExampleObject(
                                     name = "success",
-                                    value = """
-                                            {
-                                              "success": true,
-                                              "data": {
-                                                "groupId": 3001,
-                                                "status": "ACTIVE"
-                                              },
-                                              "error": null
-                                            }
-                                            """
+                                    value = GroupApiExamples.CREATE_GROUP_SUCCESS
                             )
                     )
             )
@@ -90,7 +82,11 @@ public interface GroupApi {
                     description = "조회 성공",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = GroupSummaryPageApiResponse.class)
+                            schema = @Schema(implementation = GroupSummaryPageApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = GroupApiExamples.GROUP_LIST_SUCCESS
+                            )
                     )
             )
     })
@@ -112,7 +108,11 @@ public interface GroupApi {
                     description = "조회 성공",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = GroupDetailApiResponse.class)
+                            schema = @Schema(implementation = GroupDetailApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = GroupApiExamples.GROUP_DETAIL_SUCCESS
+                            )
                     )
             )
     })
@@ -134,7 +134,11 @@ public interface GroupApi {
                     description = "초대 코드 생성 성공",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = CreateGroupInviteApiResponse.class)
+                            schema = @Schema(implementation = CreateGroupInviteApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = GroupApiExamples.CREATE_INVITE_SUCCESS
+                            )
                     )
             )
     })
@@ -156,7 +160,11 @@ public interface GroupApi {
                     description = "그룹 참여 성공",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = JoinGroupApiResponse.class)
+                            schema = @Schema(implementation = JoinGroupApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = GroupApiExamples.JOIN_GROUP_SUCCESS
+                            )
                     )
             )
     })
@@ -178,7 +186,11 @@ public interface GroupApi {
                     description = "그룹 탈퇴 성공",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = LeaveGroupApiResponse.class)
+                            schema = @Schema(implementation = LeaveGroupApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = GroupApiExamples.LEAVE_GROUP_SUCCESS
+                            )
                     )
             )
     })
@@ -201,7 +213,11 @@ public interface GroupApi {
                     description = "그룹 추천 시작 성공",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = CreateGroupRecommendationApiResponse.class)
+                            schema = @Schema(implementation = CreateGroupRecommendationApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = GroupApiExamples.CREATE_RECOMMENDATION_SUCCESS
+                            )
                     )
             )
     })
@@ -226,7 +242,11 @@ public interface GroupApi {
                     description = "조회 성공",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = GroupRecommendationSessionApiResponse.class)
+                            schema = @Schema(implementation = GroupRecommendationSessionApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = GroupApiExamples.RECOMMENDATION_SESSION_SUCCESS
+                            )
                     )
             )
     })
@@ -248,7 +268,11 @@ public interface GroupApi {
                     description = "조회 성공",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = GroupRecommendationCandidateListApiResponse.class)
+                            schema = @Schema(implementation = GroupRecommendationCandidateListApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = GroupApiExamples.RECOMMENDATION_CANDIDATES_SUCCESS
+                            )
                     )
             )
     })
@@ -271,7 +295,11 @@ public interface GroupApi {
                     description = "투표 성공",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = GroupVoteApiResponse.class)
+                            schema = @Schema(implementation = GroupVoteApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = GroupApiExamples.VOTE_SUCCESS
+                            )
                     )
             )
     })
@@ -293,7 +321,11 @@ public interface GroupApi {
                     description = "확정 성공",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = FinalizeGroupRecommendationApiResponse.class)
+                            schema = @Schema(implementation = FinalizeGroupRecommendationApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = GroupApiExamples.FINALIZE_RECOMMENDATION_SUCCESS
+                            )
                     )
             )
     })

--- a/src/main/java/matchuri/backend/api/group/GroupController.java
+++ b/src/main/java/matchuri/backend/api/group/GroupController.java
@@ -1,0 +1,120 @@
+package matchuri.backend.api.group;
+
+import jakarta.validation.Valid;
+import java.util.List;
+import matchuri.backend.api.group.dto.request.CreateGroupRecommendationRequest;
+import matchuri.backend.api.group.dto.request.CreateGroupRequest;
+import matchuri.backend.api.group.dto.request.JoinGroupRequest;
+import matchuri.backend.api.group.dto.request.VoteGroupRecommendationRequest;
+import matchuri.backend.api.group.dto.response.CreateGroupInviteResponse;
+import matchuri.backend.api.group.dto.response.CreateGroupRecommendationResponse;
+import matchuri.backend.api.group.dto.response.CreateGroupResponse;
+import matchuri.backend.api.group.dto.response.FinalizeGroupRecommendationResponse;
+import matchuri.backend.api.group.dto.response.GroupDetailResponse;
+import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateListResponse;
+import matchuri.backend.api.group.dto.response.GroupRecommendationSessionResponse;
+import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
+import matchuri.backend.api.group.dto.response.GroupVoteResponse;
+import matchuri.backend.api.group.dto.response.JoinGroupResponse;
+import matchuri.backend.api.group.dto.response.LeaveGroupResponse;
+import matchuri.backend.global.api.ApiResponse;
+import matchuri.backend.global.api.PageResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/groups")
+public class GroupController implements GroupApi {
+
+    @Override
+    @PostMapping
+    public ApiResponse<CreateGroupResponse> createGroup(@Valid @RequestBody CreateGroupRequest request) {
+        return ApiResponse.success(CreateGroupResponse.mockActive());
+    }
+
+    @Override
+    @GetMapping
+    public ApiResponse<PageResponse<GroupSummaryResponse>> getMyGroups(
+            @RequestParam(required = false) String status,
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "20") Integer size
+    ) {
+        return ApiResponse.success(PageResponse.mock(List.of(GroupSummaryResponse.mockActive())));
+    }
+
+    @Override
+    @GetMapping("/{groupId}")
+    public ApiResponse<GroupDetailResponse> getGroup(@PathVariable Long groupId) {
+        return ApiResponse.success(GroupDetailResponse.mockActive());
+    }
+
+    @Override
+    @PostMapping("/{groupId}/invites")
+    public ApiResponse<CreateGroupInviteResponse> createInvite(@PathVariable Long groupId) {
+        return ApiResponse.success(CreateGroupInviteResponse.mockActive());
+    }
+
+    @Override
+    @PostMapping("/join")
+    public ApiResponse<JoinGroupResponse> joinGroup(@Valid @RequestBody JoinGroupRequest request) {
+        return ApiResponse.success(JoinGroupResponse.mockJoined());
+    }
+
+    @Override
+    @PostMapping("/{groupId}/leave")
+    public ApiResponse<LeaveGroupResponse> leaveGroup(@PathVariable Long groupId) {
+        return ApiResponse.success(LeaveGroupResponse.mockLeft());
+    }
+
+    @Override
+    @PostMapping("/{groupId}/recommendation-sessions")
+    public ApiResponse<CreateGroupRecommendationResponse> createRecommendation(
+            @PathVariable Long groupId,
+            @Valid @RequestBody CreateGroupRecommendationRequest request
+    ) {
+        return ApiResponse.success(CreateGroupRecommendationResponse.mockOpen());
+    }
+
+    @Override
+    @GetMapping("/{groupId}/recommendation-sessions/{sessionId}")
+    public ApiResponse<GroupRecommendationSessionResponse> getRecommendation(
+            @PathVariable Long groupId,
+            @PathVariable Long sessionId
+    ) {
+        return ApiResponse.success(GroupRecommendationSessionResponse.mockOpen());
+    }
+
+    @Override
+    @GetMapping("/{groupId}/recommendation-sessions/{sessionId}/candidates")
+    public ApiResponse<GroupRecommendationCandidateListResponse> getRecommendationCandidates(
+            @PathVariable Long groupId,
+            @PathVariable Long sessionId
+    ) {
+        return ApiResponse.success(GroupRecommendationCandidateListResponse.mock());
+    }
+
+    @Override
+    @PostMapping("/{groupId}/recommendation-sessions/{sessionId}/votes")
+    public ApiResponse<GroupVoteResponse> vote(
+            @PathVariable Long groupId,
+            @PathVariable Long sessionId,
+            @Valid @RequestBody VoteGroupRecommendationRequest request
+    ) {
+        return ApiResponse.success(GroupVoteResponse.mockVoted(request.candidateId(), request.voteValue()));
+    }
+
+    @Override
+    @PatchMapping("/{groupId}/recommendation-sessions/{sessionId}/finalize")
+    public ApiResponse<FinalizeGroupRecommendationResponse> finalizeRecommendation(
+            @PathVariable Long groupId,
+            @PathVariable Long sessionId
+    ) {
+        return ApiResponse.success(FinalizeGroupRecommendationResponse.mockFinalized());
+    }
+}

--- a/src/main/java/matchuri/backend/api/group/dto/docs/CreateGroupApiResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/CreateGroupApiResponse.java
@@ -1,0 +1,9 @@
+package matchuri.backend.api.group.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.group.dto.response.CreateGroupResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "그룹 생성 API의 공통 응답 envelope입니다.")
+public record CreateGroupApiResponse(boolean success, CreateGroupResponse data, ErrorResponse error) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/docs/CreateGroupInviteApiResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/CreateGroupInviteApiResponse.java
@@ -1,0 +1,9 @@
+package matchuri.backend.api.group.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.group.dto.response.CreateGroupInviteResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "그룹 초대 코드 생성 API의 공통 응답 envelope입니다.")
+public record CreateGroupInviteApiResponse(boolean success, CreateGroupInviteResponse data, ErrorResponse error) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/docs/CreateGroupRecommendationApiResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/CreateGroupRecommendationApiResponse.java
@@ -1,0 +1,13 @@
+package matchuri.backend.api.group.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.group.dto.response.CreateGroupRecommendationResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "그룹 추천 시작 API의 공통 응답 envelope입니다.")
+public record CreateGroupRecommendationApiResponse(
+        boolean success,
+        CreateGroupRecommendationResponse data,
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/docs/FinalizeGroupRecommendationApiResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/FinalizeGroupRecommendationApiResponse.java
@@ -1,0 +1,13 @@
+package matchuri.backend.api.group.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.group.dto.response.FinalizeGroupRecommendationResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "그룹 추천 최종 메뉴 확정 API의 공통 응답 envelope입니다.")
+public record FinalizeGroupRecommendationApiResponse(
+        boolean success,
+        FinalizeGroupRecommendationResponse data,
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -1,0 +1,312 @@
+package matchuri.backend.api.group.dto.docs;
+
+public final class GroupApiExamples {
+
+    private GroupApiExamples() {
+    }
+
+    public static final String CREATE_GROUP_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "groupId": 3001,
+                "status": "ACTIVE"
+              },
+              "error": null
+            }
+            """;
+
+    public static final String GROUP_LIST_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "content": [
+                  {
+                    "id": 3001,
+                    "name": "오늘 점심 메뉴 회의",
+                    "status": "ACTIVE",
+                    "memberCount": 4,
+                    "latestRecommendationStatus": "OPEN",
+                    "createdAt": "2026-05-06T12:00:00"
+                  }
+                ],
+                "pageInfo": {
+                  "page": 0,
+                  "size": 10,
+                  "totalElements": 1,
+                  "totalPages": 1,
+                  "first": true,
+                  "last": true,
+                  "hasNext": false,
+                  "hasPrevious": false
+                }
+              },
+              "error": null
+            }
+            """;
+
+    public static final String GROUP_DETAIL_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "id": 3001,
+                "name": "오늘 점심 메뉴 회의",
+                "latitude": 37.498095,
+                "longitude": 127.027610,
+                "status": "ACTIVE",
+                "members": [
+                  {
+                    "memberId": 1,
+                    "nickname": "점심탐험가",
+                    "role": "OWNER",
+                    "status": "ACTIVE",
+                    "joinedAt": "2026-05-06T12:01:00"
+                  },
+                  {
+                    "memberId": 2,
+                    "nickname": "든든한한끼",
+                    "role": "MEMBER",
+                    "status": "ACTIVE",
+                    "joinedAt": "2026-05-06T12:02:00"
+                  },
+                  {
+                    "memberId": 3,
+                    "nickname": "매콤러버",
+                    "role": "MEMBER",
+                    "status": "ACTIVE",
+                    "joinedAt": "2026-05-06T12:02:00"
+                  },
+                  {
+                    "memberId": 4,
+                    "nickname": "국물파",
+                    "role": "MEMBER",
+                    "status": "ACTIVE",
+                    "joinedAt": "2026-05-06T12:02:00"
+                  }
+                ],
+                "activeRecommendation": {
+                  "sessionId": 5001,
+                  "status": "OPEN",
+                  "candidates": [
+                    {
+                      "candidateId": 8001,
+                      "menuId": 1001,
+                      "menuName": "비빔밥",
+                      "rankNo": 1,
+                      "score": 91.5,
+                      "voteCount": 3
+                    },
+                    {
+                      "candidateId": 8002,
+                      "menuId": 1002,
+                      "menuName": "돈까스",
+                      "rankNo": 2,
+                      "score": 84.0,
+                      "voteCount": 1
+                    },
+                    {
+                      "candidateId": 8003,
+                      "menuId": 1003,
+                      "menuName": "쌀국수",
+                      "rankNo": 3,
+                      "score": 79.5,
+                      "voteCount": 0
+                    }
+                  ],
+                  "voteProgress": {
+                    "totalMemberCount": 4,
+                    "votedMemberCount": 3
+                  },
+                  "finalCandidate": null,
+                  "createdAt": "2026-05-06T12:05:00"
+                }
+              },
+              "error": null
+            }
+            """;
+
+    public static final String CREATE_INVITE_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "groupId": 3001,
+                "inviteCode": "LUNCH42",
+                "expiresAt": "2026-05-06T13:00:00",
+                "status": "ACTIVE"
+              },
+              "error": null
+            }
+            """;
+
+    public static final String JOIN_GROUP_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "groupId": 3001,
+                "memberStatus": "ACTIVE"
+              },
+              "error": null
+            }
+            """;
+
+    public static final String LEAVE_GROUP_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "groupId": 3001,
+                "memberStatus": "LEFT",
+                "leftAt": "2026-05-06T12:30:00"
+              },
+              "error": null
+            }
+            """;
+
+    public static final String CREATE_RECOMMENDATION_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "sessionId": 5001,
+                "status": "OPEN",
+                "candidates": [
+                  {
+                    "candidateId": 8001,
+                    "menuId": 1001,
+                    "menuName": "비빔밥",
+                    "rankNo": 1,
+                    "score": 91.5,
+                    "voteCount": 3
+                  },
+                  {
+                    "candidateId": 8002,
+                    "menuId": 1002,
+                    "menuName": "돈까스",
+                    "rankNo": 2,
+                    "score": 84.0,
+                    "voteCount": 1
+                  },
+                  {
+                    "candidateId": 8003,
+                    "menuId": 1003,
+                    "menuName": "쌀국수",
+                    "rankNo": 3,
+                    "score": 79.5,
+                    "voteCount": 0
+                  }
+                ]
+              },
+              "error": null
+            }
+            """;
+
+    public static final String RECOMMENDATION_SESSION_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "sessionId": 5001,
+                "status": "OPEN",
+                "candidates": [
+                  {
+                    "candidateId": 8001,
+                    "menuId": 1001,
+                    "menuName": "비빔밥",
+                    "rankNo": 1,
+                    "score": 91.5,
+                    "voteCount": 3
+                  },
+                  {
+                    "candidateId": 8002,
+                    "menuId": 1002,
+                    "menuName": "돈까스",
+                    "rankNo": 2,
+                    "score": 84.0,
+                    "voteCount": 1
+                  },
+                  {
+                    "candidateId": 8003,
+                    "menuId": 1003,
+                    "menuName": "쌀국수",
+                    "rankNo": 3,
+                    "score": 79.5,
+                    "voteCount": 0
+                  }
+                ],
+                "voteProgress": {
+                  "totalMemberCount": 4,
+                  "votedMemberCount": 3
+                },
+                "finalCandidate": null,
+                "createdAt": "2026-05-06T12:05:00"
+              },
+              "error": null
+            }
+            """;
+
+    public static final String RECOMMENDATION_CANDIDATES_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "sessionId": 5001,
+                "candidates": [
+                  {
+                    "candidateId": 8001,
+                    "menuId": 1001,
+                    "menuName": "비빔밥",
+                    "rankNo": 1,
+                    "score": 91.5,
+                    "voteCount": 3
+                  },
+                  {
+                    "candidateId": 8002,
+                    "menuId": 1002,
+                    "menuName": "돈까스",
+                    "rankNo": 2,
+                    "score": 84.0,
+                    "voteCount": 1
+                  },
+                  {
+                    "candidateId": 8003,
+                    "menuId": 1003,
+                    "menuName": "쌀국수",
+                    "rankNo": 3,
+                    "score": 79.5,
+                    "voteCount": 0
+                  }
+                ]
+              },
+              "error": null
+            }
+            """;
+
+    public static final String VOTE_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "voteId": 91001,
+                "candidateId": 8001,
+                "voteValue": 1,
+                "votedAt": "2026-05-06T12:20:00"
+              },
+              "error": null
+            }
+            """;
+
+    public static final String FINALIZE_RECOMMENDATION_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "sessionId": 5001,
+                "status": "FINALIZED",
+                "finalCandidate": {
+                  "candidateId": 8001,
+                  "menuId": 1001,
+                  "menuName": "비빔밥",
+                  "rankNo": 1,
+                  "score": 91.5,
+                  "voteCount": 3
+                },
+                "finalizedAt": "2026-05-06T12:25:00"
+              },
+              "error": null
+            }
+            """;
+}

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupDetailApiResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupDetailApiResponse.java
@@ -1,0 +1,9 @@
+package matchuri.backend.api.group.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.group.dto.response.GroupDetailResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "그룹 상세 조회 API의 공통 응답 envelope입니다.")
+public record GroupDetailApiResponse(boolean success, GroupDetailResponse data, ErrorResponse error) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupRecommendationCandidateListApiResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupRecommendationCandidateListApiResponse.java
@@ -1,0 +1,13 @@
+package matchuri.backend.api.group.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateListResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "그룹 추천 후보 목록 API의 공통 응답 envelope입니다.")
+public record GroupRecommendationCandidateListApiResponse(
+        boolean success,
+        GroupRecommendationCandidateListResponse data,
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupRecommendationSessionApiResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupRecommendationSessionApiResponse.java
@@ -1,0 +1,13 @@
+package matchuri.backend.api.group.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.group.dto.response.GroupRecommendationSessionResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "그룹 추천 세션 상세 API의 공통 응답 envelope입니다.")
+public record GroupRecommendationSessionApiResponse(
+        boolean success,
+        GroupRecommendationSessionResponse data,
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupSummaryPageApiResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupSummaryPageApiResponse.java
@@ -1,0 +1,10 @@
+package matchuri.backend.api.group.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
+import matchuri.backend.global.api.ErrorResponse;
+import matchuri.backend.global.api.PageResponse;
+
+@Schema(description = "내 그룹 목록 API의 공통 응답 envelope입니다.")
+public record GroupSummaryPageApiResponse(boolean success, PageResponse<GroupSummaryResponse> data, ErrorResponse error) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupVoteApiResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupVoteApiResponse.java
@@ -1,0 +1,9 @@
+package matchuri.backend.api.group.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.group.dto.response.GroupVoteResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "그룹 추천 후보 투표 API의 공통 응답 envelope입니다.")
+public record GroupVoteApiResponse(boolean success, GroupVoteResponse data, ErrorResponse error) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/docs/JoinGroupApiResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/JoinGroupApiResponse.java
@@ -1,0 +1,9 @@
+package matchuri.backend.api.group.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.group.dto.response.JoinGroupResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "그룹 참여 API의 공통 응답 envelope입니다.")
+public record JoinGroupApiResponse(boolean success, JoinGroupResponse data, ErrorResponse error) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/docs/LeaveGroupApiResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/LeaveGroupApiResponse.java
@@ -1,0 +1,9 @@
+package matchuri.backend.api.group.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.group.dto.response.LeaveGroupResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "그룹 탈퇴 API의 공통 응답 envelope입니다.")
+public record LeaveGroupApiResponse(boolean success, LeaveGroupResponse data, ErrorResponse error) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/request/CreateGroupRecommendationRequest.java
+++ b/src/main/java/matchuri/backend/api/group/dto/request/CreateGroupRecommendationRequest.java
@@ -1,0 +1,15 @@
+package matchuri.backend.api.group.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+
+public record CreateGroupRecommendationRequest(
+        @Schema(
+                description = "그룹 추천 컨텍스트입니다. MVP에서는 mealTime, partySize, locationLabel 같은 느슨한 JSON 값으로 시작합니다.",
+                example = "{\"mealTime\":\"LUNCH\",\"partySize\":4}"
+        )
+        @NotNull(message = "contextJson은 null일 수 없습니다.")
+        Map<String, Object> contextJson
+) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/request/CreateGroupRequest.java
+++ b/src/main/java/matchuri/backend/api/group/dto/request/CreateGroupRequest.java
@@ -1,0 +1,26 @@
+package matchuri.backend.api.group.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+
+public record CreateGroupRequest(
+        @Schema(description = "그룹 방 이름입니다.", example = "오늘 점심 메뉴 회의")
+        @NotBlank(message = "name은 비어 있을 수 없습니다.")
+        @Size(max = 100, message = "name은 100자를 초과할 수 없습니다.")
+        String name,
+
+        @Schema(description = "그룹 추천 기준 위치의 위도입니다.", example = "37.498095")
+        @DecimalMin(value = "-90.0", message = "latitude는 -90 이상이어야 합니다.")
+        @DecimalMax(value = "90.0", message = "latitude는 90 이하여야 합니다.")
+        BigDecimal latitude,
+
+        @Schema(description = "그룹 추천 기준 위치의 경도입니다.", example = "127.027610")
+        @DecimalMin(value = "-180.0", message = "longitude는 -180 이상이어야 합니다.")
+        @DecimalMax(value = "180.0", message = "longitude는 180 이하여야 합니다.")
+        BigDecimal longitude
+) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/request/JoinGroupRequest.java
+++ b/src/main/java/matchuri/backend/api/group/dto/request/JoinGroupRequest.java
@@ -1,0 +1,13 @@
+package matchuri.backend.api.group.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record JoinGroupRequest(
+        @Schema(description = "그룹 초대 코드입니다.", example = "LUNCH42")
+        @NotBlank(message = "inviteCode는 비어 있을 수 없습니다.")
+        @Size(max = 32, message = "inviteCode는 32자를 초과할 수 없습니다.")
+        String inviteCode
+) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/request/VoteGroupRecommendationRequest.java
+++ b/src/main/java/matchuri/backend/api/group/dto/request/VoteGroupRecommendationRequest.java
@@ -1,0 +1,21 @@
+package matchuri.backend.api.group.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record VoteGroupRecommendationRequest(
+        @Schema(description = "투표할 그룹 추천 후보 ID입니다.", example = "8001")
+        @NotNull(message = "candidateId는 null일 수 없습니다.")
+        @Positive(message = "candidateId는 양수여야 합니다.")
+        Long candidateId,
+
+        @Schema(description = "투표 값입니다. MVP에서는 1=찬성, 0=비선호로 사용합니다.", example = "1")
+        @NotNull(message = "voteValue는 null일 수 없습니다.")
+        @Min(value = 0, message = "voteValue는 0 또는 1이어야 합니다.")
+        @Max(value = 1, message = "voteValue는 0 또는 1이어야 합니다.")
+        Integer voteValue
+) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/response/CreateGroupInviteResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/CreateGroupInviteResponse.java
@@ -1,0 +1,28 @@
+package matchuri.backend.api.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import matchuri.backend.domain.group.entity.GroupInviteStatus;
+
+public record CreateGroupInviteResponse(
+        @Schema(description = "그룹 ID입니다.", example = "3001")
+        Long groupId,
+
+        @Schema(description = "생성된 초대 코드입니다.", example = "LUNCH42")
+        String inviteCode,
+
+        @Schema(description = "초대 코드 만료 시각입니다.", example = "2026-05-06T13:00:00")
+        LocalDateTime expiresAt,
+
+        @Schema(description = "초대 코드 상태입니다.", example = "ACTIVE")
+        GroupInviteStatus status
+) {
+    public static CreateGroupInviteResponse mockActive() {
+        return new CreateGroupInviteResponse(
+                3001L,
+                "LUNCH42",
+                LocalDateTime.of(2026, 5, 6, 13, 0),
+                GroupInviteStatus.ACTIVE
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/api/group/dto/response/CreateGroupRecommendationResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/CreateGroupRecommendationResponse.java
@@ -1,0 +1,24 @@
+package matchuri.backend.api.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
+
+public record CreateGroupRecommendationResponse(
+        @Schema(description = "그룹 추천 ID입니다. API 경로에서는 sessionId로 표현합니다.", example = "5001")
+        Long sessionId,
+
+        @Schema(description = "그룹 추천 상태입니다.", example = "OPEN")
+        GroupRecommendationStatus status,
+
+        @Schema(description = "생성된 추천 후보 목록입니다.")
+        List<GroupRecommendationCandidateResponse> candidates
+) {
+    public static CreateGroupRecommendationResponse mockOpen() {
+        return new CreateGroupRecommendationResponse(
+                5001L,
+                GroupRecommendationStatus.OPEN,
+                GroupMocks.candidates()
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/api/group/dto/response/CreateGroupResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/CreateGroupResponse.java
@@ -1,0 +1,16 @@
+package matchuri.backend.api.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.domain.group.entity.GroupRoomStatus;
+
+public record CreateGroupResponse(
+        @Schema(description = "생성된 그룹 ID입니다.", example = "3001")
+        Long groupId,
+
+        @Schema(description = "그룹 상태입니다.", example = "ACTIVE")
+        GroupRoomStatus status
+) {
+    public static CreateGroupResponse mockActive() {
+        return new CreateGroupResponse(3001L, GroupRoomStatus.ACTIVE);
+    }
+}

--- a/src/main/java/matchuri/backend/api/group/dto/response/FinalizeGroupRecommendationResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/FinalizeGroupRecommendationResponse.java
@@ -1,0 +1,28 @@
+package matchuri.backend.api.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
+
+public record FinalizeGroupRecommendationResponse(
+        @Schema(description = "그룹 추천 ID입니다. API 경로에서는 sessionId로 표현합니다.", example = "5001")
+        Long sessionId,
+
+        @Schema(description = "확정 후 그룹 추천 상태입니다.", example = "FINALIZED")
+        GroupRecommendationStatus status,
+
+        @Schema(description = "최종 확정 후보입니다.")
+        GroupRecommendationCandidateResponse finalCandidate,
+
+        @Schema(description = "최종 확정 시각입니다.", example = "2026-05-06T12:25:00")
+        LocalDateTime finalizedAt
+) {
+    public static FinalizeGroupRecommendationResponse mockFinalized() {
+        return new FinalizeGroupRecommendationResponse(
+                5001L,
+                GroupRecommendationStatus.FINALIZED,
+                GroupRecommendationCandidateResponse.mockBibimbap(),
+                LocalDateTime.of(2026, 5, 6, 12, 25)
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupDetailResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupDetailResponse.java
@@ -1,0 +1,41 @@
+package matchuri.backend.api.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.util.List;
+import matchuri.backend.domain.group.entity.GroupRoomStatus;
+
+public record GroupDetailResponse(
+        @Schema(description = "그룹 ID입니다.", example = "3001")
+        Long id,
+
+        @Schema(description = "그룹 이름입니다.", example = "오늘 점심 메뉴 회의")
+        String name,
+
+        @Schema(description = "추천 기준 위치의 위도입니다.", example = "37.498095")
+        BigDecimal latitude,
+
+        @Schema(description = "추천 기준 위치의 경도입니다.", example = "127.027610")
+        BigDecimal longitude,
+
+        @Schema(description = "그룹 상태입니다.", example = "ACTIVE")
+        GroupRoomStatus status,
+
+        @Schema(description = "현재 그룹 멤버 목록입니다.")
+        List<GroupMemberSummaryResponse> members,
+
+        @Schema(description = "진행 중인 그룹 추천입니다. 없으면 null입니다.")
+        GroupRecommendationSessionResponse activeRecommendation
+) {
+    public static GroupDetailResponse mockActive() {
+        return new GroupDetailResponse(
+                3001L,
+                "오늘 점심 메뉴 회의",
+                new BigDecimal("37.498095"),
+                new BigDecimal("127.027610"),
+                GroupRoomStatus.ACTIVE,
+                GroupMocks.members(),
+                GroupRecommendationSessionResponse.mockOpen()
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupMemberSummaryResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupMemberSummaryResponse.java
@@ -1,0 +1,43 @@
+package matchuri.backend.api.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import matchuri.backend.domain.group.entity.GroupMemberRole;
+import matchuri.backend.domain.group.entity.GroupMemberStatus;
+
+public record GroupMemberSummaryResponse(
+        @Schema(description = "회원 ID입니다.", example = "1")
+        Long memberId,
+
+        @Schema(description = "회원 닉네임입니다.", example = "점심탐험가")
+        String nickname,
+
+        @Schema(description = "그룹 내 역할입니다.", example = "OWNER")
+        GroupMemberRole role,
+
+        @Schema(description = "그룹 멤버 상태입니다.", example = "ACTIVE")
+        GroupMemberStatus status,
+
+        @Schema(description = "그룹 참여 시각입니다.", example = "2026-05-06T12:01:00")
+        LocalDateTime joinedAt
+) {
+    public static GroupMemberSummaryResponse mockOwner() {
+        return new GroupMemberSummaryResponse(
+                1L,
+                "점심탐험가",
+                GroupMemberRole.OWNER,
+                GroupMemberStatus.ACTIVE,
+                LocalDateTime.of(2026, 5, 6, 12, 1)
+        );
+    }
+
+    public static GroupMemberSummaryResponse mockMember(Long memberId, String nickname) {
+        return new GroupMemberSummaryResponse(
+                memberId,
+                nickname,
+                GroupMemberRole.MEMBER,
+                GroupMemberStatus.ACTIVE,
+                LocalDateTime.of(2026, 5, 6, 12, 2)
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupMocks.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupMocks.java
@@ -1,0 +1,26 @@
+package matchuri.backend.api.group.dto.response;
+
+import java.util.List;
+
+final class GroupMocks {
+
+    private GroupMocks() {
+    }
+
+    static List<GroupMemberSummaryResponse> members() {
+        return List.of(
+                GroupMemberSummaryResponse.mockOwner(),
+                GroupMemberSummaryResponse.mockMember(2L, "든든한한끼"),
+                GroupMemberSummaryResponse.mockMember(3L, "매콤러버"),
+                GroupMemberSummaryResponse.mockMember(4L, "국물파")
+        );
+    }
+
+    static List<GroupRecommendationCandidateResponse> candidates() {
+        return List.of(
+                GroupRecommendationCandidateResponse.mockBibimbap(),
+                GroupRecommendationCandidateResponse.mockPorkCutlet(),
+                GroupRecommendationCandidateResponse.mockRiceNoodle()
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationCandidateListResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationCandidateListResponse.java
@@ -1,0 +1,16 @@
+package matchuri.backend.api.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record GroupRecommendationCandidateListResponse(
+        @Schema(description = "그룹 추천 ID입니다. API 경로에서는 sessionId로 표현합니다.", example = "5001")
+        Long sessionId,
+
+        @Schema(description = "추천 후보 목록입니다.")
+        List<GroupRecommendationCandidateResponse> candidates
+) {
+    public static GroupRecommendationCandidateListResponse mock() {
+        return new GroupRecommendationCandidateListResponse(5001L, GroupMocks.candidates());
+    }
+}

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationCandidateResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationCandidateResponse.java
@@ -18,9 +18,6 @@ public record GroupRecommendationCandidateResponse(
         @Schema(description = "Mock 추천 점수입니다.", example = "91.5")
         Double score,
 
-//        @Schema(description = "그룹 추천 근거 요약입니다.", example = "매운맛 선호와 제한 재료 회피 조건을 함께 만족합니다.")
-//        String reasonSummary,
-
         @Schema(description = "현재 찬성 투표 수입니다.", example = "3")
         Integer voteCount
 ) {
@@ -31,7 +28,6 @@ public record GroupRecommendationCandidateResponse(
                 "비빔밥",
                 1,
                 91.5,
-//                "매운맛 선호와 제한 재료 회피 조건을 함께 만족합니다.",
                 3
         );
     }
@@ -43,7 +39,6 @@ public record GroupRecommendationCandidateResponse(
                 "돈까스",
                 2,
                 84.0,
-//                "바삭한 식감 선호자가 많고 대중적으로 합의하기 쉬운 후보입니다.",
                 1
         );
     }
@@ -55,7 +50,6 @@ public record GroupRecommendationCandidateResponse(
                 "쌀국수",
                 3,
                 79.5,
-//                "따뜻한 국물 선호와 가벼운 점심 요구를 반영한 후보입니다.",
                 0
         );
     }

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationCandidateResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationCandidateResponse.java
@@ -18,8 +18,8 @@ public record GroupRecommendationCandidateResponse(
         @Schema(description = "Mock 추천 점수입니다.", example = "91.5")
         Double score,
 
-        @Schema(description = "그룹 추천 근거 요약입니다.", example = "매운맛 선호와 제한 재료 회피 조건을 함께 만족합니다.")
-        String reasonSummary,
+//        @Schema(description = "그룹 추천 근거 요약입니다.", example = "매운맛 선호와 제한 재료 회피 조건을 함께 만족합니다.")
+//        String reasonSummary,
 
         @Schema(description = "현재 찬성 투표 수입니다.", example = "3")
         Integer voteCount
@@ -31,7 +31,7 @@ public record GroupRecommendationCandidateResponse(
                 "비빔밥",
                 1,
                 91.5,
-                "매운맛 선호와 제한 재료 회피 조건을 함께 만족합니다.",
+//                "매운맛 선호와 제한 재료 회피 조건을 함께 만족합니다.",
                 3
         );
     }
@@ -43,7 +43,7 @@ public record GroupRecommendationCandidateResponse(
                 "돈까스",
                 2,
                 84.0,
-                "바삭한 식감 선호자가 많고 대중적으로 합의하기 쉬운 후보입니다.",
+//                "바삭한 식감 선호자가 많고 대중적으로 합의하기 쉬운 후보입니다.",
                 1
         );
     }
@@ -55,7 +55,7 @@ public record GroupRecommendationCandidateResponse(
                 "쌀국수",
                 3,
                 79.5,
-                "따뜻한 국물 선호와 가벼운 점심 요구를 반영한 후보입니다.",
+//                "따뜻한 국물 선호와 가벼운 점심 요구를 반영한 후보입니다.",
                 0
         );
     }

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationCandidateResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationCandidateResponse.java
@@ -1,0 +1,62 @@
+package matchuri.backend.api.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GroupRecommendationCandidateResponse(
+        @Schema(description = "그룹 추천 후보 ID입니다.", example = "8001")
+        Long candidateId,
+
+        @Schema(description = "후보 메뉴 ID입니다.", example = "1001")
+        Long menuId,
+
+        @Schema(description = "후보 메뉴명입니다.", example = "비빔밥")
+        String menuName,
+
+        @Schema(description = "추천 순위입니다.", example = "1")
+        Integer rankNo,
+
+        @Schema(description = "Mock 추천 점수입니다.", example = "91.5")
+        Double score,
+
+        @Schema(description = "그룹 추천 근거 요약입니다.", example = "매운맛 선호와 제한 재료 회피 조건을 함께 만족합니다.")
+        String reasonSummary,
+
+        @Schema(description = "현재 찬성 투표 수입니다.", example = "3")
+        Integer voteCount
+) {
+    public static GroupRecommendationCandidateResponse mockBibimbap() {
+        return new GroupRecommendationCandidateResponse(
+                8001L,
+                1001L,
+                "비빔밥",
+                1,
+                91.5,
+                "매운맛 선호와 제한 재료 회피 조건을 함께 만족합니다.",
+                3
+        );
+    }
+
+    public static GroupRecommendationCandidateResponse mockPorkCutlet() {
+        return new GroupRecommendationCandidateResponse(
+                8002L,
+                1002L,
+                "돈까스",
+                2,
+                84.0,
+                "바삭한 식감 선호자가 많고 대중적으로 합의하기 쉬운 후보입니다.",
+                1
+        );
+    }
+
+    public static GroupRecommendationCandidateResponse mockRiceNoodle() {
+        return new GroupRecommendationCandidateResponse(
+                8003L,
+                1003L,
+                "쌀국수",
+                3,
+                79.5,
+                "따뜻한 국물 선호와 가벼운 점심 요구를 반영한 후보입니다.",
+                0
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationSessionResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationSessionResponse.java
@@ -1,0 +1,37 @@
+package matchuri.backend.api.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
+
+public record GroupRecommendationSessionResponse(
+        @Schema(description = "그룹 추천 ID입니다. API 경로에서는 sessionId로 표현합니다.", example = "5001")
+        Long sessionId,
+
+        @Schema(description = "그룹 추천 상태입니다.", example = "OPEN")
+        GroupRecommendationStatus status,
+
+        @Schema(description = "추천 후보 목록입니다.")
+        List<GroupRecommendationCandidateResponse> candidates,
+
+        @Schema(description = "투표 진행률입니다.")
+        GroupVoteProgressResponse voteProgress,
+
+        @Schema(description = "최종 확정 후보입니다. 확정 전에는 null입니다.")
+        GroupRecommendationCandidateResponse finalCandidate,
+
+        @Schema(description = "그룹 추천 생성 시각입니다.", example = "2026-05-06T12:05:00")
+        LocalDateTime createdAt
+) {
+    public static GroupRecommendationSessionResponse mockOpen() {
+        return new GroupRecommendationSessionResponse(
+                5001L,
+                GroupRecommendationStatus.OPEN,
+                GroupMocks.candidates(),
+                GroupVoteProgressResponse.mockInProgress(),
+                null,
+                LocalDateTime.of(2026, 5, 6, 12, 5)
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupSummaryResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupSummaryResponse.java
@@ -1,0 +1,37 @@
+package matchuri.backend.api.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
+import matchuri.backend.domain.group.entity.GroupRoomStatus;
+
+public record GroupSummaryResponse(
+        @Schema(description = "그룹 ID입니다.", example = "3001")
+        Long id,
+
+        @Schema(description = "그룹 이름입니다.", example = "오늘 점심 메뉴 회의")
+        String name,
+
+        @Schema(description = "그룹 상태입니다.", example = "ACTIVE")
+        GroupRoomStatus status,
+
+        @Schema(description = "활성 멤버 수입니다.", example = "4")
+        Integer memberCount,
+
+        @Schema(description = "최근 그룹 추천 상태입니다.", example = "OPEN")
+        GroupRecommendationStatus latestRecommendationStatus,
+
+        @Schema(description = "그룹 생성 시각입니다.", example = "2026-05-06T12:00:00")
+        LocalDateTime createdAt
+) {
+    public static GroupSummaryResponse mockActive() {
+        return new GroupSummaryResponse(
+                3001L,
+                "오늘 점심 메뉴 회의",
+                GroupRoomStatus.ACTIVE,
+                4,
+                GroupRecommendationStatus.OPEN,
+                LocalDateTime.of(2026, 5, 6, 12, 0)
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupVoteProgressResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupVoteProgressResponse.java
@@ -1,0 +1,15 @@
+package matchuri.backend.api.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GroupVoteProgressResponse(
+        @Schema(description = "투표 대상 멤버 수입니다.", example = "4")
+        Integer totalMemberCount,
+
+        @Schema(description = "투표를 완료한 멤버 수입니다.", example = "3")
+        Integer votedMemberCount
+) {
+    public static GroupVoteProgressResponse mockInProgress() {
+        return new GroupVoteProgressResponse(4, 3);
+    }
+}

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupVoteResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupVoteResponse.java
@@ -1,0 +1,27 @@
+package matchuri.backend.api.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record GroupVoteResponse(
+        @Schema(description = "투표 ID입니다.", example = "91001")
+        Long voteId,
+
+        @Schema(description = "투표한 후보 ID입니다.", example = "8001")
+        Long candidateId,
+
+        @Schema(description = "투표 값입니다.", example = "1")
+        Integer voteValue,
+
+        @Schema(description = "투표 시각입니다.", example = "2026-05-06T12:20:00")
+        LocalDateTime votedAt
+) {
+    public static GroupVoteResponse mockVoted(Long candidateId, Integer voteValue) {
+        return new GroupVoteResponse(
+                91001L,
+                candidateId,
+                voteValue,
+                LocalDateTime.of(2026, 5, 6, 12, 20)
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/api/group/dto/response/JoinGroupResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/JoinGroupResponse.java
@@ -1,0 +1,16 @@
+package matchuri.backend.api.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.domain.group.entity.GroupMemberStatus;
+
+public record JoinGroupResponse(
+        @Schema(description = "참여한 그룹 ID입니다.", example = "3001")
+        Long groupId,
+
+        @Schema(description = "그룹 멤버 상태입니다.", example = "ACTIVE")
+        GroupMemberStatus memberStatus
+) {
+    public static JoinGroupResponse mockJoined() {
+        return new JoinGroupResponse(3001L, GroupMemberStatus.ACTIVE);
+    }
+}

--- a/src/main/java/matchuri/backend/api/group/dto/response/LeaveGroupResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/LeaveGroupResponse.java
@@ -1,0 +1,24 @@
+package matchuri.backend.api.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import matchuri.backend.domain.group.entity.GroupMemberStatus;
+
+public record LeaveGroupResponse(
+        @Schema(description = "탈퇴한 그룹 ID입니다.", example = "3001")
+        Long groupId,
+
+        @Schema(description = "탈퇴 후 멤버 상태입니다.", example = "LEFT")
+        GroupMemberStatus memberStatus,
+
+        @Schema(description = "탈퇴 처리 시각입니다.", example = "2026-05-06T12:30:00")
+        LocalDateTime leftAt
+) {
+    public static LeaveGroupResponse mockLeft() {
+        return new LeaveGroupResponse(
+                3001L,
+                GroupMemberStatus.LEFT,
+                LocalDateTime.of(2026, 5, 6, 12, 30)
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
@@ -79,8 +79,7 @@ public interface RecommendationApi {
                                                     "menuId": 1001,
                                                     "menuName": "비빔밥",
                                                     "rankNo": 1,
-                                                    "score": 93.5,
-                                                    "reasonSummary": "채소와 매운맛 선호가 잘 맞는 후보입니다."
+                                                    "score": 93.5
                                                   }
                                                 ],
                                                 "resultJson": {

--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
@@ -1,0 +1,172 @@
+package matchuri.backend.api.recommendation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import matchuri.backend.api.recommendation.dto.docs.PersonalRecommendationCandidateListApiResponse;
+import matchuri.backend.api.recommendation.dto.docs.PersonalRecommendationDetailApiResponse;
+import matchuri.backend.api.recommendation.dto.docs.PersonalRecommendationRequestApiResponse;
+import matchuri.backend.api.recommendation.dto.docs.PersonalRecommendationSummaryPageApiResponse;
+import matchuri.backend.api.recommendation.dto.docs.SelectPersonalRecommendationApiResponse;
+import matchuri.backend.api.recommendation.dto.request.CreatePersonalRecommendationRequest;
+import matchuri.backend.api.recommendation.dto.request.SelectPersonalRecommendationRequest;
+import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationCandidateListResponse;
+import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationDetailResponse;
+import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationRequestResponse;
+import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationResponse;
+import matchuri.backend.api.recommendation.dto.response.SelectPersonalRecommendationResponse;
+import matchuri.backend.global.api.ApiResponse;
+import matchuri.backend.global.api.PageResponse;
+
+@Tag(name = "Personal Recommendation", description = "개인 점심 메뉴 추천 API")
+public interface RecommendationApi {
+
+    @Operation(
+            summary = "내 개인 추천 이력 목록 조회 (Mock API)",
+            description = """
+                    내 개인 추천 이력 목록을 조회합니다.
+
+                    Mock API 상태:
+                    - 현재 응답은 비즈니스 로직과 DB 조회를 거치지 않는 더미 응답입니다.
+                    - 실제 저장 테이블은 `personal_recommendations` 기준입니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = PersonalRecommendationSummaryPageApiResponse.class)
+                    )
+            )
+    })
+    ApiResponse<PageResponse<PersonalRecommendationResponse>> getMyPersonalRecommendationList();
+
+    @Operation(
+            summary = "개인 추천 요청 생성 (Mock API)",
+            description = """
+                    현재 회원의 취향 프로필과 요청 컨텍스트를 바탕으로 개인 추천을 실행합니다.
+
+                    Mock API 상태:
+                    - request body validation만 수행합니다.
+                    - 추천 알고리즘, 후보 저장, 이력 저장은 아직 수행하지 않습니다.
+                    - 실제 저장 테이블은 `personal_recommendations`, `personal_recommendation_candidates` 기준입니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "추천 요청 생성 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = PersonalRecommendationRequestApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "data": {
+                                                "requestId": 9001,
+                                                "status": "COMPLETED",
+                                                "requestedAt": "2026-05-06T12:10:00",
+                                                "candidates": [
+                                                  {
+                                                    "id": 10001,
+                                                    "menuId": 1001,
+                                                    "menuName": "비빔밥",
+                                                    "rankNo": 1,
+                                                    "score": 93.5,
+                                                    "reasonSummary": "채소와 매운맛 선호가 잘 맞는 후보입니다."
+                                                  }
+                                                ],
+                                                "resultJson": {
+                                                  "summary": "가볍고 매콤한 점심 후보를 우선 추천했습니다.",
+                                                  "algorithmVersion": "mock-v1",
+                                                  "candidateCount": 3
+                                                }
+                                              },
+                                              "error": null
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ApiResponse<PersonalRecommendationRequestResponse> createPersonalRecommendation(
+            CreatePersonalRecommendationRequest request
+    );
+
+    @Operation(
+            summary = "개인 추천 요청 상세 조회 (Mock API)",
+            description = """
+                    개인 추천 요청과 후보 목록, 선택 상태를 조회합니다.
+
+                    Mock API 상태:
+                    - `requestId` 존재 여부나 소유자 검증은 수행하지 않습니다.
+                    - 항상 같은 더미 추천 상세를 반환합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = PersonalRecommendationDetailApiResponse.class)
+                    )
+            )
+    })
+    ApiResponse<PersonalRecommendationDetailResponse> getPersonalRecommendation(Long requestId);
+
+    @Operation(
+            summary = "개인 추천 후보 목록 조회 (Mock API)",
+            description = """
+                    개인 추천 요청의 후보 메뉴 목록만 조회합니다.
+
+                    Mock API 상태:
+                    - `requestId` 존재 여부나 소유자 검증은 수행하지 않습니다.
+                    - 후보 3개를 고정 응답으로 반환합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = PersonalRecommendationCandidateListApiResponse.class)
+                    )
+            )
+    })
+    ApiResponse<PersonalRecommendationCandidateListResponse> getPersonalRecommendationCandidates(Long requestId);
+
+    @Operation(
+            summary = "개인 추천 후보 선택 (Mock API)",
+            description = """
+                    개인 추천 후보 중 하나를 최종 선택으로 반영합니다.
+
+                    Mock API 상태:
+                    - request body validation만 수행합니다.
+                    - 이미 선택된 요청인지, 후보가 해당 요청에 속하는지는 아직 검증하지 않습니다.
+                    - 실제 구현에서는 `member_menu_actions` 로그 저장과 추천 결과 갱신을 함께 검토합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "선택 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SelectPersonalRecommendationApiResponse.class)
+                    )
+            )
+    })
+    ApiResponse<SelectPersonalRecommendationResponse> selectPersonalRecommendationCandidate(
+            Long requestId,
+            SelectPersonalRecommendationRequest request
+    );
+}

--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
@@ -10,6 +10,7 @@ import matchuri.backend.api.recommendation.dto.docs.PersonalRecommendationCandid
 import matchuri.backend.api.recommendation.dto.docs.PersonalRecommendationDetailApiResponse;
 import matchuri.backend.api.recommendation.dto.docs.PersonalRecommendationRequestApiResponse;
 import matchuri.backend.api.recommendation.dto.docs.PersonalRecommendationSummaryPageApiResponse;
+import matchuri.backend.api.recommendation.dto.docs.RecommendationApiExamples;
 import matchuri.backend.api.recommendation.dto.docs.SelectPersonalRecommendationApiResponse;
 import matchuri.backend.api.recommendation.dto.request.CreatePersonalRecommendationRequest;
 import matchuri.backend.api.recommendation.dto.request.SelectPersonalRecommendationRequest;
@@ -40,7 +41,11 @@ public interface RecommendationApi {
                     description = "조회 성공",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = PersonalRecommendationSummaryPageApiResponse.class)
+                            schema = @Schema(implementation = PersonalRecommendationSummaryPageApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = RecommendationApiExamples.PERSONAL_RECOMMENDATION_LIST_SUCCESS
+                            )
                     )
             )
     })
@@ -66,31 +71,7 @@ public interface RecommendationApi {
                             schema = @Schema(implementation = PersonalRecommendationRequestApiResponse.class),
                             examples = @ExampleObject(
                                     name = "success",
-                                    value = """
-                                            {
-                                              "success": true,
-                                              "data": {
-                                                "requestId": 9001,
-                                                "status": "COMPLETED",
-                                                "requestedAt": "2026-05-06T12:10:00",
-                                                "candidates": [
-                                                  {
-                                                    "id": 10001,
-                                                    "menuId": 1001,
-                                                    "menuName": "비빔밥",
-                                                    "rankNo": 1,
-                                                    "score": 93.5
-                                                  }
-                                                ],
-                                                "resultJson": {
-                                                  "summary": "가볍고 매콤한 점심 후보를 우선 추천했습니다.",
-                                                  "algorithmVersion": "mock-v1",
-                                                  "candidateCount": 3
-                                                }
-                                              },
-                                              "error": null
-                                            }
-                                            """
+                                    value = RecommendationApiExamples.PERSONAL_RECOMMENDATION_CREATE_SUCCESS
                             )
                     )
             )
@@ -115,7 +96,11 @@ public interface RecommendationApi {
                     description = "조회 성공",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = PersonalRecommendationDetailApiResponse.class)
+                            schema = @Schema(implementation = PersonalRecommendationDetailApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = RecommendationApiExamples.PERSONAL_RECOMMENDATION_DETAIL_SUCCESS
+                            )
                     )
             )
     })
@@ -137,7 +122,11 @@ public interface RecommendationApi {
                     description = "조회 성공",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = PersonalRecommendationCandidateListApiResponse.class)
+                            schema = @Schema(implementation = PersonalRecommendationCandidateListApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = RecommendationApiExamples.PERSONAL_RECOMMENDATION_CANDIDATES_SUCCESS
+                            )
                     )
             )
     })
@@ -160,7 +149,11 @@ public interface RecommendationApi {
                     description = "선택 성공",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = SelectPersonalRecommendationApiResponse.class)
+                            schema = @Schema(implementation = SelectPersonalRecommendationApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = RecommendationApiExamples.PERSONAL_RECOMMENDATION_SELECT_SUCCESS
+                            )
                     )
             )
     })

--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationController.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationController.java
@@ -1,0 +1,24 @@
+package matchuri.backend.api.recommendation;
+
+import java.util.List;
+import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationResponse;
+import matchuri.backend.global.api.ApiResponse;
+import matchuri.backend.global.api.PageResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/personal-recommendations")
+public class RecommendationController {
+
+    @GetMapping
+    public ApiResponse<PageResponse<PersonalRecommendationResponse>> getMyPersonalRecommendationList() {
+
+        PageResponse<PersonalRecommendationResponse> response = PageResponse.mock(
+                List.of(PersonalRecommendationResponse.mock(),
+                        PersonalRecommendationResponse.mock()));
+
+        return ApiResponse.success(response);
+    }
+}

--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationController.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationController.java
@@ -28,8 +28,7 @@ public class RecommendationController implements RecommendationApi {
     public ApiResponse<PageResponse<PersonalRecommendationResponse>> getMyPersonalRecommendationList() {
 
         PageResponse<PersonalRecommendationResponse> response = PageResponse.mock(
-                List.of(PersonalRecommendationResponse.mock(),
-                        PersonalRecommendationResponse.mock()));
+                List.of(PersonalRecommendationResponse.mock()));
 
         return ApiResponse.success(response);
     }

--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationController.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationController.java
@@ -1,18 +1,30 @@
 package matchuri.backend.api.recommendation;
 
+import jakarta.validation.Valid;
 import java.util.List;
+import matchuri.backend.api.recommendation.dto.request.CreatePersonalRecommendationRequest;
+import matchuri.backend.api.recommendation.dto.request.SelectPersonalRecommendationRequest;
+import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationCandidateListResponse;
+import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationDetailResponse;
+import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationRequestResponse;
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationResponse;
+import matchuri.backend.api.recommendation.dto.response.SelectPersonalRecommendationResponse;
 import matchuri.backend.global.api.ApiResponse;
 import matchuri.backend.global.api.PageResponse;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/personal-recommendations")
-public class RecommendationController {
+@RequestMapping("/api/v1")
+public class RecommendationController implements RecommendationApi {
 
-    @GetMapping
+    @Override
+    @GetMapping("/personal-recommendations")
     public ApiResponse<PageResponse<PersonalRecommendationResponse>> getMyPersonalRecommendationList() {
 
         PageResponse<PersonalRecommendationResponse> response = PageResponse.mock(
@@ -20,5 +32,36 @@ public class RecommendationController {
                         PersonalRecommendationResponse.mock()));
 
         return ApiResponse.success(response);
+    }
+
+    @Override
+    @PostMapping("/personal-recommendation-requests")
+    public ApiResponse<PersonalRecommendationRequestResponse> createPersonalRecommendation(
+            @Valid @RequestBody CreatePersonalRecommendationRequest request
+    ) {
+        return ApiResponse.success(PersonalRecommendationRequestResponse.mockCompleted());
+    }
+
+    @Override
+    @GetMapping("/personal-recommendation-requests/{requestId}")
+    public ApiResponse<PersonalRecommendationDetailResponse> getPersonalRecommendation(@PathVariable Long requestId) {
+        return ApiResponse.success(PersonalRecommendationDetailResponse.mockSelected());
+    }
+
+    @Override
+    @GetMapping("/personal-recommendation-requests/{requestId}/candidates")
+    public ApiResponse<PersonalRecommendationCandidateListResponse> getPersonalRecommendationCandidates(
+            @PathVariable Long requestId
+    ) {
+        return ApiResponse.success(PersonalRecommendationCandidateListResponse.mock());
+    }
+
+    @Override
+    @PatchMapping("/personal-recommendation-requests/{requestId}")
+    public ApiResponse<SelectPersonalRecommendationResponse> selectPersonalRecommendationCandidate(
+            @PathVariable Long requestId,
+            @Valid @RequestBody SelectPersonalRecommendationRequest request
+    ) {
+        return ApiResponse.success(SelectPersonalRecommendationResponse.mockSelected(request.selectedCandidateId()));
     }
 }

--- a/src/main/java/matchuri/backend/api/recommendation/dto/docs/PersonalRecommendationCandidateListApiResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/docs/PersonalRecommendationCandidateListApiResponse.java
@@ -1,0 +1,18 @@
+package matchuri.backend.api.recommendation.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationCandidateListResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "개인 추천 후보 목록 API의 공통 응답 envelope입니다.")
+public record PersonalRecommendationCandidateListApiResponse(
+        @Schema(description = "요청 성공 여부입니다.", example = "true")
+        boolean success,
+
+        @Schema(description = "개인 추천 후보 목록입니다.")
+        PersonalRecommendationCandidateListResponse data,
+
+        @Schema(description = "실패 시 반환되는 에러 정보입니다.")
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/recommendation/dto/docs/PersonalRecommendationDetailApiResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/docs/PersonalRecommendationDetailApiResponse.java
@@ -1,0 +1,18 @@
+package matchuri.backend.api.recommendation.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationDetailResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "개인 추천 상세 조회 API의 공통 응답 envelope입니다.")
+public record PersonalRecommendationDetailApiResponse(
+        @Schema(description = "요청 성공 여부입니다.", example = "true")
+        boolean success,
+
+        @Schema(description = "개인 추천 상세입니다.")
+        PersonalRecommendationDetailResponse data,
+
+        @Schema(description = "실패 시 반환되는 에러 정보입니다.")
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/recommendation/dto/docs/PersonalRecommendationRequestApiResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/docs/PersonalRecommendationRequestApiResponse.java
@@ -1,0 +1,18 @@
+package matchuri.backend.api.recommendation.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationRequestResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "개인 추천 요청 생성 API의 공통 응답 envelope입니다.")
+public record PersonalRecommendationRequestApiResponse(
+        @Schema(description = "요청 성공 여부입니다.", example = "true")
+        boolean success,
+
+        @Schema(description = "생성된 개인 추천 요청과 후보 목록입니다.")
+        PersonalRecommendationRequestResponse data,
+
+        @Schema(description = "실패 시 반환되는 에러 정보입니다.")
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/recommendation/dto/docs/PersonalRecommendationSummaryPageApiResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/docs/PersonalRecommendationSummaryPageApiResponse.java
@@ -1,0 +1,19 @@
+package matchuri.backend.api.recommendation.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationResponse;
+import matchuri.backend.global.api.ErrorResponse;
+import matchuri.backend.global.api.PageResponse;
+
+@Schema(description = "개인 추천 이력 목록 API의 공통 응답 envelope입니다.")
+public record PersonalRecommendationSummaryPageApiResponse(
+        @Schema(description = "요청 성공 여부입니다.", example = "true")
+        boolean success,
+
+        @Schema(description = "성공 시 반환되는 개인 추천 이력 페이지입니다.")
+        PageResponse<PersonalRecommendationResponse> data,
+
+        @Schema(description = "실패 시 반환되는 에러 정보입니다.")
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/recommendation/dto/docs/RecommendationApiExamples.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/docs/RecommendationApiExamples.java
@@ -1,0 +1,153 @@
+package matchuri.backend.api.recommendation.dto.docs;
+
+public final class RecommendationApiExamples {
+
+    private RecommendationApiExamples() {
+    }
+
+    public static final String PERSONAL_RECOMMENDATION_LIST_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "content": [
+                  {
+                    "id": 9001,
+                    "status": "COMPLETED",
+                    "requestedAt": "2026-05-06T12:10:00"
+                  }
+                ],
+                "pageInfo": {
+                  "page": 0,
+                  "size": 10,
+                  "totalElements": 1,
+                  "totalPages": 1,
+                  "first": true,
+                  "last": true,
+                  "hasNext": false,
+                  "hasPrevious": false
+                }
+              },
+              "error": null
+            }
+            """;
+
+    public static final String PERSONAL_RECOMMENDATION_CREATE_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "requestId": 9001,
+                "status": "COMPLETED",
+                "requestedAt": "2026-05-06T12:10:00",
+                "candidates": [
+                  {
+                    "id": 10001,
+                    "menuId": 1001,
+                    "menuName": "비빔밥",
+                    "rankNo": 1,
+                    "score": 93.5
+                  },
+                  {
+                    "id": 10002,
+                    "menuId": 1002,
+                    "menuName": "돈까스",
+                    "rankNo": 2,
+                    "score": 86.0
+                  },
+                  {
+                    "id": 10003,
+                    "menuId": 1003,
+                    "menuName": "쌀국수",
+                    "rankNo": 3,
+                    "score": 81.5
+                  }
+                ]
+              },
+              "error": null
+            }
+            """;
+
+    public static final String PERSONAL_RECOMMENDATION_DETAIL_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "id": 9001,
+                "status": "COMPLETED",
+                "contextJson": {
+                  "mealTime": "LUNCH",
+                  "budgetLevel": 2,
+                  "mood": "가볍지만 든든한 점심"
+                },
+                "candidates": [
+                  {
+                    "id": 10001,
+                    "menuId": 1001,
+                    "menuName": "비빔밥",
+                    "rankNo": 1,
+                    "score": 93.5
+                  },
+                  {
+                    "id": 10002,
+                    "menuId": 1002,
+                    "menuName": "돈까스",
+                    "rankNo": 2,
+                    "score": 86.0
+                  },
+                  {
+                    "id": 10003,
+                    "menuId": 1003,
+                    "menuName": "쌀국수",
+                    "rankNo": 3,
+                    "score": 81.5
+                  }
+                ],
+                "selectedCandidateId": 10001
+              },
+              "error": null
+            }
+            """;
+
+    public static final String PERSONAL_RECOMMENDATION_CANDIDATES_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "requestId": 9001,
+                "candidates": [
+                  {
+                    "id": 10001,
+                    "menuId": 1001,
+                    "menuName": "비빔밥",
+                    "rankNo": 1,
+                    "score": 93.5
+                  },
+                  {
+                    "id": 10002,
+                    "menuId": 1002,
+                    "menuName": "돈까스",
+                    "rankNo": 2,
+                    "score": 86.0
+                  },
+                  {
+                    "id": 10003,
+                    "menuId": 1003,
+                    "menuName": "쌀국수",
+                    "rankNo": 3,
+                    "score": 81.5
+                  }
+                ]
+              },
+              "error": null
+            }
+            """;
+
+    public static final String PERSONAL_RECOMMENDATION_SELECT_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "id": 9001,
+                "selectedCandidateId": 10001,
+                "updatedAt": "2026-05-06T12:15:00"
+              },
+              "error": null
+            }
+            """;
+}

--- a/src/main/java/matchuri/backend/api/recommendation/dto/docs/SelectPersonalRecommendationApiResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/docs/SelectPersonalRecommendationApiResponse.java
@@ -1,0 +1,18 @@
+package matchuri.backend.api.recommendation.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.recommendation.dto.response.SelectPersonalRecommendationResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "개인 추천 후보 선택 API의 공통 응답 envelope입니다.")
+public record SelectPersonalRecommendationApiResponse(
+        @Schema(description = "요청 성공 여부입니다.", example = "true")
+        boolean success,
+
+        @Schema(description = "선택 반영 결과입니다.")
+        SelectPersonalRecommendationResponse data,
+
+        @Schema(description = "실패 시 반환되는 에러 정보입니다.")
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/recommendation/dto/request/CreatePersonalRecommendationRequest.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/request/CreatePersonalRecommendationRequest.java
@@ -1,0 +1,15 @@
+package matchuri.backend.api.recommendation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+
+public record CreatePersonalRecommendationRequest(
+        @Schema(
+                description = "추천 요청 컨텍스트입니다. MVP에서는 mealTime, partySize, budgetLevel 같은 느슨한 JSON 값으로 시작합니다.",
+                example = "{\"mealTime\":\"LUNCH\",\"budgetLevel\":2}"
+        )
+        @NotNull(message = "contextJson은 null일 수 없습니다.")
+        Map<String, Object> contextJson
+) {
+}

--- a/src/main/java/matchuri/backend/api/recommendation/dto/request/SelectPersonalRecommendationRequest.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/request/SelectPersonalRecommendationRequest.java
@@ -1,0 +1,13 @@
+package matchuri.backend.api.recommendation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record SelectPersonalRecommendationRequest(
+        @Schema(description = "최종 선택할 개인 추천 후보 ID입니다.", example = "10001")
+        @NotNull(message = "selectedCandidateId는 null일 수 없습니다.")
+        @Positive(message = "selectedCandidateId는 양수여야 합니다.")
+        Long selectedCandidateId
+) {
+}

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationCandidateListResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationCandidateListResponse.java
@@ -1,0 +1,16 @@
+package matchuri.backend.api.recommendation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record PersonalRecommendationCandidateListResponse(
+        @Schema(description = "개인 추천 요청 ID입니다.", example = "9001")
+        Long requestId,
+
+        @Schema(description = "추천 후보 목록입니다.")
+        List<PersonalRecommendationCandidateResponse> candidates
+) {
+    public static PersonalRecommendationCandidateListResponse mock() {
+        return new PersonalRecommendationCandidateListResponse(9001L, PersonalRecommendationMocks.candidates());
+    }
+}

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationCandidateResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationCandidateResponse.java
@@ -16,10 +16,10 @@ public record PersonalRecommendationCandidateResponse(
         Integer rankNo,
 
         @Schema(description = "Mock 추천 점수입니다.", example = "93.5")
-        Double score,
+        Double score
 
-        @Schema(description = "사용자에게 보여줄 추천 근거 요약입니다.", example = "채소와 매운맛 선호가 잘 맞는 후보입니다.")
-        String reasonSummary
+//        @Schema(description = "사용자에게 보여줄 추천 근거 요약입니다.", example = "채소와 매운맛 선호가 잘 맞는 후보입니다.")
+//        String reasonSummary
 ) {
     public static PersonalRecommendationCandidateResponse mockBibimbap() {
         return new PersonalRecommendationCandidateResponse(
@@ -27,8 +27,8 @@ public record PersonalRecommendationCandidateResponse(
                 1001L,
                 "비빔밥",
                 1,
-                93.5,
-                "채소와 매운맛 선호가 잘 맞는 후보입니다."
+                93.5
+//                "채소와 매운맛 선호가 잘 맞는 후보입니다."
         );
     }
 
@@ -38,8 +38,8 @@ public record PersonalRecommendationCandidateResponse(
                 1002L,
                 "돈까스",
                 2,
-                86.0,
-                "바삭한 식감 선호와 든든한 점심 상황에 맞는 후보입니다."
+                86.0
+//                "바삭한 식감 선호와 든든한 점심 상황에 맞는 후보입니다."
         );
     }
 
@@ -49,8 +49,8 @@ public record PersonalRecommendationCandidateResponse(
                 1003L,
                 "쌀국수",
                 3,
-                81.5,
-                "따뜻한 국물과 부담 없는 식사를 원하는 상황에 맞는 후보입니다."
+                81.5
+//                "따뜻한 국물과 부담 없는 식사를 원하는 상황에 맞는 후보입니다."
         );
     }
 }

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationCandidateResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationCandidateResponse.java
@@ -1,0 +1,56 @@
+package matchuri.backend.api.recommendation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PersonalRecommendationCandidateResponse(
+        @Schema(description = "개인 추천 후보 ID입니다.", example = "10001")
+        Long id,
+
+        @Schema(description = "추천된 메뉴 ID입니다.", example = "1001")
+        Long menuId,
+
+        @Schema(description = "추천된 메뉴명입니다.", example = "비빔밥")
+        String menuName,
+
+        @Schema(description = "추천 순위입니다.", example = "1")
+        Integer rankNo,
+
+        @Schema(description = "Mock 추천 점수입니다.", example = "93.5")
+        Double score,
+
+        @Schema(description = "사용자에게 보여줄 추천 근거 요약입니다.", example = "채소와 매운맛 선호가 잘 맞는 후보입니다.")
+        String reasonSummary
+) {
+    public static PersonalRecommendationCandidateResponse mockBibimbap() {
+        return new PersonalRecommendationCandidateResponse(
+                10001L,
+                1001L,
+                "비빔밥",
+                1,
+                93.5,
+                "채소와 매운맛 선호가 잘 맞는 후보입니다."
+        );
+    }
+
+    public static PersonalRecommendationCandidateResponse mockPorkCutlet() {
+        return new PersonalRecommendationCandidateResponse(
+                10002L,
+                1002L,
+                "돈까스",
+                2,
+                86.0,
+                "바삭한 식감 선호와 든든한 점심 상황에 맞는 후보입니다."
+        );
+    }
+
+    public static PersonalRecommendationCandidateResponse mockRiceNoodle() {
+        return new PersonalRecommendationCandidateResponse(
+                10003L,
+                1003L,
+                "쌀국수",
+                3,
+                81.5,
+                "따뜻한 국물과 부담 없는 식사를 원하는 상황에 맞는 후보입니다."
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationCandidateResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationCandidateResponse.java
@@ -17,9 +17,6 @@ public record PersonalRecommendationCandidateResponse(
 
         @Schema(description = "Mock 추천 점수입니다.", example = "93.5")
         Double score
-
-//        @Schema(description = "사용자에게 보여줄 추천 근거 요약입니다.", example = "채소와 매운맛 선호가 잘 맞는 후보입니다.")
-//        String reasonSummary
 ) {
     public static PersonalRecommendationCandidateResponse mockBibimbap() {
         return new PersonalRecommendationCandidateResponse(
@@ -28,7 +25,6 @@ public record PersonalRecommendationCandidateResponse(
                 "비빔밥",
                 1,
                 93.5
-//                "채소와 매운맛 선호가 잘 맞는 후보입니다."
         );
     }
 
@@ -39,7 +35,6 @@ public record PersonalRecommendationCandidateResponse(
                 "돈까스",
                 2,
                 86.0
-//                "바삭한 식감 선호와 든든한 점심 상황에 맞는 후보입니다."
         );
     }
 
@@ -50,7 +45,6 @@ public record PersonalRecommendationCandidateResponse(
                 "쌀국수",
                 3,
                 81.5
-//                "따뜻한 국물과 부담 없는 식사를 원하는 상황에 맞는 후보입니다."
         );
     }
 }

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationDetailResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationDetailResponse.java
@@ -18,8 +18,8 @@ public record PersonalRecommendationDetailResponse(
         @Schema(description = "추천 후보 목록입니다.")
         List<PersonalRecommendationCandidateResponse> candidates,
 
-        @Schema(description = "추천 결과 요약 JSON입니다.")
-        Map<String, Object> resultJson,
+//        @Schema(description = "추천 결과 요약 JSON입니다.")
+//        Map<String, Object> resultJson,
 
         @Schema(description = "최종 선택된 후보 ID입니다. 아직 선택하지 않았다면 null입니다.", example = "10001")
         Long selectedCandidateId
@@ -30,7 +30,7 @@ public record PersonalRecommendationDetailResponse(
                 PersonalRecommendationStatus.COMPLETED,
                 PersonalRecommendationMocks.contextJson(),
                 PersonalRecommendationMocks.candidates(),
-                PersonalRecommendationMocks.resultJson(),
+//                PersonalRecommendationMocks.resultJson(),
                 10001L
         );
     }

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationDetailResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationDetailResponse.java
@@ -18,9 +18,6 @@ public record PersonalRecommendationDetailResponse(
         @Schema(description = "추천 후보 목록입니다.")
         List<PersonalRecommendationCandidateResponse> candidates,
 
-//        @Schema(description = "추천 결과 요약 JSON입니다.")
-//        Map<String, Object> resultJson,
-
         @Schema(description = "최종 선택된 후보 ID입니다. 아직 선택하지 않았다면 null입니다.", example = "10001")
         Long selectedCandidateId
 ) {
@@ -30,7 +27,6 @@ public record PersonalRecommendationDetailResponse(
                 PersonalRecommendationStatus.COMPLETED,
                 PersonalRecommendationMocks.contextJson(),
                 PersonalRecommendationMocks.candidates(),
-//                PersonalRecommendationMocks.resultJson(),
                 10001L
         );
     }

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationDetailResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationDetailResponse.java
@@ -1,0 +1,37 @@
+package matchuri.backend.api.recommendation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.Map;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
+
+public record PersonalRecommendationDetailResponse(
+        @Schema(description = "개인 추천 요청 ID입니다.", example = "9001")
+        Long id,
+
+        @Schema(description = "개인 추천 처리 상태입니다.", example = "COMPLETED")
+        PersonalRecommendationStatus status,
+
+        @Schema(description = "요청 컨텍스트 JSON입니다.")
+        Map<String, Object> contextJson,
+
+        @Schema(description = "추천 후보 목록입니다.")
+        List<PersonalRecommendationCandidateResponse> candidates,
+
+        @Schema(description = "추천 결과 요약 JSON입니다.")
+        Map<String, Object> resultJson,
+
+        @Schema(description = "최종 선택된 후보 ID입니다. 아직 선택하지 않았다면 null입니다.", example = "10001")
+        Long selectedCandidateId
+) {
+    public static PersonalRecommendationDetailResponse mockSelected() {
+        return new PersonalRecommendationDetailResponse(
+                9001L,
+                PersonalRecommendationStatus.COMPLETED,
+                PersonalRecommendationMocks.contextJson(),
+                PersonalRecommendationMocks.candidates(),
+                PersonalRecommendationMocks.resultJson(),
+                10001L
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationMocks.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationMocks.java
@@ -1,0 +1,35 @@
+package matchuri.backend.api.recommendation.dto.response;
+
+import java.util.List;
+import java.util.Map;
+
+final class PersonalRecommendationMocks {
+
+    private PersonalRecommendationMocks() {
+    }
+
+    static List<PersonalRecommendationCandidateResponse> candidates() {
+        return List.of(
+                PersonalRecommendationCandidateResponse.mockBibimbap(),
+                PersonalRecommendationCandidateResponse.mockPorkCutlet(),
+                PersonalRecommendationCandidateResponse.mockRiceNoodle()
+        );
+    }
+
+    static Map<String, Object> contextJson() {
+        return Map.of(
+                "mealTime", "LUNCH",
+                "budgetLevel", 2,
+                "mood", "가볍지만 든든한 점심"
+        );
+    }
+
+    static Map<String, Object> resultJson() {
+        return Map.of(
+                "summary", "가볍고 매콤한 점심 후보를 우선 추천했습니다.",
+                "algorithmVersion", "mock-v1",
+                "profileSnapshotVersion", "v1",
+                "candidateCount", 3
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationMocks.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationMocks.java
@@ -23,13 +23,4 @@ final class PersonalRecommendationMocks {
                 "mood", "가볍지만 든든한 점심"
         );
     }
-
-    static Map<String, Object> resultJson() {
-        return Map.of(
-                "summary", "가볍고 매콤한 점심 후보를 우선 추천했습니다.",
-                "algorithmVersion", "mock-v1",
-                "profileSnapshotVersion", "v1",
-                "candidateCount", 3
-        );
-    }
 }

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationRequestResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationRequestResponse.java
@@ -3,7 +3,6 @@ package matchuri.backend.api.recommendation.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 
 public record PersonalRecommendationRequestResponse(
@@ -18,9 +17,6 @@ public record PersonalRecommendationRequestResponse(
 
         @Schema(description = "추천 후보 목록입니다.")
         List<PersonalRecommendationCandidateResponse> candidates
-
-//        @Schema(description = "추천 결과 요약 JSON입니다.")
-//        Map<String, Object> resultJson
 ) {
     public static PersonalRecommendationRequestResponse mockCompleted() {
         return new PersonalRecommendationRequestResponse(
@@ -28,7 +24,6 @@ public record PersonalRecommendationRequestResponse(
                 PersonalRecommendationStatus.COMPLETED,
                 LocalDateTime.of(2026, 5, 6, 12, 10),
                 PersonalRecommendationMocks.candidates()
-//                PersonalRecommendationMocks.resultJson()
         );
     }
 }

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationRequestResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationRequestResponse.java
@@ -17,18 +17,18 @@ public record PersonalRecommendationRequestResponse(
         LocalDateTime requestedAt,
 
         @Schema(description = "추천 후보 목록입니다.")
-        List<PersonalRecommendationCandidateResponse> candidates,
+        List<PersonalRecommendationCandidateResponse> candidates
 
-        @Schema(description = "추천 결과 요약 JSON입니다.")
-        Map<String, Object> resultJson
+//        @Schema(description = "추천 결과 요약 JSON입니다.")
+//        Map<String, Object> resultJson
 ) {
     public static PersonalRecommendationRequestResponse mockCompleted() {
         return new PersonalRecommendationRequestResponse(
                 9001L,
                 PersonalRecommendationStatus.COMPLETED,
                 LocalDateTime.of(2026, 5, 6, 12, 10),
-                PersonalRecommendationMocks.candidates(),
-                PersonalRecommendationMocks.resultJson()
+                PersonalRecommendationMocks.candidates()
+//                PersonalRecommendationMocks.resultJson()
         );
     }
 }

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationRequestResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationRequestResponse.java
@@ -1,0 +1,34 @@
+package matchuri.backend.api.recommendation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
+
+public record PersonalRecommendationRequestResponse(
+        @Schema(description = "개인 추천 요청 ID입니다.", example = "9001")
+        Long requestId,
+
+        @Schema(description = "개인 추천 처리 상태입니다.", example = "COMPLETED")
+        PersonalRecommendationStatus status,
+
+        @Schema(description = "추천 요청 시각입니다.", example = "2026-05-06T12:10:00")
+        LocalDateTime requestedAt,
+
+        @Schema(description = "추천 후보 목록입니다.")
+        List<PersonalRecommendationCandidateResponse> candidates,
+
+        @Schema(description = "추천 결과 요약 JSON입니다.")
+        Map<String, Object> resultJson
+) {
+    public static PersonalRecommendationRequestResponse mockCompleted() {
+        return new PersonalRecommendationRequestResponse(
+                9001L,
+                PersonalRecommendationStatus.COMPLETED,
+                LocalDateTime.of(2026, 5, 6, 12, 10),
+                PersonalRecommendationMocks.candidates(),
+                PersonalRecommendationMocks.resultJson()
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationResponse.java
@@ -9,6 +9,10 @@ public record PersonalRecommendationResponse(
         LocalDateTime requestedAt
 ) {
     public static PersonalRecommendationResponse mock() {
-        return new PersonalRecommendationResponse(1, PersonalRecommendationStatus.REQUESTED, LocalDateTime.now());
+        return new PersonalRecommendationResponse(
+                9001L,
+                PersonalRecommendationStatus.COMPLETED,
+                LocalDateTime.of(2026, 5, 6, 12, 10)
+        );
     }
 }

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationResponse.java
@@ -1,0 +1,14 @@
+package matchuri.backend.api.recommendation.dto.response;
+
+import java.time.LocalDateTime;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
+
+public record PersonalRecommendationResponse(
+        long id,
+        PersonalRecommendationStatus status,
+        LocalDateTime requestedAt
+) {
+    public static PersonalRecommendationResponse mock() {
+        return new PersonalRecommendationResponse(1, PersonalRecommendationStatus.REQUESTED, LocalDateTime.now());
+    }
+}

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/SelectPersonalRecommendationResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/SelectPersonalRecommendationResponse.java
@@ -1,0 +1,23 @@
+package matchuri.backend.api.recommendation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record SelectPersonalRecommendationResponse(
+        @Schema(description = "개인 추천 요청 ID입니다.", example = "9001")
+        Long id,
+
+        @Schema(description = "최종 선택 후보 ID입니다.", example = "10001")
+        Long selectedCandidateId,
+
+        @Schema(description = "선택 반영 시각입니다.", example = "2026-05-06T12:15:00")
+        LocalDateTime updatedAt
+) {
+    public static SelectPersonalRecommendationResponse mockSelected(Long selectedCandidateId) {
+        return new SelectPersonalRecommendationResponse(
+                9001L,
+                selectedCandidateId,
+                LocalDateTime.of(2026, 5, 6, 12, 15)
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendation.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendation.java
@@ -52,9 +52,6 @@ public class GroupRecommendation extends BaseEntity {
     @Column(name = "context_json", columnDefinition = "json", comment = "그룹 추천 컨텍스트 JSON")
     private String contextJson;
 
-//    @Column(name = "result_json", columnDefinition = "json", comment = "그룹 추천 결과 요약 JSON")
-//    private String resultJson;
-
     public GroupRecommendation(GroupRoom room, String contextJson, LocalDateTime startedAt) {
         this.room = room;
         this.contextJson = contextJson;
@@ -67,10 +64,9 @@ public class GroupRecommendation extends BaseEntity {
         this.endedAt = endedAt;
     }
 
-    public void finalizeWith(GroupRecommendationCandidate selectedCandidate, String resultJson, LocalDateTime endedAt) {
+    public void finalizeWith(GroupRecommendationCandidate selectedCandidate, LocalDateTime endedAt) {
         this.status = GroupRecommendationStatus.FINALIZED;
         this.selectedCandidate = selectedCandidate;
-//        this.resultJson = resultJson;
         this.endedAt = endedAt;
     }
 

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendation.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendation.java
@@ -52,8 +52,8 @@ public class GroupRecommendation extends BaseEntity {
     @Column(name = "context_json", columnDefinition = "json", comment = "그룹 추천 컨텍스트 JSON")
     private String contextJson;
 
-    @Column(name = "result_json", columnDefinition = "json", comment = "그룹 추천 결과 요약 JSON")
-    private String resultJson;
+//    @Column(name = "result_json", columnDefinition = "json", comment = "그룹 추천 결과 요약 JSON")
+//    private String resultJson;
 
     public GroupRecommendation(GroupRoom room, String contextJson, LocalDateTime startedAt) {
         this.room = room;
@@ -70,7 +70,7 @@ public class GroupRecommendation extends BaseEntity {
     public void finalizeWith(GroupRecommendationCandidate selectedCandidate, String resultJson, LocalDateTime endedAt) {
         this.status = GroupRecommendationStatus.FINALIZED;
         this.selectedCandidate = selectedCandidate;
-        this.resultJson = resultJson;
+//        this.resultJson = resultJson;
         this.endedAt = endedAt;
     }
 

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationCandidate.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationCandidate.java
@@ -49,18 +49,18 @@ public class GroupRecommendationCandidate extends BaseEntity {
     @Column(name = "rank_no", nullable = false, comment = "후보 순위")
     private int rankNo;
 
-    @Column(name = "reason_summary", length = REASON_SUMMARY_MAX_LENGTH, comment = "추천 사유 요약")
-    private String reasonSummary;
+//    @Column(name = "reason_summary", length = REASON_SUMMARY_MAX_LENGTH, comment = "추천 사유 요약")
+//    private String reasonSummary;
 
     public GroupRecommendationCandidate(
             GroupRecommendation groupRecommendation,
             MenuItem menuItem,
-            int rankNo,
-            String reasonSummary
+            int rankNo
+//            String reasonSummary
     ) {
         this.groupRecommendation = groupRecommendation;
         this.menuItem = menuItem;
         this.rankNo = rankNo;
-        this.reasonSummary = reasonSummary;
+//        this.reasonSummary = reasonSummary;
     }
 }

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationCandidate.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationCandidate.java
@@ -31,8 +31,6 @@ import matchuri.backend.domain.menu.entity.MenuItem;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GroupRecommendationCandidate extends BaseEntity {
 
-    public static final int REASON_SUMMARY_MAX_LENGTH = 300;
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(comment = "그룹 추천 후보 ID")
@@ -49,18 +47,13 @@ public class GroupRecommendationCandidate extends BaseEntity {
     @Column(name = "rank_no", nullable = false, comment = "후보 순위")
     private int rankNo;
 
-//    @Column(name = "reason_summary", length = REASON_SUMMARY_MAX_LENGTH, comment = "추천 사유 요약")
-//    private String reasonSummary;
-
     public GroupRecommendationCandidate(
             GroupRecommendation groupRecommendation,
             MenuItem menuItem,
             int rankNo
-//            String reasonSummary
     ) {
         this.groupRecommendation = groupRecommendation;
         this.menuItem = menuItem;
         this.rankNo = rankNo;
-//        this.reasonSummary = reasonSummary;
     }
 }

--- a/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendation.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendation.java
@@ -46,8 +46,8 @@ public class PersonalRecommendation extends BaseEntity {
     @Column(name = "context_json", columnDefinition = "json", comment = "개인 추천 컨텍스트 JSON")
     private String contextJson;
 
-    @Column(name = "result_json", columnDefinition = "json", comment = "개인 추천 결과 요약 JSON")
-    private String resultJson;
+//    @Column(name = "result_json", columnDefinition = "json", comment = "개인 추천 결과 요약 JSON")
+//    private String resultJson;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "selected_candidate_id", comment = "최종 선택 후보 ID")
@@ -70,12 +70,12 @@ public class PersonalRecommendation extends BaseEntity {
 
     public void complete(String resultJson) {
         this.status = PersonalRecommendationStatus.COMPLETED;
-        this.resultJson = resultJson;
+//        this.resultJson = resultJson;
     }
 
     public void fail(String resultJson) {
         this.status = PersonalRecommendationStatus.FAILED;
-        this.resultJson = resultJson;
+//        this.resultJson = resultJson;
     }
 
     public void select(PersonalRecommendationCandidate selectedCandidate) {

--- a/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendation.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendation.java
@@ -46,9 +46,6 @@ public class PersonalRecommendation extends BaseEntity {
     @Column(name = "context_json", columnDefinition = "json", comment = "개인 추천 컨텍스트 JSON")
     private String contextJson;
 
-//    @Column(name = "result_json", columnDefinition = "json", comment = "개인 추천 결과 요약 JSON")
-//    private String resultJson;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "selected_candidate_id", comment = "최종 선택 후보 ID")
     private PersonalRecommendationCandidate selectedCandidate;
@@ -68,14 +65,12 @@ public class PersonalRecommendation extends BaseEntity {
         this.status = PersonalRecommendationStatus.SCORED;
     }
 
-    public void complete(String resultJson) {
+    public void complete() {
         this.status = PersonalRecommendationStatus.COMPLETED;
-//        this.resultJson = resultJson;
     }
 
-    public void fail(String resultJson) {
+    public void fail() {
         this.status = PersonalRecommendationStatus.FAILED;
-//        this.resultJson = resultJson;
     }
 
     public void select(PersonalRecommendationCandidate selectedCandidate) {

--- a/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendationCandidate.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendationCandidate.java
@@ -32,8 +32,6 @@ import matchuri.backend.domain.menu.entity.MenuItem;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PersonalRecommendationCandidate extends BaseEntity {
 
-    public static final int REASON_SUMMARY_MAX_LENGTH = 300;
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(comment = "개인 추천 후보 ID")
@@ -53,9 +51,6 @@ public class PersonalRecommendationCandidate extends BaseEntity {
     @Column(precision = 10, scale = 4, comment = "추천 점수")
     private BigDecimal score;
 
-//    @Column(name = "reason_summary", length = REASON_SUMMARY_MAX_LENGTH, comment = "추천 사유 요약")
-//    private String reasonSummary;
-
     @Column(name = "candidate_meta_json", columnDefinition = "json", comment = "후보 메타 JSON")
     private String candidateMetaJson;
 
@@ -64,14 +59,12 @@ public class PersonalRecommendationCandidate extends BaseEntity {
             MenuItem menuItem,
             int rankNo,
             BigDecimal score,
-//            String reasonSummary,
             String candidateMetaJson
     ) {
         this.personalRecommendation = personalRecommendation;
         this.menuItem = menuItem;
         this.rankNo = rankNo;
         this.score = score;
-//        this.reasonSummary = reasonSummary;
         this.candidateMetaJson = candidateMetaJson;
     }
 }

--- a/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendationCandidate.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendationCandidate.java
@@ -53,8 +53,8 @@ public class PersonalRecommendationCandidate extends BaseEntity {
     @Column(precision = 10, scale = 4, comment = "추천 점수")
     private BigDecimal score;
 
-    @Column(name = "reason_summary", length = REASON_SUMMARY_MAX_LENGTH, comment = "추천 사유 요약")
-    private String reasonSummary;
+//    @Column(name = "reason_summary", length = REASON_SUMMARY_MAX_LENGTH, comment = "추천 사유 요약")
+//    private String reasonSummary;
 
     @Column(name = "candidate_meta_json", columnDefinition = "json", comment = "후보 메타 JSON")
     private String candidateMetaJson;
@@ -64,14 +64,14 @@ public class PersonalRecommendationCandidate extends BaseEntity {
             MenuItem menuItem,
             int rankNo,
             BigDecimal score,
-            String reasonSummary,
+//            String reasonSummary,
             String candidateMetaJson
     ) {
         this.personalRecommendation = personalRecommendation;
         this.menuItem = menuItem;
         this.rankNo = rankNo;
         this.score = score;
-        this.reasonSummary = reasonSummary;
+//        this.reasonSummary = reasonSummary;
         this.candidateMetaJson = candidateMetaJson;
     }
 }

--- a/src/main/java/matchuri/backend/global/api/PageInfo.java
+++ b/src/main/java/matchuri/backend/global/api/PageInfo.java
@@ -30,4 +30,17 @@ public class PageInfo {
                 page.hasPrevious()
         );
     }
+
+    public static PageInfo mock() {
+        return new PageInfo(
+                0,
+                10,
+                1L,
+                1,
+                true,
+                true,
+                false,
+                false
+        );
+    }
 }

--- a/src/main/java/matchuri/backend/global/api/PageResponse.java
+++ b/src/main/java/matchuri/backend/global/api/PageResponse.java
@@ -24,4 +24,8 @@ public class PageResponse<T> {
                 .toList();
         return new PageResponse<>(mappedContent, PageInfo.of(page));
     }
+
+    public static <T> PageResponse<T> mock(List<T> list) {
+        return new PageResponse<>(list, PageInfo.mock());
+    }
 }

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -216,6 +216,79 @@ class OpenApiDocumentationIntegrationTest {
     }
 
     @Test
+    @DisplayName("OpenAPI 문서에 Mock API 표시와 200 응답 예시가 노출된다")
+    void exposesMockApiMetadataAndSuccessExamplesInOpenApi() throws Exception {
+        mockMvc.perform(get("/docs/openapi"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("application/json"))
+                .andExpect(jsonPath("$.paths['/api/v1/personal-recommendations'].get.summary")
+                        .value("내 개인 추천 이력 목록 조회 (Mock API)"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/personal-recommendations'].get.responses['200'].content['application/json'].examples.success.value.data.content[0].id")
+                        .value(9001))
+                .andExpect(jsonPath("$.paths['/api/v1/personal-recommendation-requests'].post.summary")
+                        .value("개인 추천 요청 생성 (Mock API)"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/personal-recommendation-requests'].post.responses['200'].content['application/json'].examples.success.value.data.candidates[0].menuName")
+                        .value("비빔밥"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/personal-recommendation-requests'].post.responses['200'].content['application/json'].examples.success.value.data.resultJson")
+                        .doesNotExist())
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/personal-recommendation-requests/{requestId}'].get.responses['200'].content['application/json'].examples.success.value.data.contextJson.mealTime")
+                        .value("LUNCH"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/personal-recommendation-requests/{requestId}'].get.responses['200'].content['application/json'].examples.success.value.data.resultJson")
+                        .doesNotExist())
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/personal-recommendation-requests/{requestId}/candidates'].get.responses['200'].content['application/json'].examples.success.value.data.candidates[2].menuName")
+                        .value("쌀국수"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/personal-recommendation-requests/{requestId}'].patch.responses['200'].content['application/json'].examples.success.value.data.selectedCandidateId")
+                        .value(10001))
+                .andExpect(jsonPath("$.paths['/api/v1/groups'].post.summary")
+                        .value("그룹 생성 (Mock API)"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups'].post.responses['200'].content['application/json'].examples.success.value.data.groupId")
+                        .value(3001))
+                .andExpect(jsonPath("$.paths['/api/v1/groups'].get.summary")
+                        .value("내 그룹 목록 조회 (Mock API)"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups'].get.responses['200'].content['application/json'].examples.success.value.data.content[0].latestRecommendationStatus")
+                        .value("OPEN"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}'].get.responses['200'].content['application/json'].examples.success.value.data.activeRecommendation.voteProgress.votedMemberCount")
+                        .value(3))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/invites'].post.responses['200'].content['application/json'].examples.success.value.data.inviteCode")
+                        .value("LUNCH42"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/join'].post.responses['200'].content['application/json'].examples.success.value.data.memberStatus")
+                        .value("ACTIVE"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/leave'].post.responses['200'].content['application/json'].examples.success.value.data.memberStatus")
+                        .value("LEFT"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendation-sessions'].post.responses['200'].content['application/json'].examples.success.value.data.candidates[0].candidateId")
+                        .value(8001))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendation-sessions/{sessionId}'].get.responses['200'].content['application/json'].examples.success.value.data.finalCandidate")
+                        .value((Object) null))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendation-sessions/{sessionId}'].get.responses['200'].content['application/json'].examples.success.value.data.resultJson")
+                        .doesNotExist())
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendation-sessions/{sessionId}/candidates'].get.responses['200'].content['application/json'].examples.success.value.data.candidates[1].menuName")
+                        .value("돈까스"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendation-sessions/{sessionId}/votes'].post.responses['200'].content['application/json'].examples.success.value.data.voteValue")
+                        .value(1))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendation-sessions/{sessionId}/finalize'].patch.responses['200'].content['application/json'].examples.success.value.data.finalCandidate.menuName")
+                        .value("비빔밥"));
+    }
+
+    @Test
     @DisplayName("OpenAPI 문서에 Menu Reference 공개 API의 비인증 정책과 envelope 응답 스키마가 노출된다")
     void exposesMenuReferenceApiMetadataInOpenApi() throws Exception {
         mockMvc.perform(get("/docs/openapi"))


### PR DESCRIPTION
## 관련 이슈
Closes #176

## 📝 작업 내용
- 개인 추천 Mock API와 그룹 의사결정 Mock API를 추가/정리했습니다.
- 추가된 Mock API의 Swagger 200 응답 example을 보강했습니다.
- 긴 example JSON은 `dto/docs` 전용 클래스로 분리했습니다.
- OpenAPI 통합 테스트에 Mock API summary와 200 응답 example 검증을 추가했습니다.

추가된 Mock API:
- 내 개인 추천 이력 목록 조회: `GET /api/v1/personal-recommendations`
- 개인 추천 요청 생성: `POST /api/v1/personal-recommendation-requests`
- 개인 추천 요청 상세 조회: `GET /api/v1/personal-recommendation-requests/{requestId}`
- 개인 추천 후보 목록 조회: `GET /api/v1/personal-recommendation-requests/{requestId}/candidates`
- 개인 추천 후보 선택: `PATCH /api/v1/personal-recommendation-requests/{requestId}`
- 그룹 생성: `POST /api/v1/groups`
- 내 그룹 목록 조회: `GET /api/v1/groups`
- 그룹 상세 조회: `GET /api/v1/groups/{groupId}`
- 그룹 초대 코드 생성: `POST /api/v1/groups/{groupId}/invites`
- 초대 코드로 그룹 참여: `POST /api/v1/groups/join`
- 그룹 탈퇴: `POST /api/v1/groups/{groupId}/leave`
- 그룹 추천 시작: `POST /api/v1/groups/{groupId}/recommendation-sessions`
- 그룹 추천 세션 상세 조회: `GET /api/v1/groups/{groupId}/recommendation-sessions/{sessionId}`
- 그룹 추천 후보 목록 조회: `GET /api/v1/groups/{groupId}/recommendation-sessions/{sessionId}/candidates`
- 그룹 추천 후보 투표: `POST /api/v1/groups/{groupId}/recommendation-sessions/{sessionId}/votes`
- 그룹 추천 최종 메뉴 확정: `PATCH /api/v1/groups/{groupId}/recommendation-sessions/{sessionId}/finalize`

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
  - Swagger UI에서 각 Mock API의 200 응답 example이 프론트 개발에 충분한 형태인지 확인 부탁드립니다.
- 알려진 제한 사항:
  - 현재 API는 Mock API이므로 비즈니스 로직 및 DB 연동은 포함하지 않습니다.
  - MVP 범위에서 `summaryJson`/`resultJson` 기반 요약 응답은 제공하지 않습니다.
