### PR TITLE
[Feat] 개인 메뉴 추천 알고리즘 및 API 연결

### DIFF
--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
@@ -26,13 +26,11 @@ import matchuri.backend.global.api.PageResponse;
 public interface RecommendationApi {
 
     @Operation(
-            summary = "내 개인 추천 이력 목록 조회 (Mock API)",
+            summary = "내 개인 추천 이력 목록 조회",
             description = """
                     내 개인 추천 이력 목록을 조회합니다.
 
-                    Mock API 상태:
-                    - 현재 응답은 비즈니스 로직과 DB 조회를 거치지 않는 더미 응답입니다.
-                    - 실제 저장 테이블은 `personal_recommendations` 기준입니다.
+                    현재 로그인한 회원의 개인 추천 이력을 최신 요청 순서로 반환합니다.
                     """
     )
     @ApiResponses({
@@ -52,14 +50,11 @@ public interface RecommendationApi {
     ApiResponse<PageResponse<PersonalRecommendationResponse>> getMyPersonalRecommendationList();
 
     @Operation(
-            summary = "개인 추천 요청 생성 (Mock API)",
+            summary = "개인 추천 요청 생성",
             description = """
                     현재 회원의 취향 프로필과 요청 컨텍스트를 바탕으로 개인 추천을 실행합니다.
 
-                    Mock API 상태:
-                    - request body validation만 수행합니다.
-                    - 추천 알고리즘, 후보 저장, 이력 저장은 아직 수행하지 않습니다.
-                    - 실제 저장 테이블은 `personal_recommendations`, `personal_recommendation_candidates` 기준입니다.
+                    `restriction ingredient`, `disliked menu item`, 최근 선택 메뉴를 제외한 뒤 후보를 저장하고 반환합니다.
                     """
     )
     @ApiResponses({
@@ -81,13 +76,11 @@ public interface RecommendationApi {
     );
 
     @Operation(
-            summary = "개인 추천 요청 상세 조회 (Mock API)",
+            summary = "개인 추천 요청 상세 조회",
             description = """
                     개인 추천 요청과 후보 목록, 선택 상태를 조회합니다.
 
-                    Mock API 상태:
-                    - `requestId` 존재 여부나 소유자 검증은 수행하지 않습니다.
-                    - 항상 같은 더미 추천 상세를 반환합니다.
+                    본인이 생성한 개인 추천만 조회할 수 있습니다.
                     """
     )
     @ApiResponses({
@@ -107,13 +100,11 @@ public interface RecommendationApi {
     ApiResponse<PersonalRecommendationDetailResponse> getPersonalRecommendation(Long requestId);
 
     @Operation(
-            summary = "개인 추천 후보 목록 조회 (Mock API)",
+            summary = "개인 추천 후보 목록 조회",
             description = """
                     개인 추천 요청의 후보 메뉴 목록만 조회합니다.
 
-                    Mock API 상태:
-                    - `requestId` 존재 여부나 소유자 검증은 수행하지 않습니다.
-                    - 후보 3개를 고정 응답으로 반환합니다.
+                    본인이 생성한 개인 추천의 후보만 조회할 수 있습니다.
                     """
     )
     @ApiResponses({
@@ -133,14 +124,11 @@ public interface RecommendationApi {
     ApiResponse<PersonalRecommendationCandidateListResponse> getPersonalRecommendationCandidates(Long requestId);
 
     @Operation(
-            summary = "개인 추천 후보 선택 (Mock API)",
+            summary = "개인 추천 후보 선택",
             description = """
                     개인 추천 후보 중 하나를 최종 선택으로 반영합니다.
 
-                    Mock API 상태:
-                    - request body validation만 수행합니다.
-                    - 이미 선택된 요청인지, 후보가 해당 요청에 속하는지는 아직 검증하지 않습니다.
-                    - 실제 구현에서는 `member_menu_actions` 로그 저장과 추천 결과 갱신을 함께 검토합니다.
+                    선택된 후보는 개인 추천에 저장되며 `member_menu_actions`에 `CHOOSE` 로그가 함께 기록됩니다.
                     """
     )
     @ApiResponses({

--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationController.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationController.java
@@ -2,6 +2,7 @@ package matchuri.backend.api.recommendation;
 
 import jakarta.validation.Valid;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import matchuri.backend.api.recommendation.dto.request.CreatePersonalRecommendationRequest;
 import matchuri.backend.api.recommendation.dto.request.SelectPersonalRecommendationRequest;
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationCandidateListResponse;
@@ -9,6 +10,11 @@ import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationDe
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationRequestResponse;
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationResponse;
 import matchuri.backend.api.recommendation.dto.response.SelectPersonalRecommendationResponse;
+import matchuri.backend.domain.recommendation.result.PersonalRecommendationCandidateResult;
+import matchuri.backend.domain.recommendation.result.PersonalRecommendationResult;
+import matchuri.backend.domain.recommendation.result.PersonalRecommendationSummaryResult;
+import matchuri.backend.domain.recommendation.result.SelectPersonalRecommendationResult;
+import matchuri.backend.domain.recommendation.service.RecommendationService;
 import matchuri.backend.global.api.ApiResponse;
 import matchuri.backend.global.api.PageResponse;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,46 +27,67 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1")
+@RequiredArgsConstructor
 public class RecommendationController implements RecommendationApi {
 
-    @Override
-    @GetMapping("/personal-recommendations")
-    public ApiResponse<PageResponse<PersonalRecommendationResponse>> getMyPersonalRecommendationList() {
+    private final RecommendationService recommendationService;
+    private final RecommendationMapper recommendationMapper;
 
-        PageResponse<PersonalRecommendationResponse> response = PageResponse.mock(
-                List.of(PersonalRecommendationResponse.mock()));
+    @Override
+    @GetMapping("/personal/recommendations")
+    public ApiResponse<PageResponse<PersonalRecommendationResponse>> getMyPersonalRecommendationList() {
+        List<PersonalRecommendationSummaryResult> results = recommendationService.getMyPersonalRecommendations();
+
+        PageResponse<PersonalRecommendationResponse> response = PageResponse.ofList(
+                results.stream()
+                        .map(recommendationMapper::toSummaryResponse)
+                        .toList()
+        );
 
         return ApiResponse.success(response);
     }
 
     @Override
-    @PostMapping("/personal-recommendation-requests")
+    @PostMapping("/personal/recommendations")
     public ApiResponse<PersonalRecommendationRequestResponse> createPersonalRecommendation(
             @Valid @RequestBody CreatePersonalRecommendationRequest request
     ) {
-        return ApiResponse.success(PersonalRecommendationRequestResponse.mockCompleted());
+        String contextJson = recommendationMapper.toContextJson(request);
+        PersonalRecommendationResult result = recommendationService.createPersonalRecommendation(contextJson);
+
+        return ApiResponse.success(recommendationMapper.toCreateResponse(result));
     }
 
     @Override
-    @GetMapping("/personal-recommendation-requests/{requestId}")
+    @GetMapping("/personal/recommendations/{requestId}")
     public ApiResponse<PersonalRecommendationDetailResponse> getPersonalRecommendation(@PathVariable Long requestId) {
-        return ApiResponse.success(PersonalRecommendationDetailResponse.mockSelected());
+        PersonalRecommendationResult result = recommendationService.getPersonalRecommendation(requestId);
+
+        return ApiResponse.success(recommendationMapper.toDetailResponse(result));
     }
 
     @Override
-    @GetMapping("/personal-recommendation-requests/{requestId}/candidates")
+    @GetMapping("/personal/recommendations/{requestId}/candidates")
     public ApiResponse<PersonalRecommendationCandidateListResponse> getPersonalRecommendationCandidates(
             @PathVariable Long requestId
     ) {
-        return ApiResponse.success(PersonalRecommendationCandidateListResponse.mock());
+        List<PersonalRecommendationCandidateResult> results =
+                recommendationService.getPersonalRecommendationCandidates(requestId);
+
+        return ApiResponse.success(recommendationMapper.toCandidateListResponse(requestId, results));
     }
 
     @Override
-    @PatchMapping("/personal-recommendation-requests/{requestId}")
+    @PatchMapping("/personal/recommendations/{requestId}")
     public ApiResponse<SelectPersonalRecommendationResponse> selectPersonalRecommendationCandidate(
             @PathVariable Long requestId,
             @Valid @RequestBody SelectPersonalRecommendationRequest request
     ) {
-        return ApiResponse.success(SelectPersonalRecommendationResponse.mockSelected(request.selectedCandidateId()));
+        SelectPersonalRecommendationResult result = recommendationService.selectPersonalRecommendationCandidate(
+                requestId,
+                request.selectedCandidateId()
+        );
+
+        return ApiResponse.success(recommendationMapper.toSelectResponse(result));
     }
 }

--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationController.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationController.java
@@ -17,6 +17,8 @@ import matchuri.backend.domain.recommendation.result.SelectPersonalRecommendatio
 import matchuri.backend.domain.recommendation.service.RecommendationService;
 import matchuri.backend.global.api.ApiResponse;
 import matchuri.backend.global.api.PageResponse;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@NullMarked
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
@@ -40,18 +43,11 @@ public class RecommendationController implements RecommendationApi {
             @RequestParam(defaultValue = "0") Integer page,
             @RequestParam(defaultValue = "20") Integer size
     ) {
-        List<PersonalRecommendationSummaryResult> results = recommendationService.getMyPersonalRecommendations();
+        Page<PersonalRecommendationSummaryResult> results =
+                recommendationService.getMyPersonalRecommendations(page, size);
 
-        List<PersonalRecommendationResponse> content = results.stream()
-                .map(recommendationMapper::toSummaryResponse)
-                .toList();
-
-        PageResponse<PersonalRecommendationResponse> response = PageResponse.mock(
-                content,
-                page,
-                size,
-                content.size()
-        );
+        PageResponse<PersonalRecommendationResponse> response =
+                PageResponse.of(results, recommendationMapper::toSummaryResponse);
 
         return ApiResponse.success(response);
     }

--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationController.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationController.java
@@ -2,6 +2,7 @@ package matchuri.backend.api.recommendation;
 
 import jakarta.validation.Valid;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import matchuri.backend.api.recommendation.dto.request.CreatePersonalRecommendationRequest;
 import matchuri.backend.api.recommendation.dto.request.SelectPersonalRecommendationRequest;
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationCandidateListResponse;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -34,13 +36,21 @@ public class RecommendationController implements RecommendationApi {
 
     @Override
     @GetMapping("/personal/recommendations")
-    public ApiResponse<PageResponse<PersonalRecommendationResponse>> getMyPersonalRecommendationList() {
+    public ApiResponse<PageResponse<PersonalRecommendationResponse>> getMyPersonalRecommendationList(
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "20") Integer size
+    ) {
         List<PersonalRecommendationSummaryResult> results = recommendationService.getMyPersonalRecommendations();
 
-        PageResponse<PersonalRecommendationResponse> response = PageResponse.ofList(
-                results.stream()
-                        .map(recommendationMapper::toSummaryResponse)
-                        .toList()
+        List<PersonalRecommendationResponse> content = results.stream()
+                .map(recommendationMapper::toSummaryResponse)
+                .toList();
+
+        PageResponse<PersonalRecommendationResponse> response = PageResponse.mock(
+                content,
+                page,
+                size,
+                content.size()
         );
 
         return ApiResponse.success(response);

--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationMapper.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationMapper.java
@@ -1,0 +1,113 @@
+package matchuri.backend.api.recommendation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import matchuri.backend.api.recommendation.dto.request.CreatePersonalRecommendationRequest;
+import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationCandidateListResponse;
+import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationCandidateResponse;
+import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationDetailResponse;
+import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationRequestResponse;
+import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationResponse;
+import matchuri.backend.api.recommendation.dto.response.SelectPersonalRecommendationResponse;
+import matchuri.backend.domain.recommendation.result.PersonalRecommendationCandidateResult;
+import matchuri.backend.domain.recommendation.result.PersonalRecommendationResult;
+import matchuri.backend.domain.recommendation.result.PersonalRecommendationSummaryResult;
+import matchuri.backend.domain.recommendation.result.SelectPersonalRecommendationResult;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RecommendationMapper {
+
+    private final ObjectMapper objectMapper;
+
+    public String toContextJson(CreatePersonalRecommendationRequest request) {
+        try {
+            Map<String, Object> contextJson = request.contextJson() == null ? Map.of() : request.contextJson();
+
+            return objectMapper.writeValueAsString(contextJson);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalArgumentException("contextJson을 JSON 문자열로 변환할 수 없습니다.", exception);
+        }
+    }
+
+    public PersonalRecommendationRequestResponse toCreateResponse(PersonalRecommendationResult result) {
+        return new PersonalRecommendationRequestResponse(
+                result.id(),
+                result.status(),
+                result.requestedAt(),
+                toCandidateResponses(result.candidates())
+        );
+    }
+
+    public PersonalRecommendationDetailResponse toDetailResponse(PersonalRecommendationResult result) {
+        return new PersonalRecommendationDetailResponse(
+                result.id(),
+                result.status(),
+                toContextMap(result.contextJson()),
+                toCandidateResponses(result.candidates()),
+                result.selectedCandidateId()
+        );
+    }
+
+    public PersonalRecommendationCandidateListResponse toCandidateListResponse(
+            Long personalRecommendationId,
+            List<PersonalRecommendationCandidateResult> candidates
+    ) {
+        return new PersonalRecommendationCandidateListResponse(
+                personalRecommendationId,
+                toCandidateResponses(candidates)
+        );
+    }
+
+    public PersonalRecommendationResponse toSummaryResponse(PersonalRecommendationSummaryResult result) {
+        return new PersonalRecommendationResponse(
+                result.id(),
+                result.status(),
+                result.requestedAt()
+        );
+    }
+
+    public SelectPersonalRecommendationResponse toSelectResponse(SelectPersonalRecommendationResult result) {
+        return new SelectPersonalRecommendationResponse(
+                result.id(),
+                result.selectedCandidateId(),
+                result.updatedAt()
+        );
+    }
+
+    private List<PersonalRecommendationCandidateResponse> toCandidateResponses(
+            List<PersonalRecommendationCandidateResult> candidates
+    ) {
+        return candidates.stream()
+                .map(this::toCandidateResponse)
+                .toList();
+    }
+
+    private PersonalRecommendationCandidateResponse toCandidateResponse(PersonalRecommendationCandidateResult result) {
+        return new PersonalRecommendationCandidateResponse(
+                result.id(),
+                result.menuId(),
+                result.menuName(),
+                result.rankNo(),
+                result.score()
+        );
+    }
+
+    private Map<String, Object> toContextMap(String contextJson) {
+        if (contextJson == null || contextJson.isBlank()) {
+            return Map.of();
+        }
+
+        try {
+            return objectMapper.readValue(contextJson, new TypeReference<>() {
+            });
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("저장된 contextJson을 해석할 수 없습니다.", exception);
+        }
+    }
+}

--- a/src/main/java/matchuri/backend/api/recommendation/dto/request/CreatePersonalRecommendationRequest.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/request/CreatePersonalRecommendationRequest.java
@@ -1,15 +1,13 @@
 package matchuri.backend.api.recommendation.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 
 public record CreatePersonalRecommendationRequest(
         @Schema(
-                description = "추천 요청 컨텍스트입니다. MVP에서는 mealTime, partySize, budgetLevel 같은 느슨한 JSON 값으로 시작합니다.",
+                description = "추천 요청 컨텍스트입니다. MVP에서는 선택 입력이며 mealTime, partySize, budgetLevel 같은 느슨한 JSON 값으로 시작합니다.",
                 example = "{\"mealTime\":\"LUNCH\",\"budgetLevel\":2}"
         )
-        @NotNull(message = "contextJson은 null일 수 없습니다.")
         Map<String, Object> contextJson
 ) {
 }

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationCandidateResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationCandidateResponse.java
@@ -15,7 +15,7 @@ public record PersonalRecommendationCandidateResponse(
         @Schema(description = "추천 순위입니다.", example = "1")
         Integer rankNo,
 
-        @Schema(description = "Mock 추천 점수입니다.", example = "93.5")
+        @Schema(description = "추천 점수입니다.", example = "93.5")
         Double score
 ) {
     public static PersonalRecommendationCandidateResponse mockBibimbap() {

--- a/src/main/java/matchuri/backend/domain/behavior/repository/MemberMenuActionRepository.java
+++ b/src/main/java/matchuri/backend/domain/behavior/repository/MemberMenuActionRepository.java
@@ -1,0 +1,9 @@
+package matchuri.backend.domain.behavior.repository;
+
+import matchuri.backend.domain.behavior.entity.MemberMenuAction;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+@NullMarked
+public interface MemberMenuActionRepository extends JpaRepository<MemberMenuAction, Long> {
+}

--- a/src/main/java/matchuri/backend/domain/member/entity/MemberTasteProfile.java
+++ b/src/main/java/matchuri/backend/domain/member/entity/MemberTasteProfile.java
@@ -7,13 +7,19 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import matchuri.backend.domain.common.BaseEntity;
+import matchuri.backend.domain.menu.entity.AttributeCategory;
+import matchuri.backend.domain.menu.entity.Ingredient;
+import matchuri.backend.domain.menu.entity.MenuItem;
 
 @Getter
 @Entity
@@ -41,6 +47,15 @@ public class MemberTasteProfile extends BaseEntity {
     @Column(name = "profile_version", nullable = false, length = PROFILE_VERSION_MAX_SIZE, comment = "프로필 버전")
     private String profileVersion;
 
+    @OneToMany(mappedBy = "profile")
+    private List<MemberTasteProfileCategory> preferAttributeCategories = new ArrayList<>();
+
+    @OneToMany(mappedBy = "profile")
+    private List<MemberTasteProfileRestrictionIngredient> restrictionIngredients = new ArrayList<>();
+
+    @OneToMany(mappedBy = "profile")
+    private List<MemberTasteProfileDislikedMenuItem> dislikedMenuItems = new ArrayList<>();
+
     public MemberTasteProfile(Member member, String profileVersion) {
         this.member = member;
         this.profileVersion = profileVersion;
@@ -49,5 +64,23 @@ public class MemberTasteProfile extends BaseEntity {
 
     public void updateProfileVersion(String profileVersion) {
         this.profileVersion = profileVersion;
+    }
+
+    public List<Ingredient> getRestrictionIngredients() {
+        return restrictionIngredients.stream()
+                .map(MemberTasteProfileRestrictionIngredient::getIngredient)
+                .toList();
+    }
+
+    public List<MenuItem> getDisLikeMenuItems() {
+        return dislikedMenuItems.stream()
+                .map(MemberTasteProfileDislikedMenuItem::getMenuItem)
+                .toList();
+    }
+
+    public List<AttributeCategory> getPreferAttributeCategories() {
+        return preferAttributeCategories.stream()
+                .map(MemberTasteProfileCategory::getAttributeCategory)
+                .toList();
     }
 }

--- a/src/main/java/matchuri/backend/domain/menu/entity/MenuItem.java
+++ b/src/main/java/matchuri/backend/domain/menu/entity/MenuItem.java
@@ -5,8 +5,13 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -44,6 +49,9 @@ public class MenuItem extends BaseEntity {
     @Column(name = "is_active", nullable = false, comment = "활성 여부")
     private boolean active;
 
+    @OneToMany(mappedBy = "menu")
+    private List<MenuAttributeCategory> menuAttributeCategories = new ArrayList<>();
+
     public MenuItem(
             String code,
             String name,
@@ -69,5 +77,17 @@ public class MenuItem extends BaseEntity {
 
     public void deactivate() {
         this.active = false;
+    }
+
+    public long countMatchingCategories(List<AttributeCategory> categories) {
+
+        Set<Long> ids = categories.stream()
+                .map(AttributeCategory::getId)
+                .collect(Collectors.toSet());
+
+        return this.menuAttributeCategories.stream()
+                .map(MenuAttributeCategory::getAttributeCategory)
+                .filter(attributeCategory -> ids.contains(attributeCategory.getId()))
+                .count();
     }
 }

--- a/src/main/java/matchuri/backend/domain/menu/repository/MenuIngredientRepository.java
+++ b/src/main/java/matchuri/backend/domain/menu/repository/MenuIngredientRepository.java
@@ -1,5 +1,6 @@
 package matchuri.backend.domain.menu.repository;
 
+import java.util.Collection;
 import java.util.List;
 import matchuri.backend.domain.menu.entity.Ingredient;
 import matchuri.backend.domain.menu.entity.MenuIngredient;
@@ -13,4 +14,6 @@ public interface MenuIngredientRepository extends JpaRepository<MenuIngredient, 
     boolean existsByMenuAndIngredient(MenuItem menu, Ingredient ingredient);
 
     List<MenuIngredient> findAllByMenuIdAndIngredientActiveTrueOrderByIngredientSortOrderAscIngredientIdAsc(Long menuId);
+
+    List<MenuIngredient> findAllByIngredientIdNotIn(Collection<Long> ingredientIds);
 }

--- a/src/main/java/matchuri/backend/domain/menu/repository/MenuItemRepository.java
+++ b/src/main/java/matchuri/backend/domain/menu/repository/MenuItemRepository.java
@@ -56,4 +56,6 @@ public interface MenuItemRepository extends JpaRepository<MenuItem, Long> {
             @Param("ingredientIds") Collection<Long> ingredientIds,
             @Param("ingredientIdsEmpty") boolean ingredientIdsEmpty
     );
+
+    List<MenuItem> findAllByIdNotIn(Collection<Long> ids);
 }

--- a/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendation.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendation.java
@@ -12,11 +12,15 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import matchuri.backend.domain.common.BaseEntity;
 import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.menu.entity.AttributeCategory;
+import matchuri.backend.domain.menu.entity.MenuAttributeCategory;
+import matchuri.backend.domain.menu.entity.MenuItem;
 
 @Getter
 @Entity
@@ -50,11 +54,21 @@ public class PersonalRecommendation extends BaseEntity {
     @JoinColumn(name = "selected_candidate_id", comment = "최종 선택 후보 ID")
     private PersonalRecommendationCandidate selectedCandidate;
 
-    public PersonalRecommendation(Member member, String contextJson, LocalDateTime requestedAt) {
+    private PersonalRecommendation(Member member, String contextJson, LocalDateTime requestedAt,
+                                   PersonalRecommendationStatus status) {
         this.member = member;
         this.contextJson = contextJson;
         this.requestedAt = requestedAt;
-        this.status = PersonalRecommendationStatus.REQUESTED;
+        this.status = status;
+    }
+
+    public static PersonalRecommendation of(Member member, String contextJson) {
+        return new PersonalRecommendation(
+                member,
+                contextJson,
+                LocalDateTime.now(),
+                PersonalRecommendationStatus.REQUESTED
+        );
     }
 
     public void markFiltered() {
@@ -75,5 +89,19 @@ public class PersonalRecommendation extends BaseEntity {
 
     public void select(PersonalRecommendationCandidate selectedCandidate) {
         this.selectedCandidate = selectedCandidate;
+    }
+
+    public MenuItem getSelectedMenu() {
+        return this.selectedCandidate.getMenuItem();
+    }
+
+    public List<AttributeCategory> getSelectedMenuAttributeCategory() {
+
+        MenuItem menuItem = this.selectedCandidate.getMenuItem();
+        List<MenuAttributeCategory> menuAttributeCategories = menuItem.getMenuAttributeCategories();
+
+        return menuAttributeCategories.stream()
+                .map(MenuAttributeCategory::getAttributeCategory)
+                .toList();
     }
 }

--- a/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendationCandidate.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendationCandidate.java
@@ -48,17 +48,17 @@ public class PersonalRecommendationCandidate extends BaseEntity {
     @Column(name = "rank_no", nullable = false, comment = "후보 순위")
     private int rankNo;
 
-    @Column(precision = 10, scale = 4, comment = "추천 점수")
-    private BigDecimal score;
+    @Column(comment = "추천 점수")
+    private Double score;
 
     @Column(name = "candidate_meta_json", columnDefinition = "json", comment = "후보 메타 JSON")
     private String candidateMetaJson;
 
-    public PersonalRecommendationCandidate(
+    private PersonalRecommendationCandidate(
             PersonalRecommendation personalRecommendation,
             MenuItem menuItem,
             int rankNo,
-            BigDecimal score,
+            Double score,
             String candidateMetaJson
     ) {
         this.personalRecommendation = personalRecommendation;
@@ -66,5 +66,20 @@ public class PersonalRecommendationCandidate extends BaseEntity {
         this.rankNo = rankNo;
         this.score = score;
         this.candidateMetaJson = candidateMetaJson;
+    }
+
+    public static PersonalRecommendationCandidate of(
+            PersonalRecommendation personalRecommendation,
+            MenuItem menuItem,
+            int rankNo,
+            Double score
+    ) {
+        return new PersonalRecommendationCandidate(
+                personalRecommendation,
+                menuItem,
+                rankNo,
+                score,
+                null
+        );
     }
 }

--- a/src/main/java/matchuri/backend/domain/recommendation/exception/RecommendationErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/exception/RecommendationErrorCode.java
@@ -1,0 +1,30 @@
+package matchuri.backend.domain.recommendation.exception;
+
+import java.text.MessageFormat;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import matchuri.backend.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RecommendationErrorCode implements ErrorCode {
+
+    TASTE_PROFILE_REQUIRED(HttpStatus.FORBIDDEN, "개인 추천을 만들려면 취향 프로필이 필요합니다. memberId : {0}"),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "해당 개인 추천을 찾을 수 없습니다. personalRecommendationId : {0}"),
+    CANDIDATE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 개인 추천 후보를 찾을 수 없습니다. candidateId : {0}"),
+    ALREADY_SELECTED(HttpStatus.CONFLICT, "이미 최종 후보가 선택된 개인 추천입니다. personalRecommendationId : {0}");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String format(Object... args) {
+        return MessageFormat.format(message, args);
+    }
+
+    @Override
+    public String getDomainPrefix() {
+        return "PERSONAL_RECOMMENDATION_";
+    }
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/repository/PersonalRecommendationCandidateRepository.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/repository/PersonalRecommendationCandidateRepository.java
@@ -1,9 +1,18 @@
 package matchuri.backend.domain.recommendation.repository;
 
+import java.util.List;
+import java.util.Optional;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCandidate;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 @NullMarked
 public interface PersonalRecommendationCandidateRepository extends JpaRepository<PersonalRecommendationCandidate, Long> {
+
+    List<PersonalRecommendationCandidate> findByPersonalRecommendationIdOrderByRankNoAsc(Long personalRecommendationId);
+
+    Optional<PersonalRecommendationCandidate> findByIdAndPersonalRecommendationId(
+            Long id,
+            Long personalRecommendationId
+    );
 }

--- a/src/main/java/matchuri/backend/domain/recommendation/repository/PersonalRecommendationCandidateRepository.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/repository/PersonalRecommendationCandidateRepository.java
@@ -1,0 +1,9 @@
+package matchuri.backend.domain.recommendation.repository;
+
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCandidate;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+@NullMarked
+public interface PersonalRecommendationCandidateRepository extends JpaRepository<PersonalRecommendationCandidate, Long> {
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/repository/PersonalRecommendationRepository.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/repository/PersonalRecommendationRepository.java
@@ -1,0 +1,11 @@
+package matchuri.backend.domain.recommendation.repository;
+
+import java.util.List;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+@NullMarked
+public interface PersonalRecommendationRepository extends JpaRepository<PersonalRecommendation, Long> {
+    List<PersonalRecommendation> findByMemberId(Long memberId);
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/repository/PersonalRecommendationRepository.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/repository/PersonalRecommendationRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
 import org.jspecify.annotations.NullMarked;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 @NullMarked
@@ -11,6 +13,7 @@ public interface PersonalRecommendationRepository extends JpaRepository<Personal
     List<PersonalRecommendation> findByMemberId(Long memberId);
 
     List<PersonalRecommendation> findByMemberIdOrderByRequestedAtDescIdDesc(Long memberId);
+    Page<PersonalRecommendation> findByMemberIdOrderByRequestedAtDescIdDesc(Long memberId, Pageable pageable);
 
     Optional<PersonalRecommendation> findByIdAndMemberId(Long id, Long memberId);
 }

--- a/src/main/java/matchuri/backend/domain/recommendation/repository/PersonalRecommendationRepository.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/repository/PersonalRecommendationRepository.java
@@ -1,6 +1,7 @@
 package matchuri.backend.domain.recommendation.repository;
 
 import java.util.List;
+import java.util.Optional;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 @NullMarked
 public interface PersonalRecommendationRepository extends JpaRepository<PersonalRecommendation, Long> {
     List<PersonalRecommendation> findByMemberId(Long memberId);
+
+    List<PersonalRecommendation> findByMemberIdOrderByRequestedAtDescIdDesc(Long memberId);
+
+    Optional<PersonalRecommendation> findByIdAndMemberId(Long id, Long memberId);
 }

--- a/src/main/java/matchuri/backend/domain/recommendation/result/PersonalRecommendationCandidateResult.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/result/PersonalRecommendationCandidateResult.java
@@ -1,0 +1,21 @@
+package matchuri.backend.domain.recommendation.result;
+
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCandidate;
+
+public record PersonalRecommendationCandidateResult(
+        Long id,
+        Long menuId,
+        String menuName,
+        int rankNo,
+        Double score
+) {
+    public static PersonalRecommendationCandidateResult from(PersonalRecommendationCandidate candidate) {
+        return new PersonalRecommendationCandidateResult(
+                candidate.getId(),
+                candidate.getMenuItem().getId(),
+                candidate.getMenuItem().getName(),
+                candidate.getRankNo(),
+                candidate.getScore()
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/result/PersonalRecommendationResult.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/result/PersonalRecommendationResult.java
@@ -1,0 +1,36 @@
+package matchuri.backend.domain.recommendation.result;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCandidate;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
+
+public record PersonalRecommendationResult(
+        Long id,
+        PersonalRecommendationStatus status,
+        LocalDateTime requestedAt,
+        String contextJson,
+        Long selectedCandidateId,
+        List<PersonalRecommendationCandidateResult> candidates
+) {
+    public static PersonalRecommendationResult of(
+            PersonalRecommendation personalRecommendation,
+            List<PersonalRecommendationCandidate> candidates
+    ) {
+        Long selectedCandidateId = personalRecommendation.getSelectedCandidate() == null
+                ? null
+                : personalRecommendation.getSelectedCandidate().getId();
+
+        return new PersonalRecommendationResult(
+                personalRecommendation.getId(),
+                personalRecommendation.getStatus(),
+                personalRecommendation.getRequestedAt(),
+                personalRecommendation.getContextJson(),
+                selectedCandidateId,
+                candidates.stream()
+                        .map(PersonalRecommendationCandidateResult::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/result/PersonalRecommendationSummaryResult.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/result/PersonalRecommendationSummaryResult.java
@@ -1,0 +1,19 @@
+package matchuri.backend.domain.recommendation.result;
+
+import java.time.LocalDateTime;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
+
+public record PersonalRecommendationSummaryResult(
+        Long id,
+        PersonalRecommendationStatus status,
+        LocalDateTime requestedAt
+) {
+    public static PersonalRecommendationSummaryResult from(PersonalRecommendation personalRecommendation) {
+        return new PersonalRecommendationSummaryResult(
+                personalRecommendation.getId(),
+                personalRecommendation.getStatus(),
+                personalRecommendation.getRequestedAt()
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/result/SelectPersonalRecommendationResult.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/result/SelectPersonalRecommendationResult.java
@@ -1,0 +1,22 @@
+package matchuri.backend.domain.recommendation.result;
+
+import java.time.LocalDateTime;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCandidate;
+
+public record SelectPersonalRecommendationResult(
+        Long id,
+        Long selectedCandidateId,
+        LocalDateTime updatedAt
+) {
+    public static SelectPersonalRecommendationResult of(
+            PersonalRecommendation personalRecommendation,
+            PersonalRecommendationCandidate selectedCandidate
+    ) {
+        return new SelectPersonalRecommendationResult(
+                personalRecommendation.getId(),
+                selectedCandidate.getId(),
+                personalRecommendation.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationService.java
@@ -1,5 +1,5 @@
 package matchuri.backend.domain.recommendation.service;
 
 public interface RecommendationService {
-    void getPersonalRecommendation();
+    void getPersonalRecommendation(String contextJson);
 }

--- a/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationService.java
@@ -1,5 +1,22 @@
 package matchuri.backend.domain.recommendation.service;
 
+import java.util.List;
+import matchuri.backend.domain.recommendation.result.PersonalRecommendationCandidateResult;
+import matchuri.backend.domain.recommendation.result.PersonalRecommendationResult;
+import matchuri.backend.domain.recommendation.result.PersonalRecommendationSummaryResult;
+import matchuri.backend.domain.recommendation.result.SelectPersonalRecommendationResult;
+
 public interface RecommendationService {
-    void getPersonalRecommendation(String contextJson);
+    PersonalRecommendationResult createPersonalRecommendation(String contextJson);
+
+    PersonalRecommendationResult getPersonalRecommendation(Long personalRecommendationId);
+
+    List<PersonalRecommendationCandidateResult> getPersonalRecommendationCandidates(Long personalRecommendationId);
+
+    List<PersonalRecommendationSummaryResult> getMyPersonalRecommendations();
+
+    SelectPersonalRecommendationResult selectPersonalRecommendationCandidate(
+            Long personalRecommendationId,
+            Long selectedCandidateId
+    );
 }

--- a/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationService.java
@@ -5,6 +5,8 @@ import matchuri.backend.domain.recommendation.result.PersonalRecommendationCandi
 import matchuri.backend.domain.recommendation.result.PersonalRecommendationResult;
 import matchuri.backend.domain.recommendation.result.PersonalRecommendationSummaryResult;
 import matchuri.backend.domain.recommendation.result.SelectPersonalRecommendationResult;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.domain.Page;
 
 public interface RecommendationService {
     PersonalRecommendationResult createPersonalRecommendation(String contextJson);
@@ -13,7 +15,7 @@ public interface RecommendationService {
 
     List<PersonalRecommendationCandidateResult> getPersonalRecommendationCandidates(Long personalRecommendationId);
 
-    List<PersonalRecommendationSummaryResult> getMyPersonalRecommendations();
+    Page<@NonNull PersonalRecommendationSummaryResult> getMyPersonalRecommendations(int page, int size);
 
     SelectPersonalRecommendationResult selectPersonalRecommendationCandidate(
             Long personalRecommendationId,

--- a/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.domain.behavior.entity.ActionType;
 import matchuri.backend.domain.behavior.entity.MemberMenuAction;
@@ -32,6 +33,8 @@ import matchuri.backend.domain.recommendation.result.SelectPersonalRecommendatio
 import matchuri.backend.domain.recommendation.support.MenuItemScoreBoard;
 import matchuri.backend.domain.recommendation.support.ScoreCalculator;
 import matchuri.backend.global.exception.BusinessException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -129,13 +132,12 @@ public class RecommendationServiceImpl implements RecommendationService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<PersonalRecommendationSummaryResult> getMyPersonalRecommendations() {
+    public Page<@NonNull PersonalRecommendationSummaryResult> getMyPersonalRecommendations(int page, int size) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
 
-        return personalRecommendationRepository.findByMemberIdOrderByRequestedAtDescIdDesc(member.getId())
-                .stream()
-                .map(PersonalRecommendationSummaryResult::from)
-                .toList();
+        return personalRecommendationRepository
+                .findByMemberIdOrderByRequestedAtDescIdDesc(member.getId(), PageRequest.of(page, size))
+                .map(PersonalRecommendationSummaryResult::from);
     }
 
     @Override

--- a/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
@@ -8,6 +8,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
+import matchuri.backend.domain.behavior.entity.ActionType;
+import matchuri.backend.domain.behavior.entity.MemberMenuAction;
+import matchuri.backend.domain.behavior.repository.MemberMenuActionRepository;
 import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.entity.MemberTasteProfile;
 import matchuri.backend.domain.member.support.member.ActiveMemberReader;
@@ -19,10 +22,16 @@ import matchuri.backend.domain.menu.repository.MenuIngredientRepository;
 import matchuri.backend.domain.menu.repository.MenuItemRepository;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCandidate;
+import matchuri.backend.domain.recommendation.exception.RecommendationErrorCode;
 import matchuri.backend.domain.recommendation.repository.PersonalRecommendationCandidateRepository;
 import matchuri.backend.domain.recommendation.repository.PersonalRecommendationRepository;
+import matchuri.backend.domain.recommendation.result.PersonalRecommendationCandidateResult;
+import matchuri.backend.domain.recommendation.result.PersonalRecommendationResult;
+import matchuri.backend.domain.recommendation.result.PersonalRecommendationSummaryResult;
+import matchuri.backend.domain.recommendation.result.SelectPersonalRecommendationResult;
 import matchuri.backend.domain.recommendation.support.MenuItemScoreBoard;
 import matchuri.backend.domain.recommendation.support.ScoreCalculator;
+import matchuri.backend.global.exception.BusinessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,17 +47,25 @@ public class RecommendationServiceImpl implements RecommendationService {
     private final MenuItemRepository menuItemRepository;
     private final MenuIngredientRepository menuIngredientRepository;
     private final PersonalRecommendationCandidateRepository personalRecommendationCandidateRepository;
+    private final MemberMenuActionRepository memberMenuActionRepository;
 
     /**
      * 현재 로그인한 회원의 취향 프로필과 과거 선택 이력을 기반으로 개인 메뉴 후보를 생성한다.
      *
      * @param contextJson 추천 요청 시점의 컨텍스트 JSON
+     * @return 생성된 개인 추천과 추천 후보 목록
      */
     @Override
-    public void getPersonalRecommendation(String contextJson) {
+    public PersonalRecommendationResult createPersonalRecommendation(String contextJson) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
         MemberTasteProfile tasteProfile = member.getTasteProfile();
-        List<PersonalRecommendation> recommendations = personalRecommendationRepository.findByMemberId(member.getId());
+
+        if (tasteProfile == null) {
+            throw new BusinessException(RecommendationErrorCode.TASTE_PROFILE_REQUIRED, member.getId());
+        }
+
+        List<PersonalRecommendation> recommendations =
+                personalRecommendationRepository.findByMemberIdOrderByRequestedAtDescIdDesc(member.getId());
 
         Map<Long, MenuItem> availableMenuItemsMap = findAvailableMenuItems(tasteProfile);
         excludeRecentlySelectedMenus(availableMenuItemsMap, recommendations);
@@ -70,10 +87,92 @@ public class RecommendationServiceImpl implements RecommendationService {
         List<MenuItemScoreBoard> finalizeMenuItems = scoreCalculator.calculate(menuItemScoreBoardMap);
 
         PersonalRecommendation personalRecommendation = PersonalRecommendation.of(member, contextJson);
+        personalRecommendation.markFiltered();
+        personalRecommendation.markScored();
+        personalRecommendation.complete();
         PersonalRecommendation savedPersonalRecommendation =
                 personalRecommendationRepository.save(personalRecommendation);
 
-        saveRecommendationCandidates(savedPersonalRecommendation, finalizeMenuItems);
+        List<PersonalRecommendationCandidate> savedCandidates =
+                saveRecommendationCandidates(savedPersonalRecommendation, finalizeMenuItems);
+
+        return PersonalRecommendationResult.of(savedPersonalRecommendation, savedCandidates);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PersonalRecommendationResult getPersonalRecommendation(Long personalRecommendationId) {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        PersonalRecommendation personalRecommendation = getOwnedPersonalRecommendation(personalRecommendationId,
+                member.getId());
+        List<PersonalRecommendationCandidate> candidates =
+                personalRecommendationCandidateRepository.findByPersonalRecommendationIdOrderByRankNoAsc(
+                        personalRecommendationId);
+
+        return PersonalRecommendationResult.of(personalRecommendation, candidates);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<PersonalRecommendationCandidateResult> getPersonalRecommendationCandidates(
+            Long personalRecommendationId
+    ) {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        getOwnedPersonalRecommendation(personalRecommendationId, member.getId());
+
+        return personalRecommendationCandidateRepository
+                .findByPersonalRecommendationIdOrderByRankNoAsc(personalRecommendationId)
+                .stream()
+                .map(PersonalRecommendationCandidateResult::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<PersonalRecommendationSummaryResult> getMyPersonalRecommendations() {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+
+        return personalRecommendationRepository.findByMemberIdOrderByRequestedAtDescIdDesc(member.getId())
+                .stream()
+                .map(PersonalRecommendationSummaryResult::from)
+                .toList();
+    }
+
+    @Override
+    public SelectPersonalRecommendationResult selectPersonalRecommendationCandidate(
+            Long personalRecommendationId,
+            Long selectedCandidateId
+    ) {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        PersonalRecommendation personalRecommendation = getOwnedPersonalRecommendation(personalRecommendationId,
+                member.getId());
+
+        if (personalRecommendation.getSelectedCandidate() != null) {
+            throw new BusinessException(RecommendationErrorCode.ALREADY_SELECTED, personalRecommendationId);
+        }
+
+        PersonalRecommendationCandidate selectedCandidate = personalRecommendationCandidateRepository
+                .findByIdAndPersonalRecommendationId(selectedCandidateId, personalRecommendationId)
+                .orElseThrow(() -> new BusinessException(
+                        RecommendationErrorCode.CANDIDATE_NOT_FOUND,
+                        selectedCandidateId
+                ));
+
+        personalRecommendation.select(selectedCandidate);
+        memberMenuActionRepository.save(new MemberMenuAction(
+                member,
+                selectedCandidate.getMenuItem(),
+                personalRecommendation,
+                ActionType.CHOOSE
+        ));
+        personalRecommendationRepository.flush();
+
+        return SelectPersonalRecommendationResult.of(personalRecommendation, selectedCandidate);
+    }
+
+    private PersonalRecommendation getOwnedPersonalRecommendation(Long personalRecommendationId, Long memberId) {
+        return personalRecommendationRepository.findByIdAndMemberId(personalRecommendationId, memberId)
+                .orElseThrow(() -> new BusinessException(RecommendationErrorCode.NOT_FOUND, personalRecommendationId));
     }
 
     /**
@@ -94,7 +193,11 @@ public class RecommendationServiceImpl implements RecommendationService {
 
         return menuItemsExceptByIngredients.stream()
                 .filter(menuItem -> menuItemIdsExceptByMenuItems.contains(menuItem.getId()))
-                .collect(Collectors.toMap(MenuItem::getId, menuItem -> menuItem));
+                .collect(Collectors.toMap(
+                        MenuItem::getId,
+                        menuItem -> menuItem,
+                        (current, ignored) -> current
+                ));
     }
 
     /**
@@ -108,6 +211,7 @@ public class RecommendationServiceImpl implements RecommendationService {
             List<PersonalRecommendation> recommendations
     ) {
         recommendations.stream()
+                .filter(recommendation -> recommendation.getSelectedCandidate() != null)
                 .map(PersonalRecommendation::getSelectedMenu)
                 .limit(RECENT_SELECTED_MENU_EXCLUSION_COUNT)
                 .forEach(menuItem -> availableMenuItemsMap.remove(menuItem.getId()));
@@ -151,8 +255,9 @@ public class RecommendationServiceImpl implements RecommendationService {
      *
      * @param savedPersonalRecommendation 저장된 개인 추천 엔티티
      * @param finalizeMenuItems 점수 계산이 끝난 최종 후보 목록
+     * @return 저장된 개인 추천 후보 목록
      */
-    private void saveRecommendationCandidates(
+    private List<PersonalRecommendationCandidate> saveRecommendationCandidates(
             PersonalRecommendation savedPersonalRecommendation,
             List<MenuItemScoreBoard> finalizeMenuItems
     ) {
@@ -164,13 +269,13 @@ public class RecommendationServiceImpl implements RecommendationService {
                     return PersonalRecommendationCandidate.of(
                             savedPersonalRecommendation,
                             board.getMenuItem(),
-                            i,
+                            i + 1,
                             board.getTotalScore()
                     );
                 })
                 .toList();
 
-        personalRecommendationCandidateRepository.saveAll(personalRecommendationCandidates);
+        return personalRecommendationCandidateRepository.saveAll(personalRecommendationCandidates);
     }
 
     /**
@@ -202,10 +307,15 @@ public class RecommendationServiceImpl implements RecommendationService {
                 .map(Ingredient::getId)
                 .toList();
 
+        if (ids.isEmpty()) {
+            return menuItemRepository.findAll();
+        }
+
         List<MenuIngredient> allByIngredientIdNotIn = menuIngredientRepository.findAllByIngredientIdNotIn(ids);
 
         return allByIngredientIdNotIn.stream()
                 .map(MenuIngredient::getMenu)
+                .distinct()
                 .toList();
     }
 
@@ -221,6 +331,7 @@ public class RecommendationServiceImpl implements RecommendationService {
         List<List<AttributeCategory>> selectedMenuCategoryGroups = new ArrayList<>();
 
         recommendations.stream()
+                .filter(recommendation -> recommendation.getSelectedCandidate() != null)
                 .map(PersonalRecommendation::getSelectedMenuAttributeCategory)
                 .forEach(selectedMenuCategoryGroups::add);
 

--- a/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
@@ -8,13 +8,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.entity.MemberTasteProfile;
-import matchuri.backend.domain.member.repository.MemberTasteProfileCategoryRepository;
-import matchuri.backend.domain.member.repository.MemberTasteProfileDislikedMenuItemRepository;
-import matchuri.backend.domain.member.repository.MemberTasteProfileRepository;
-import matchuri.backend.domain.member.repository.MemberTasteProfileRestrictionIngredientRepository;
 import matchuri.backend.domain.member.support.member.ActiveMemberReader;
 import matchuri.backend.domain.menu.entity.AttributeCategory;
 import matchuri.backend.domain.menu.entity.Ingredient;
@@ -34,60 +29,30 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 @RequiredArgsConstructor
-@Slf4j
 public class RecommendationServiceImpl implements RecommendationService {
 
-    private final MemberTasteProfileRepository memberTasteProfileRepository;
-    private final MemberTasteProfileCategoryRepository memberTasteProfileCategoryRepository;
-    private final MemberTasteProfileRestrictionIngredientRepository memberTasteProfileRestrictionIngredientRepository;
-    private final MemberTasteProfileDislikedMenuItemRepository memberTasteProfileDislikedMenuItemRepository;
+    private static final int RECENT_SELECTED_MENU_EXCLUSION_COUNT = 3;
+
     private final ActiveMemberReader activeMemberReader;
     private final PersonalRecommendationRepository personalRecommendationRepository;
     private final MenuItemRepository menuItemRepository;
     private final MenuIngredientRepository menuIngredientRepository;
     private final PersonalRecommendationCandidateRepository personalRecommendationCandidateRepository;
 
-
+    /**
+     * 현재 로그인한 회원의 취향 프로필과 과거 선택 이력을 기반으로 개인 메뉴 후보를 생성한다.
+     *
+     * @param contextJson 추천 요청 시점의 컨텍스트 JSON
+     */
     @Override
     public void getPersonalRecommendation(String contextJson) {
-        // 취향 프로필, 지난 내역 불러오기
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
         MemberTasteProfile tasteProfile = member.getTasteProfile();
-
-        // 알레르기 식품과 비선호 식품은 완전히 배제
-        // 알레르기 식재료
-        List<Ingredient> restrictionIngredients = tasteProfile.getRestrictionIngredients();
-        List<MenuItem> menuItemExceptByIngredients = findMenuItemsExceptByIngredients(restrictionIngredients);
-
-        // 비선호 음식
-        List<MenuItem> disLikeMenuItems = tasteProfile.getDisLikeMenuItems();
-        List<MenuItem> menuItemsExceptByMenuItems = findMenuItemsExceptByMenuItems(disLikeMenuItems);
-
-        // 추천 가능한 메뉴 (1차 필터링)
-        Set<Long> menuItemIdsExceptByMenuItems = menuItemsExceptByMenuItems.stream()
-                .map(MenuItem::getId)
-                .collect(Collectors.toSet());
-
-        Map<Long, MenuItem> availableMenuItemsMap = menuItemExceptByIngredients.stream()
-                .filter(menuItem -> menuItemIdsExceptByMenuItems.contains(menuItem.getId()))
-                .collect(Collectors.toMap(MenuItem::getId, menuItem -> menuItem));
-
-        // 이전 요청 목록
         List<PersonalRecommendation> recommendations = personalRecommendationRepository.findByMemberId(member.getId());
-        // 이전 요청 목록에서 선택했던 메뉴
-        List<MenuItem> selectedMenuItems = recommendations.stream()
-                .map(PersonalRecommendation::getSelectedMenu)
-                .toList();
 
-        // 최근에 선택했던 메뉴들을 제외 (2차 필터링)
-        int n = 3;
-        List<MenuItem> latestSelectedMenus = selectedMenuItems.subList(0, Math.min(n, selectedMenuItems.size()));
-        latestSelectedMenus
-                .forEach(menuItem -> {
-                    availableMenuItemsMap.remove(menuItem.getId());
-                });
+        Map<Long, MenuItem> availableMenuItemsMap = findAvailableMenuItems(tasteProfile);
+        excludeRecentlySelectedMenus(availableMenuItemsMap, recommendations);
 
-        // 필터링을 마친 예비 후보들
         Map<Long, MenuItemScoreBoard> menuItemScoreBoardMap = availableMenuItemsMap.values().stream()
                 .map(MenuItemScoreBoard::of)
                 .collect(Collectors.toMap(
@@ -95,40 +60,102 @@ public class RecommendationServiceImpl implements RecommendationService {
                         menuItemScoreBoard -> menuItemScoreBoard
                 ));
 
-        // 선호 카테고리 종합
         List<AttributeCategory> preferAttributeCategories = tasteProfile.getPreferAttributeCategories();
+        addCategoryMatchingCounts(menuItemScoreBoardMap, preferAttributeCategories);
 
-        // score1: 필터링된 메뉴 리스트에서 선호 카테고리가 일치하는 갯수 넣기
-        menuItemScoreBoardMap.forEach((id, menuItemScoreBoard) -> {
-            MenuItem menuItem = menuItemScoreBoard.getMenuItem();
-            long matchingCount = menuItem.countMatchingCategories(preferAttributeCategories);
+        Map<AttributeCategory, Long> categoryFrequencyMap = countSelectedCategoryFrequency(recommendations);
+        addHistoryWeightCounts(menuItemScoreBoardMap, categoryFrequencyMap);
 
-            menuItemScoreBoard.addCategoryMatchingCount(matchingCount);
-        });
-
-        // 이전에 선택했던 메뉴들의 카테고리를 종합하여 가중치 부여
-        List<List<AttributeCategory>> selectedMenuCategoryGroups = new ArrayList<>();
-
-        recommendations.stream()
-                .map(PersonalRecommendation::getSelectedMenuAttributeCategory)
-                .forEach(selectedMenuCategoryGroups::add);
-
-        // score2: 이전에 선택했던 메뉴들의 카테고리 빈도 수
-        Map<AttributeCategory, Long> categoryFrequencyMap = countCategoryFrequency(selectedMenuCategoryGroups);
-
-        menuItemScoreBoardMap.forEach((id, menuItemScoreBoard) -> {
-            menuItemScoreBoard.setWeightMatchingCount(categoryFrequencyMap);
-        });
-
-        // 계산 후 최종 MenuItems
         ScoreCalculator scoreCalculator = ScoreCalculator.of(preferAttributeCategories, categoryFrequencyMap);
         List<MenuItemScoreBoard> finalizeMenuItems = scoreCalculator.calculate(menuItemScoreBoardMap);
 
-        // 요청 엔티티, 후보 엔티티 생성
         PersonalRecommendation personalRecommendation = PersonalRecommendation.of(member, contextJson);
         PersonalRecommendation savedPersonalRecommendation =
                 personalRecommendationRepository.save(personalRecommendation);
 
+        saveRecommendationCandidates(savedPersonalRecommendation, finalizeMenuItems);
+    }
+
+    /**
+     * 제한 식재료와 비선호 메뉴를 제외한 추천 가능 메뉴 목록을 조회한다.
+     *
+     * @param tasteProfile 회원 취향 프로필
+     * @return 추천 가능 메뉴 ID를 key로 하는 메뉴 map
+     */
+    private Map<Long, MenuItem> findAvailableMenuItems(MemberTasteProfile tasteProfile) {
+        List<MenuItem> menuItemsExceptByIngredients =
+                findMenuItemsExceptByIngredients(tasteProfile.getRestrictionIngredients());
+        List<MenuItem> menuItemsExceptByMenuItems =
+                findMenuItemsExceptByMenuItems(tasteProfile.getDisLikeMenuItems());
+
+        Set<Long> menuItemIdsExceptByMenuItems = menuItemsExceptByMenuItems.stream()
+                .map(MenuItem::getId)
+                .collect(Collectors.toSet());
+
+        return menuItemsExceptByIngredients.stream()
+                .filter(menuItem -> menuItemIdsExceptByMenuItems.contains(menuItem.getId()))
+                .collect(Collectors.toMap(MenuItem::getId, menuItem -> menuItem));
+    }
+
+    /**
+     * 과거 추천에서 최근 선택한 메뉴를 현재 후보 목록에서 제거한다.
+     *
+     * @param availableMenuItemsMap 추천 후보 메뉴 map
+     * @param recommendations 회원의 과거 개인 추천 목록
+     */
+    private void excludeRecentlySelectedMenus(
+            Map<Long, MenuItem> availableMenuItemsMap,
+            List<PersonalRecommendation> recommendations
+    ) {
+        recommendations.stream()
+                .map(PersonalRecommendation::getSelectedMenu)
+                .limit(RECENT_SELECTED_MENU_EXCLUSION_COUNT)
+                .forEach(menuItem -> availableMenuItemsMap.remove(menuItem.getId()));
+    }
+
+    /**
+     * 후보 메뉴별로 회원이 명시적으로 선호한 attribute category와 일치하는 개수를 반영한다.
+     *
+     * @param menuItemScoreBoardMap 후보 메뉴별 점수판 map
+     * @param preferAttributeCategories 회원이 선호한 attribute category 목록
+     */
+    private void addCategoryMatchingCounts(
+            Map<Long, MenuItemScoreBoard> menuItemScoreBoardMap,
+            List<AttributeCategory> preferAttributeCategories
+    ) {
+        menuItemScoreBoardMap.values()
+                .forEach(menuItemScoreBoard -> {
+                    MenuItem menuItem = menuItemScoreBoard.getMenuItem();
+                    long matchingCount = menuItem.countMatchingCategories(preferAttributeCategories);
+
+                    menuItemScoreBoard.addCategoryMatchingCount(matchingCount);
+                });
+    }
+
+    /**
+     * 과거 선택 메뉴에서 자주 등장한 attribute category 빈도를 후보 메뉴 점수판에 반영한다.
+     *
+     * @param menuItemScoreBoardMap 후보 메뉴별 점수판 map
+     * @param categoryFrequencyMap 과거 선택 메뉴의 attribute category 빈도 map
+     */
+    private void addHistoryWeightCounts(
+            Map<Long, MenuItemScoreBoard> menuItemScoreBoardMap,
+            Map<AttributeCategory, Long> categoryFrequencyMap
+    ) {
+        menuItemScoreBoardMap.values()
+                .forEach(menuItemScoreBoard -> menuItemScoreBoard.setWeightMatchingCount(categoryFrequencyMap));
+    }
+
+    /**
+     * 최종 추천 후보를 개인 추천 엔티티에 연결해 저장한다.
+     *
+     * @param savedPersonalRecommendation 저장된 개인 추천 엔티티
+     * @param finalizeMenuItems 점수 계산이 끝난 최종 후보 목록
+     */
+    private void saveRecommendationCandidates(
+            PersonalRecommendation savedPersonalRecommendation,
+            List<MenuItemScoreBoard> finalizeMenuItems
+    ) {
         List<PersonalRecommendationCandidate> personalRecommendationCandidates = IntStream.range(0,
                         finalizeMenuItems.size())
                 .mapToObj(i -> {
@@ -143,12 +170,16 @@ public class RecommendationServiceImpl implements RecommendationService {
                 })
                 .toList();
 
-        List<PersonalRecommendationCandidate> savedPersonalRecommendationCandidates =
-                personalRecommendationCandidateRepository.saveAll(personalRecommendationCandidates);
-
+        personalRecommendationCandidateRepository.saveAll(personalRecommendationCandidates);
     }
 
-    public List<MenuItem> findMenuItemsExceptByMenuItems(List<MenuItem> menuItems) {
+    /**
+     * 지정한 비선호 메뉴를 제외한 메뉴 목록을 조회한다.
+     *
+     * @param menuItems 제외할 메뉴 목록
+     * @return 비선호 메뉴가 제외된 메뉴 목록
+     */
+    private List<MenuItem> findMenuItemsExceptByMenuItems(List<MenuItem> menuItems) {
         List<Long> ids = menuItems.stream()
                 .map(MenuItem::getId)
                 .toList();
@@ -160,7 +191,13 @@ public class RecommendationServiceImpl implements RecommendationService {
         return menuItemRepository.findAllByIdNotIn(ids);
     }
 
-    public List<MenuItem> findMenuItemsExceptByIngredients(List<Ingredient> ingredients) {
+    /**
+     * 지정한 제한 식재료를 제외한 메뉴 목록을 조회한다.
+     *
+     * @param ingredients 제외할 제한 식재료 목록
+     * @return 제한 식재료가 제외된 메뉴 목록
+     */
+    private List<MenuItem> findMenuItemsExceptByIngredients(List<Ingredient> ingredients) {
         List<Long> ids = ingredients.stream()
                 .map(Ingredient::getId)
                 .toList();
@@ -172,7 +209,31 @@ public class RecommendationServiceImpl implements RecommendationService {
                 .toList();
     }
 
-    public Map<AttributeCategory, Long> countCategoryFrequency(
+    /**
+     * 과거 개인 추천에서 선택된 메뉴들의 attribute category 빈도를 계산한다.
+     *
+     * @param recommendations 회원의 과거 개인 추천 목록
+     * @return 선택 이력 기반 attribute category 빈도 map
+     */
+    private Map<AttributeCategory, Long> countSelectedCategoryFrequency(
+            List<PersonalRecommendation> recommendations
+    ) {
+        List<List<AttributeCategory>> selectedMenuCategoryGroups = new ArrayList<>();
+
+        recommendations.stream()
+                .map(PersonalRecommendation::getSelectedMenuAttributeCategory)
+                .forEach(selectedMenuCategoryGroups::add);
+
+        return countCategoryFrequency(selectedMenuCategoryGroups);
+    }
+
+    /**
+     * attribute category 목록들을 하나로 펼쳐 category별 등장 횟수를 계산한다.
+     *
+     * @param categoryLists attribute category 목록들의 그룹
+     * @return attribute category별 등장 횟수 map
+     */
+    private Map<AttributeCategory, Long> countCategoryFrequency(
             List<List<AttributeCategory>> categoryLists
     ) {
         Map<Long, AttributeCategory> categoryById = new LinkedHashMap<>();

--- a/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
@@ -1,19 +1,197 @@
 package matchuri.backend.domain.recommendation.service;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.entity.MemberTasteProfile;
+import matchuri.backend.domain.member.repository.MemberTasteProfileCategoryRepository;
+import matchuri.backend.domain.member.repository.MemberTasteProfileDislikedMenuItemRepository;
+import matchuri.backend.domain.member.repository.MemberTasteProfileRepository;
+import matchuri.backend.domain.member.repository.MemberTasteProfileRestrictionIngredientRepository;
+import matchuri.backend.domain.member.support.member.ActiveMemberReader;
+import matchuri.backend.domain.menu.entity.AttributeCategory;
+import matchuri.backend.domain.menu.entity.Ingredient;
+import matchuri.backend.domain.menu.entity.MenuIngredient;
+import matchuri.backend.domain.menu.entity.MenuItem;
+import matchuri.backend.domain.menu.repository.MenuIngredientRepository;
+import matchuri.backend.domain.menu.repository.MenuItemRepository;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCandidate;
+import matchuri.backend.domain.recommendation.repository.PersonalRecommendationCandidateRepository;
+import matchuri.backend.domain.recommendation.repository.PersonalRecommendationRepository;
+import matchuri.backend.domain.recommendation.support.MenuItemScoreBoard;
+import matchuri.backend.domain.recommendation.support.ScoreCalculator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class RecommendationServiceImpl implements RecommendationService {
 
+    private final MemberTasteProfileRepository memberTasteProfileRepository;
+    private final MemberTasteProfileCategoryRepository memberTasteProfileCategoryRepository;
+    private final MemberTasteProfileRestrictionIngredientRepository memberTasteProfileRestrictionIngredientRepository;
+    private final MemberTasteProfileDislikedMenuItemRepository memberTasteProfileDislikedMenuItemRepository;
+    private final ActiveMemberReader activeMemberReader;
+    private final PersonalRecommendationRepository personalRecommendationRepository;
+    private final MenuItemRepository menuItemRepository;
+    private final MenuIngredientRepository menuIngredientRepository;
+    private final PersonalRecommendationCandidateRepository personalRecommendationCandidateRepository;
+
+
     @Override
-    public void getPersonalRecommendation() {
+    public void getPersonalRecommendation(String contextJson) {
         // 취향 프로필, 지난 내역 불러오기
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        MemberTasteProfile tasteProfile = member.getTasteProfile();
+
         // 알레르기 식품과 비선호 식품은 완전히 배제
+        // 알레르기 식재료
+        List<Ingredient> restrictionIngredients = tasteProfile.getRestrictionIngredients();
+        List<MenuItem> menuItemExceptByIngredients = findMenuItemsExceptByIngredients(restrictionIngredients);
+
+        // 비선호 음식
+        List<MenuItem> disLikeMenuItems = tasteProfile.getDisLikeMenuItems();
+        List<MenuItem> menuItemsExceptByMenuItems = findMenuItemsExceptByMenuItems(disLikeMenuItems);
+
+        // 추천 가능한 메뉴 (1차 필터링)
+        Set<Long> menuItemIdsExceptByMenuItems = menuItemsExceptByMenuItems.stream()
+                .map(MenuItem::getId)
+                .collect(Collectors.toSet());
+
+        Map<Long, MenuItem> availableMenuItemsMap = menuItemExceptByIngredients.stream()
+                .filter(menuItem -> menuItemIdsExceptByMenuItems.contains(menuItem.getId()))
+                .collect(Collectors.toMap(MenuItem::getId, menuItem -> menuItem));
+
+        // 이전 요청 목록
+        List<PersonalRecommendation> recommendations = personalRecommendationRepository.findByMemberId(member.getId());
+        // 이전 요청 목록에서 선택했던 메뉴
+        List<MenuItem> selectedMenuItems = recommendations.stream()
+                .map(PersonalRecommendation::getSelectedMenu)
+                .toList();
+
+        // 최근에 선택했던 메뉴들을 제외 (2차 필터링)
+        int n = 3;
+        List<MenuItem> latestSelectedMenus = selectedMenuItems.subList(0, Math.min(n, selectedMenuItems.size()));
+        latestSelectedMenus
+                .forEach(menuItem -> {
+                    availableMenuItemsMap.remove(menuItem.getId());
+                });
+
+        // 필터링을 마친 예비 후보들
+        Map<Long, MenuItemScoreBoard> menuItemScoreBoardMap = availableMenuItemsMap.values().stream()
+                .map(MenuItemScoreBoard::of)
+                .collect(Collectors.toMap(
+                        menuItemScoreBoard -> menuItemScoreBoard.getMenuItem().getId(),
+                        menuItemScoreBoard -> menuItemScoreBoard
+                ));
+
         // 선호 카테고리 종합
-        // 이전 추천 내역 확인 (다양한 메뉴를 추천하기 위해)
+        List<AttributeCategory> preferAttributeCategories = tasteProfile.getPreferAttributeCategories();
+
+        // score1: 필터링된 메뉴 리스트에서 선호 카테고리가 일치하는 갯수 넣기
+        menuItemScoreBoardMap.forEach((id, menuItemScoreBoard) -> {
+            MenuItem menuItem = menuItemScoreBoard.getMenuItem();
+            long matchingCount = menuItem.countMatchingCategories(preferAttributeCategories);
+
+            menuItemScoreBoard.addCategoryMatchingCount(matchingCount);
+        });
+
+        // 이전에 선택했던 메뉴들의 카테고리를 종합하여 가중치 부여
+        List<List<AttributeCategory>> selectedMenuCategoryGroups = new ArrayList<>();
+
+        recommendations.stream()
+                .map(PersonalRecommendation::getSelectedMenuAttributeCategory)
+                .forEach(selectedMenuCategoryGroups::add);
+
+        // score2: 이전에 선택했던 메뉴들의 카테고리 빈도 수
+        Map<AttributeCategory, Long> categoryFrequencyMap = countCategoryFrequency(selectedMenuCategoryGroups);
+
+        menuItemScoreBoardMap.forEach((id, menuItemScoreBoard) -> {
+            menuItemScoreBoard.setWeightMatchingCount(categoryFrequencyMap);
+        });
+
+        // 계산 후 최종 MenuItems
+        ScoreCalculator scoreCalculator = ScoreCalculator.of(preferAttributeCategories, categoryFrequencyMap);
+        List<MenuItemScoreBoard> finalizeMenuItems = scoreCalculator.calculate(menuItemScoreBoardMap);
+
+        // 요청 엔티티, 후보 엔티티 생성
+        PersonalRecommendation personalRecommendation = PersonalRecommendation.of(member, contextJson);
+        PersonalRecommendation savedPersonalRecommendation =
+                personalRecommendationRepository.save(personalRecommendation);
+
+        List<PersonalRecommendationCandidate> personalRecommendationCandidates = IntStream.range(0,
+                        finalizeMenuItems.size())
+                .mapToObj(i -> {
+                    MenuItemScoreBoard board = finalizeMenuItems.get(i);
+
+                    return PersonalRecommendationCandidate.of(
+                            savedPersonalRecommendation,
+                            board.getMenuItem(),
+                            i,
+                            board.getTotalScore()
+                    );
+                })
+                .toList();
+
+        List<PersonalRecommendationCandidate> savedPersonalRecommendationCandidates =
+                personalRecommendationCandidateRepository.saveAll(personalRecommendationCandidates);
+
+    }
+
+    public List<MenuItem> findMenuItemsExceptByMenuItems(List<MenuItem> menuItems) {
+        List<Long> ids = menuItems.stream()
+                .map(MenuItem::getId)
+                .toList();
+
+        if (ids.isEmpty()) {
+            return menuItemRepository.findAll();
+        }
+
+        return menuItemRepository.findAllByIdNotIn(ids);
+    }
+
+    public List<MenuItem> findMenuItemsExceptByIngredients(List<Ingredient> ingredients) {
+        List<Long> ids = ingredients.stream()
+                .map(Ingredient::getId)
+                .toList();
+
+        List<MenuIngredient> allByIngredientIdNotIn = menuIngredientRepository.findAllByIngredientIdNotIn(ids);
+
+        return allByIngredientIdNotIn.stream()
+                .map(MenuIngredient::getMenu)
+                .toList();
+    }
+
+    public Map<AttributeCategory, Long> countCategoryFrequency(
+            List<List<AttributeCategory>> categoryLists
+    ) {
+        Map<Long, AttributeCategory> categoryById = new LinkedHashMap<>();
+        Map<Long, Long> countById = new LinkedHashMap<>();
+
+        categoryLists.stream()
+                .flatMap(List::stream)
+                .forEach(category -> {
+                    Long id = category.getId();
+                    categoryById.putIfAbsent(id, category);
+                    countById.merge(id, 1L, Long::sum);
+                });
+
+        return countById.entrySet().stream()
+                .collect(Collectors.toMap(
+                        entry -> categoryById.get(entry.getKey()),
+                        Map.Entry::getValue,
+                        (a, b) -> a,
+                        LinkedHashMap::new
+                ));
     }
 }

--- a/src/main/java/matchuri/backend/domain/recommendation/support/MenuItemScoreBoard.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/support/MenuItemScoreBoard.java
@@ -1,0 +1,42 @@
+package matchuri.backend.domain.recommendation.support;
+
+import java.util.List;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import matchuri.backend.domain.menu.entity.AttributeCategory;
+import matchuri.backend.domain.menu.entity.MenuAttributeCategory;
+import matchuri.backend.domain.menu.entity.MenuItem;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MenuItemScoreBoard {
+    private MenuItem menuItem;
+    private long categoryMatchingCount;
+    private long weightMatchingCount;
+    @Setter
+    private double totalScore;
+
+    public static MenuItemScoreBoard of(MenuItem menuItem) {
+        return new MenuItemScoreBoard(menuItem, 0, 0, 0);
+    }
+
+    public void addCategoryMatchingCount(long count) {
+        categoryMatchingCount += count;
+    }
+
+    public void setWeightMatchingCount(Map<AttributeCategory, Long> categoryFrequencyMap) {
+        List<AttributeCategory> categories = menuItem.getMenuAttributeCategories().stream()
+                .map(MenuAttributeCategory::getAttributeCategory)
+                .toList();
+
+        long weightMatchingCount = categories.stream()
+                .mapToLong(category -> categoryFrequencyMap.getOrDefault(category, 0L))
+                .sum();
+    }
+
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/support/MenuItemScoreBoard.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/support/MenuItemScoreBoard.java
@@ -34,7 +34,7 @@ public class MenuItemScoreBoard {
                 .map(MenuAttributeCategory::getAttributeCategory)
                 .toList();
 
-        long weightMatchingCount = categories.stream()
+        this.weightMatchingCount = categories.stream()
                 .mapToLong(category -> categoryFrequencyMap.getOrDefault(category, 0L))
                 .sum();
     }

--- a/src/main/java/matchuri/backend/domain/recommendation/support/MenuItemScoreBoard.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/support/MenuItemScoreBoard.java
@@ -21,14 +21,30 @@ public class MenuItemScoreBoard {
     @Setter
     private double totalScore;
 
+    /**
+     * 메뉴별 추천 점수판을 초기 점수 상태로 생성한다.
+     *
+     * @param menuItem 점수를 계산할 메뉴
+     * @return 초기화된 메뉴 점수판
+     */
     public static MenuItemScoreBoard of(MenuItem menuItem) {
         return new MenuItemScoreBoard(menuItem, 0, 0, 0);
     }
 
+    /**
+     * 회원 선호 attribute category와 일치한 개수를 누적한다.
+     *
+     * @param count 추가할 일치 개수
+     */
     public void addCategoryMatchingCount(long count) {
         categoryMatchingCount += count;
     }
 
+    /**
+     * 메뉴의 attribute category가 과거 선택 이력에서 등장한 빈도 합계를 반영한다.
+     *
+     * @param categoryFrequencyMap 과거 선택 메뉴의 attribute category 빈도 map
+     */
     public void setWeightMatchingCount(Map<AttributeCategory, Long> categoryFrequencyMap) {
         List<AttributeCategory> categories = menuItem.getMenuAttributeCategories().stream()
                 .map(MenuAttributeCategory::getAttributeCategory)

--- a/src/main/java/matchuri/backend/domain/recommendation/support/ScoreCalculator.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/support/ScoreCalculator.java
@@ -1,0 +1,53 @@
+package matchuri.backend.domain.recommendation.support;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import matchuri.backend.domain.menu.entity.AttributeCategory;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ScoreCalculator {
+    public double categoryMatchingCountRate;
+    public double weightMatchingCountRate;
+
+    public static ScoreCalculator of(List<AttributeCategory> preferAttributeCategories,
+                                     Map<AttributeCategory, Long> categoryFrequencyMap) {
+
+        int fieldCount = ScoreCalculator.class.getDeclaredFields().length;
+        double rawFieldRate = 100.0 / fieldCount;
+        double fieldRate = Math.round(rawFieldRate * 100) / 100.0;
+
+        int size = preferAttributeCategories.size();
+        double categoryMatchingCountRate = fieldRate / size;
+
+        Collection<Long> values = categoryFrequencyMap.values();
+        long maxFrequency = Collections.max(values);
+        double weightMatchingCountRate = fieldRate / maxFrequency;
+
+        return new ScoreCalculator(categoryMatchingCountRate, weightMatchingCountRate);
+    }
+
+    public List<MenuItemScoreBoard> calculate(Map<Long, MenuItemScoreBoard> menuItemScoreBoardMap) {
+        menuItemScoreBoardMap.values()
+                .forEach(menuItemScoreBoard -> {
+                    double categoryMatchingScore =
+                            menuItemScoreBoard.getCategoryMatchingCount() * this.categoryMatchingCountRate;
+
+                    double weightMatchingScore =
+                            menuItemScoreBoard.getWeightMatchingCount() * this.weightMatchingCountRate;
+
+                    double rawTotalScore = categoryMatchingScore + weightMatchingScore;
+                    menuItemScoreBoard.setTotalScore(rawTotalScore);
+                });
+
+        return menuItemScoreBoardMap.values().stream()
+                .sorted(Comparator.comparing(MenuItemScoreBoard::getTotalScore).reversed())
+                .limit(3)
+                .toList();
+    }
+
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/support/ScoreCalculator.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/support/ScoreCalculator.java
@@ -32,11 +32,11 @@ public class ScoreCalculator {
         double fieldRate = Math.round(rawFieldRate * 100) / 100.0;
 
         int size = preferAttributeCategories.size();
-        double categoryMatchingCountRate = fieldRate / size;
+        double categoryMatchingCountRate = size == 0 ? 0 : fieldRate / size;
 
         Collection<Long> values = categoryFrequencyMap.values();
-        long maxFrequency = Collections.max(values);
-        double weightMatchingCountRate = fieldRate / maxFrequency;
+        long maxFrequency = values.isEmpty() ? 0 : Collections.max(values);
+        double weightMatchingCountRate = maxFrequency == 0 ? 0 : fieldRate / maxFrequency;
 
         return new ScoreCalculator(categoryMatchingCountRate, weightMatchingCountRate);
     }

--- a/src/main/java/matchuri/backend/domain/recommendation/support/ScoreCalculator.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/support/ScoreCalculator.java
@@ -18,6 +18,13 @@ public class ScoreCalculator {
     private final double categoryMatchingCountRate;
     private final double weightMatchingCountRate;
 
+    /**
+     * 선호 카테고리 수와 과거 선택 카테고리 최대 빈도를 기준으로 점수 계산기를 생성한다.
+     *
+     * @param preferAttributeCategories 회원이 선호한 attribute category 목록
+     * @param categoryFrequencyMap 과거 선택 메뉴의 attribute category 빈도 map
+     * @return 점수 항목별 비율이 계산된 점수 계산기
+     */
     public static ScoreCalculator of(List<AttributeCategory> preferAttributeCategories,
                                      Map<AttributeCategory, Long> categoryFrequencyMap) {
 
@@ -34,6 +41,12 @@ public class ScoreCalculator {
         return new ScoreCalculator(categoryMatchingCountRate, weightMatchingCountRate);
     }
 
+    /**
+     * 후보 메뉴 점수판에 최종 점수를 반영하고 상위 개인 추천 후보를 반환한다.
+     *
+     * @param menuItemScoreBoardMap 후보 메뉴별 점수판 map
+     * @return 최종 점수 기준 상위 추천 후보 목록
+     */
     public List<MenuItemScoreBoard> calculate(Map<Long, MenuItemScoreBoard> menuItemScoreBoardMap) {
         menuItemScoreBoardMap.values()
                 .forEach(menuItemScoreBoard -> {

--- a/src/main/java/matchuri/backend/domain/recommendation/support/ScoreCalculator.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/support/ScoreCalculator.java
@@ -11,14 +11,17 @@ import matchuri.backend.domain.menu.entity.AttributeCategory;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ScoreCalculator {
-    public double categoryMatchingCountRate;
-    public double weightMatchingCountRate;
+
+    private static final int SCORE_FACTOR_COUNT = 2;
+    private static final int RECOMMENDATION_CANDIDATE_LIMIT = 3;
+
+    private final double categoryMatchingCountRate;
+    private final double weightMatchingCountRate;
 
     public static ScoreCalculator of(List<AttributeCategory> preferAttributeCategories,
                                      Map<AttributeCategory, Long> categoryFrequencyMap) {
 
-        int fieldCount = ScoreCalculator.class.getDeclaredFields().length;
-        double rawFieldRate = 100.0 / fieldCount;
+        double rawFieldRate = 100.0 / SCORE_FACTOR_COUNT;
         double fieldRate = Math.round(rawFieldRate * 100) / 100.0;
 
         int size = preferAttributeCategories.size();
@@ -46,7 +49,7 @@ public class ScoreCalculator {
 
         return menuItemScoreBoardMap.values().stream()
                 .sorted(Comparator.comparing(MenuItemScoreBoard::getTotalScore).reversed())
-                .limit(3)
+                .limit(RECOMMENDATION_CANDIDATE_LIMIT)
                 .toList();
     }
 

--- a/src/main/java/matchuri/backend/global/api/PageInfo.java
+++ b/src/main/java/matchuri/backend/global/api/PageInfo.java
@@ -43,4 +43,17 @@ public class PageInfo {
                 false
         );
     }
+
+    public static PageInfo ofList(int size) {
+        return new PageInfo(
+                0,
+                size,
+                size,
+                size == 0 ? 0 : 1,
+                true,
+                true,
+                false,
+                false
+        );
+    }
 }

--- a/src/main/java/matchuri/backend/global/api/PageResponse.java
+++ b/src/main/java/matchuri/backend/global/api/PageResponse.java
@@ -29,6 +29,10 @@ public class PageResponse<T> {
         return new PageResponse<>(list, PageInfo.mock());
     }
 
+    public static <T> PageResponse<T> mock(List<T> list, int page, int size, long totalElements) {
+        return new PageResponse<>(list, PageInfo.mock(page, size, totalElements));
+    }
+
     public static <T> PageResponse<T> ofList(List<T> list) {
         return new PageResponse<>(list, PageInfo.ofList(list.size()));
     }

--- a/src/main/java/matchuri/backend/global/api/PageResponse.java
+++ b/src/main/java/matchuri/backend/global/api/PageResponse.java
@@ -28,4 +28,8 @@ public class PageResponse<T> {
     public static <T> PageResponse<T> mock(List<T> list) {
         return new PageResponse<>(list, PageInfo.mock());
     }
+
+    public static <T> PageResponse<T> ofList(List<T> list) {
+        return new PageResponse<>(list, PageInfo.ofList(list.size()));
+    }
 }

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -269,22 +269,22 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/groups/{groupId}/leave'].post.responses['200'].content['application/json'].examples.success.value.data.memberStatus")
                         .value("LEFT"))
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/groups/{groupId}/recommendation-sessions'].post.responses['200'].content['application/json'].examples.success.value.data.candidates[0].candidateId")
+                        "$.paths['/api/v1/groups/{groupId}/recommendations'].post.responses['200'].content['application/json'].examples.success.value.data.candidates[0].candidateId")
                         .value(8001))
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/groups/{groupId}/recommendation-sessions/{sessionId}'].get.responses['200'].content['application/json'].examples.success.value.data.finalCandidate")
+                        "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}'].get.responses['200'].content['application/json'].examples.success.value.data.finalCandidate")
                         .value((Object) null))
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/groups/{groupId}/recommendation-sessions/{sessionId}'].get.responses['200'].content['application/json'].examples.success.value.data.resultJson")
+                        "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}'].get.responses['200'].content['application/json'].examples.success.value.data.resultJson")
                         .doesNotExist())
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/groups/{groupId}/recommendation-sessions/{sessionId}/candidates'].get.responses['200'].content['application/json'].examples.success.value.data.candidates[1].menuName")
+                        "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/candidates'].get.responses['200'].content['application/json'].examples.success.value.data.candidates[1].menuName")
                         .value("돈까스"))
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/groups/{groupId}/recommendation-sessions/{sessionId}/votes'].post.responses['200'].content['application/json'].examples.success.value.data.voteValue")
+                        "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/votes'].post.responses['200'].content['application/json'].examples.success.value.data.voteValue")
                         .value(1))
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/groups/{groupId}/recommendation-sessions/{sessionId}/finalize'].patch.responses['200'].content['application/json'].examples.success.value.data.finalCandidate.menuName")
+                        "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/finalize'].patch.responses['200'].content['application/json'].examples.success.value.data.finalCandidate.menuName")
                         .value("비빔밥"));
     }
 

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -216,35 +216,35 @@ class OpenApiDocumentationIntegrationTest {
     }
 
     @Test
-    @DisplayName("OpenAPI 문서에 Mock API 표시와 200 응답 예시가 노출된다")
+    @DisplayName("OpenAPI 문서에 추천/그룹 API 표시와 200 응답 예시가 노출된다")
     void exposesMockApiMetadataAndSuccessExamplesInOpenApi() throws Exception {
         mockMvc.perform(get("/docs/openapi"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith("application/json"))
-                .andExpect(jsonPath("$.paths['/api/v1/personal-recommendations'].get.summary")
-                        .value("내 개인 추천 이력 목록 조회 (Mock API)"))
+                .andExpect(jsonPath("$.paths['/api/v1/personal/recommendations'].get.summary")
+                        .value("내 개인 추천 이력 목록 조회"))
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/personal-recommendations'].get.responses['200'].content['application/json'].examples.success.value.data.content[0].id")
+                        "$.paths['/api/v1/personal/recommendations'].get.responses['200'].content['application/json'].examples.success.value.data.content[0].id")
                         .value(9001))
-                .andExpect(jsonPath("$.paths['/api/v1/personal-recommendation-requests'].post.summary")
-                        .value("개인 추천 요청 생성 (Mock API)"))
+                .andExpect(jsonPath("$.paths['/api/v1/personal/recommendations'].post.summary")
+                        .value("개인 추천 요청 생성"))
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/personal-recommendation-requests'].post.responses['200'].content['application/json'].examples.success.value.data.candidates[0].menuName")
+                        "$.paths['/api/v1/personal/recommendations'].post.responses['200'].content['application/json'].examples.success.value.data.candidates[0].menuName")
                         .value("비빔밥"))
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/personal-recommendation-requests'].post.responses['200'].content['application/json'].examples.success.value.data.resultJson")
+                        "$.paths['/api/v1/personal/recommendations'].post.responses['200'].content['application/json'].examples.success.value.data.resultJson")
                         .doesNotExist())
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/personal-recommendation-requests/{requestId}'].get.responses['200'].content['application/json'].examples.success.value.data.contextJson.mealTime")
+                        "$.paths['/api/v1/personal/recommendations/{requestId}'].get.responses['200'].content['application/json'].examples.success.value.data.contextJson.mealTime")
                         .value("LUNCH"))
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/personal-recommendation-requests/{requestId}'].get.responses['200'].content['application/json'].examples.success.value.data.resultJson")
+                        "$.paths['/api/v1/personal/recommendations/{requestId}'].get.responses['200'].content['application/json'].examples.success.value.data.resultJson")
                         .doesNotExist())
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/personal-recommendation-requests/{requestId}/candidates'].get.responses['200'].content['application/json'].examples.success.value.data.candidates[2].menuName")
+                        "$.paths['/api/v1/personal/recommendations/{requestId}/candidates'].get.responses['200'].content['application/json'].examples.success.value.data.candidates[2].menuName")
                         .value("쌀국수"))
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/personal-recommendation-requests/{requestId}'].patch.responses['200'].content['application/json'].examples.success.value.data.selectedCandidateId")
+                        "$.paths['/api/v1/personal/recommendations/{requestId}'].patch.responses['200'].content['application/json'].examples.success.value.data.selectedCandidateId")
                         .value(10001))
                 .andExpect(jsonPath("$.paths['/api/v1/groups'].post.summary")
                         .value("그룹 생성 (Mock API)"))


### PR DESCRIPTION
## 관련 이슈
Closes #145

## 📝 작업 내용
- 개인 추천 생성/목록/상세/후보 조회/후보 선택 API를 mock 응답에서 실제 `RecommendationService` 호출로 전환했습니다.
- 회원 취향 프로필의 `attribute category`, `restriction ingredient`, `disliked menu item`과 최근 선택 이력을 반영하는 MVP 개인 추천 알고리즘을 구현했습니다.
- 추천 후보 점수 계산용 `MenuItemScoreBoard`, `ScoreCalculator`와 개인 추천 result/mapper 계층을 추가했습니다.
- 추천 후보 선택 시 `PersonalRecommendation.selectedCandidate`를 저장하고 `member_menu_actions`에 `CHOOSE` 로그를 남기도록 연결했습니다.
- 개인 추천 관련 repository, error code, OpenAPI 문서 테스트를 추가/갱신했습니다.

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
  - 개인 추천 API 경로가 `/api/v1/personal/recommendations` 기준으로 정리된 점
  - 추천 후보 필터링/점수 계산 로직과 최근 선택 메뉴 제외 흐름
  - 후보 선택 시 개인 추천 상태 변경과 `CHOOSE` 행동 로그 저장이 한 트랜잭션에서 처리되는 점
- 알려진 제한 사항:
  - 개인 추천 목록은 현재 전체 목록을 단일 페이지 형태로 반환하며, 본격적인 `page/size` 페이지네이션은 후속 작업으로 둡니다.
  - `mealTime` 등 추천 컨텍스트는 저장/응답만 하고 점수 계산에는 강하게 반영하지 않습니다.
  - 후보별 추천 사유/`candidateMetaJson` 생성은 MVP 이후로 남겨두었습니다.
