### PR TITLE
[Feat] 카카오 소셜 로그인 연동

### DIFF
--- a/src/main/java/matchuri/backend/api/auth/AuthApi.java
+++ b/src/main/java/matchuri/backend/api/auth/AuthApi.java
@@ -19,7 +19,7 @@ import matchuri.backend.api.auth.dto.response.LogoutResponse;
 import matchuri.backend.api.common.docs.ErrorExamples;
 import matchuri.backend.global.api.ApiResponse;
 
-@Tag(name = "Auth", description = "로그인, 로그아웃, Google OAuth2 로그인 관련 API")
+@Tag(name = "Auth", description = "로그인, 로그아웃, 소셜 OAuth2 로그인 관련 API")
 public interface AuthApi {
 
     @Operation(
@@ -234,12 +234,13 @@ public interface AuthApi {
     ApiResponse<LogoutResponse> logout(HttpServletRequest httpRequest, HttpServletResponse httpResponse);
 
     @Operation(
-            summary = "Google OAuth2 로그인 시작",
+            summary = "소셜 OAuth2 로그인 시작",
             description = """
-                    Google 로그인 화면으로 리다이렉트합니다.
+                    요청한 provider의 로그인 화면으로 리다이렉트합니다.
                     
                     - 일반 JSON API가 아니라 `302 Redirect` 응답입니다.
                     - 브라우저 이동 또는 팝업/리다이렉트 흐름에서 사용합니다.
+                    - 현재 지원 provider는 `google`, `kakao`입니다.
                     - 로그인 성공 후 프론트는 최종적으로 `code`를 전달받고, 별도 교환 API를 호출해 `accessToken`을 받습니다.
                     """
     )
@@ -247,18 +248,19 @@ public interface AuthApi {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "302",
-                    description = "Google 인증 페이지로 리다이렉트"
+                    description = "소셜 provider 인증 페이지로 리다이렉트"
             )
     })
-    void startGoogleOAuth2Login(HttpServletResponse response) throws IOException;
+    void startOAuth2Login(String provider, HttpServletResponse response) throws IOException;
 
     @Operation(
-            summary = "Google OAuth2 교환 코드 -> Access Token 교환",
+            summary = "소셜 OAuth2 교환 코드 -> Access Token 교환",
             description = """
-                    Google OAuth2 로그인 성공 후 프론트가 받은 단기 교환 코드를 Matchuri `accessToken`으로 교환합니다.
+                    OAuth2 로그인 성공 후 프론트가 받은 단기 교환 코드를 Matchuri `accessToken`으로 교환합니다.
                     
                     - 성공 시 응답 body에는 `accessToken`과 회원 요약 정보가 포함됩니다.
                     - `refreshToken`은 이미 OAuth2 성공 리다이렉트 단계에서 `HttpOnly` 쿠키로 처리되므로 body에는 포함되지 않습니다.
+                    - 현재 지원 provider는 `GOOGLE`, `KAKAO`입니다.
                     - 같은 교환 코드는 한 번만 사용할 수 있습니다.
                     - 만료되었거나 이미 사용한 코드는 `AUTH_OAUTH2_EXCHANGE_CODE_INVALID`를 반환합니다.
                     """

--- a/src/main/java/matchuri/backend/api/auth/AuthController.java
+++ b/src/main/java/matchuri/backend/api/auth/AuthController.java
@@ -13,10 +13,12 @@ import matchuri.backend.api.member.mapper.MemberMapper;
 import matchuri.backend.domain.auth.exception.AuthErrorCode;
 import matchuri.backend.domain.auth.service.AuthService;
 import matchuri.backend.domain.auth.support.token.RefreshTokenCookieService;
+import matchuri.backend.domain.member.entity.SocialProviderType;
 import matchuri.backend.global.api.ApiResponse;
 import matchuri.backend.global.exception.AuthenticationException;
 import matchuri.backend.global.exception.BusinessException;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -79,9 +81,14 @@ public class AuthController implements AuthApi {
     }
 
     @Override
-    @GetMapping("/oauth2/google")
-    public void startGoogleOAuth2Login(HttpServletResponse response) throws IOException {
-        response.sendRedirect("/oauth2/authorization/google");
+    @GetMapping("/oauth2/{provider}")
+    public void startOAuth2Login(@PathVariable String provider, HttpServletResponse response) throws IOException {
+        SocialProviderType socialProviderType = SocialProviderType.fromRegistrationId(provider);
+        if (!socialProviderType.isOAuth2LoginSupported()) {
+            throw new AuthenticationException(AuthErrorCode.OAUTH2_PROVIDER_NOT_SUPPORTED);
+        }
+
+        response.sendRedirect("/oauth2/authorization/" + socialProviderType.toRegistrationId());
     }
 
     @Override

--- a/src/main/java/matchuri/backend/api/auth/dto/request/OAuth2ExchangeRequest.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/request/OAuth2ExchangeRequest.java
@@ -7,8 +7,8 @@ import matchuri.backend.domain.member.entity.SocialProviderType;
 
 public record OAuth2ExchangeRequest(
         @Schema(
-                description = "교환 코드가 속한 소셜 로그인 제공자입니다. 현재 단계에서는 GOOGLE만 지원합니다.",
-                example = "GOOGLE"
+                description = "교환 코드가 속한 소셜 로그인 제공자입니다. 현재 지원 값은 GOOGLE, KAKAO입니다.",
+                example = "KAKAO"
         )
         @NotNull(message = "provider는 비어 있을 수 없습니다.")
         SocialProviderType provider,

--- a/src/main/java/matchuri/backend/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/AuthServiceImpl.java
@@ -82,7 +82,7 @@ public class AuthServiceImpl implements AuthService {
     @Override
     @Transactional
     public LoginPayload exchangeOAuth2Code(OAuth2ExchangeCommand command, String clientIp) {
-        if (command.provider() != SocialProviderType.GOOGLE) {
+        if (!command.provider().isOAuth2LoginSupported()) {
             throw new AuthenticationException(AuthErrorCode.OAUTH2_PROVIDER_NOT_SUPPORTED);
         }
 

--- a/src/main/java/matchuri/backend/domain/auth/support/oauth2/KakaoOAuth2UserInfoResolver.java
+++ b/src/main/java/matchuri/backend/domain/auth/support/oauth2/KakaoOAuth2UserInfoResolver.java
@@ -1,0 +1,64 @@
+package matchuri.backend.domain.auth.support.oauth2;
+
+import java.util.Map;
+import matchuri.backend.domain.member.entity.SocialProviderType;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KakaoOAuth2UserInfoResolver implements OAuth2UserInfoResolver {
+
+    @Override
+    public boolean supports(SocialProviderType provider) {
+        return provider == SocialProviderType.KAKAO;
+    }
+
+    @Override
+    public OAuth2ProviderUserInfo resolve(OAuth2User oauth2User) {
+        Map<?, ?> kakaoAccount = asMap(oauth2User.getAttribute("kakao_account"));
+        Map<?, ?> properties = asMap(oauth2User.getAttribute("properties"));
+        Map<?, ?> profile = asMap(kakaoAccount.get("profile"));
+
+        return new OAuth2ProviderUserInfo(
+                SocialProviderType.KAKAO,
+                stringValue(oauth2User.getAttribute("id")),
+                stringValue(kakaoAccount.get("email")),
+                firstPresent(
+                        stringValue(properties.get("nickname")),
+                        stringValue(profile.get("nickname")),
+                        stringValue(kakaoAccount.get("name"))
+                )
+        );
+    }
+
+    private Map<?, ?> asMap(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            return map;
+        }
+
+        return Map.of();
+    }
+
+    private String stringValue(Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        String stringValue = String.valueOf(value);
+        if (stringValue.isBlank()) {
+            return null;
+        }
+
+        return stringValue;
+    }
+
+    private String firstPresent(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/matchuri/backend/domain/member/entity/SocialProviderType.java
+++ b/src/main/java/matchuri/backend/domain/member/entity/SocialProviderType.java
@@ -24,4 +24,8 @@ public enum SocialProviderType {
     public String toRegistrationId() {
         return name().toLowerCase(Locale.ROOT);
     }
+
+    public boolean isOAuth2LoginSupported() {
+        return this == GOOGLE || this == KAKAO;
+    }
 }

--- a/src/main/java/matchuri/backend/global/security/OAuth2RedirectService.java
+++ b/src/main/java/matchuri/backend/global/security/OAuth2RedirectService.java
@@ -17,6 +17,7 @@ public class OAuth2RedirectService {
         MatchuriProperties.OAuth2 oauth2 = matchuriProperties.getAuth().getOauth2();
         return UriComponentsBuilder.fromUriString(oauth2.getFrontendBaseUrl())
                 .path(oauth2.getSuccessPath())
+                .pathSegment(provider.toRegistrationId())
                 .queryParam("loginResult", "success")
                 .queryParam("provider", provider.toRegistrationId())
                 .queryParam("code", exchangeCode)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,6 +17,23 @@ spring:
               - openid
               - profile
               - email
+          kakao:
+            client-id: ${MATCHURI_KAKAO_CLIENT_ID:dummy-kakao-client-id}
+            client-secret: ${MATCHURI_KAKAO_CLIENT_SECRET:dummy-kakao-client-secret}
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            scope:
+              - profile_nickname
+              - profile_image_url
+              - account_email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
   mail:
     host: ${MATCHURI_MAIL_HOST:smtp.gmail.com}
     port: ${MATCHURI_MAIL_PORT:587}
@@ -56,7 +73,7 @@ matchuri:
       - /api/v1/restriction-ingredients
       - /api/v1/menu-items
       - /api/v1/menu-items/**
-      - /api/v1/auth/oauth2/google
+      - /api/v1/auth/oauth2/**
       - /oauth2/authorization/**
       - /login/oauth2/code/**
       - /docs/**
@@ -91,7 +108,7 @@ matchuri:
       max-age: 3600
     oauth2:
       frontend-base-url: ${MATCHURI_FRONTEND_ORIGIN:http://localhost:3000}
-      success-path: /auth/callback/google
+      success-path: /auth/callback
       failure-path: /login
       exchange-code-expiration-seconds: 300
     cookie:

--- a/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
@@ -874,6 +874,22 @@ class MemberAuthIntegrationTest {
     }
 
     @Test
+    @DisplayName("카카오 OAuth2 시작 요청은 Spring Security authorization 엔드포인트로 리다이렉트한다")
+    void startKakaoOAuth2LoginRedirects() throws Exception {
+        mockMvc.perform(get("/api/v1/auth/oauth2/kakao"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(header().string(HttpHeaders.LOCATION, "/oauth2/authorization/kakao"));
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 OAuth2 provider 시작 요청은 거절한다")
+    void startOAuth2LoginRejectsUnsupportedProvider() throws Exception {
+        mockMvc.perform(get("/api/v1/auth/oauth2/naver"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("AUTH_OAUTH2_PROVIDER_NOT_SUPPORTED"));
+    }
+
+    @Test
     @DisplayName("Spring Security OAuth2 authorization 엔드포인트는 서버 세션을 사용하고 대형 커스텀 쿠키를 만들지 않는다")
     void authorizationEndpointUsesServerSideSessionStorage() throws Exception {
         MvcResult result = mockMvc.perform(get("/oauth2/authorization/google"))
@@ -888,6 +904,19 @@ class MemberAuthIntegrationTest {
             assertThat(result.getResponse().getHeader(HttpHeaders.SET_COOKIE))
                     .doesNotContain("matchuri_oauth2_auth_request=");
         }
+    }
+
+    @Test
+    @DisplayName("카카오 Spring Security OAuth2 authorization 엔드포인트는 카카오 인증 서버로 리다이렉트한다")
+    void kakaoAuthorizationEndpointRedirectsToKakao() throws Exception {
+        MvcResult result = mockMvc.perform(get("/oauth2/authorization/kakao"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(header().string(HttpHeaders.LOCATION,
+                        org.hamcrest.Matchers.containsString("https://kauth.kakao.com/oauth/authorize")))
+                .andReturn();
+
+        assertThat(result.getRequest().getSession(false)).isNotNull();
+        assertThat(result.getResponse().getCookie("matchuri_oauth2_auth_request")).isNull();
     }
 
     @Test
@@ -929,6 +958,35 @@ class MemberAuthIntegrationTest {
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken)))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.error.code").value("MEMBER_AGREEMENT_REQUIRED"));
+    }
+
+    @Test
+    @DisplayName("유효한 카카오 소셜 교환 코드는 액세스 토큰으로 교환된다")
+    void exchangeKakaoOAuth2Code() throws Exception {
+        Member member = memberRepository.save(
+                Member.createSocialMember(SocialProviderType.KAKAO, "123456789", "kakao@example.com",
+                        "kakao_kakao"));
+        authExchangeCodeRepository.save(AuthExchangeCode.issue(
+                member,
+                SocialProviderType.KAKAO,
+                "valid-kakao-exchange-code",
+                LocalDateTime.now().plusMinutes(5)
+        ));
+
+        mockMvc.perform(post("/api/v1/auth/oauth2/exchange")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "provider": "KAKAO",
+                                  "code": "valid-kakao-exchange-code"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").isString())
+                .andExpect(jsonPath("$.data.refreshToken").value(nullValue()))
+                .andExpect(jsonPath("$.data.member.id").value(member.getId()))
+                .andExpect(jsonPath("$.data.member.nickname").value("kakao_kakao"))
+                .andExpect(jsonPath("$.data.onboarding.nextStep").value("REQUIRED_AGREEMENTS"));
     }
 
     @Test

--- a/src/test/java/matchuri/backend/domain/auth/service/OAuth2LoginServiceTest.java
+++ b/src/test/java/matchuri/backend/domain/auth/service/OAuth2LoginServiceTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import matchuri.backend.domain.auth.result.OAuth2LoginResult;
 import matchuri.backend.domain.auth.result.TokenPair;
 import matchuri.backend.domain.auth.support.oauth2.GoogleOAuth2UserInfoResolver;
+import matchuri.backend.domain.auth.support.oauth2.KakaoOAuth2UserInfoResolver;
 import matchuri.backend.domain.auth.support.oauth2.OAuth2MemberService;
 import matchuri.backend.domain.auth.support.token.SessionTokenService;
 import matchuri.backend.domain.member.entity.Member;
@@ -68,6 +69,47 @@ class OAuth2LoginServiceTest {
                 "google@example.com");
         verify(sessionTokenService).issueLoginTokenPair(member);
         verify(sessionTokenService).createExchangeCode(member, SocialProviderType.GOOGLE);
+        assertThat(result.refreshToken()).isEqualTo("refresh-token");
+        assertThat(result.exchangeCode()).isEqualTo("exchange-code");
+    }
+
+    @Test
+    @DisplayName("카카오 provider는 Kakao resolver로 사용자 정보를 정규화한다")
+    void loginResolvesKakaoProviderUserInfo() {
+        OAuth2User oauth2User = new DefaultOAuth2User(
+                List.of(),
+                java.util.Map.of(
+                        "id", 123456789L,
+                        "kakao_account", java.util.Map.of("email", "kakao@example.com")
+                ),
+                "id"
+        );
+        KakaoOAuth2UserInfoResolver resolver = new KakaoOAuth2UserInfoResolver();
+        OAuth2LoginService service = new OAuth2LoginService(
+                oAuth2MemberService,
+                sessionTokenService,
+                List.of(resolver)
+        );
+        Member member = Member.createSocialMember(SocialProviderType.KAKAO, "123456789", "kakao@example.com",
+                "kakao_kakao");
+        TokenPair tokenPair = new TokenPair(
+                "access-token",
+                3600L,
+                "refresh-token",
+                LocalDateTime.of(2026, 4, 9, 12, 0)
+        );
+
+        when(oAuth2MemberService.findOrCreateMember(SocialProviderType.KAKAO, "123456789", "kakao@example.com"))
+                .thenReturn(member);
+        when(sessionTokenService.issueLoginTokenPair(member)).thenReturn(tokenPair);
+        when(sessionTokenService.createExchangeCode(member, SocialProviderType.KAKAO)).thenReturn("exchange-code");
+
+        OAuth2LoginResult result = service.login(SocialProviderType.KAKAO, oauth2User, "127.0.0.1");
+
+        verify(oAuth2MemberService).findOrCreateMember(SocialProviderType.KAKAO, "123456789",
+                "kakao@example.com");
+        verify(sessionTokenService).issueLoginTokenPair(member);
+        verify(sessionTokenService).createExchangeCode(member, SocialProviderType.KAKAO);
         assertThat(result.refreshToken()).isEqualTo("refresh-token");
         assertThat(result.exchangeCode()).isEqualTo("exchange-code");
     }

--- a/src/test/java/matchuri/backend/domain/auth/support/oauth2/KakaoOAuth2UserInfoResolverTest.java
+++ b/src/test/java/matchuri/backend/domain/auth/support/oauth2/KakaoOAuth2UserInfoResolverTest.java
@@ -1,0 +1,62 @@
+package matchuri.backend.domain.auth.support.oauth2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import matchuri.backend.domain.member.entity.SocialProviderType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+class KakaoOAuth2UserInfoResolverTest {
+
+    private final KakaoOAuth2UserInfoResolver resolver = new KakaoOAuth2UserInfoResolver();
+
+    @Test
+    @DisplayName("Kakao OAuth2 사용자 정보를 공통 구조로 정규화한다")
+    void resolvesKakaoUserInfo() {
+        OAuth2User oauth2User = new DefaultOAuth2User(
+                List.of(),
+                Map.of(
+                        "id", 123456789L,
+                        "properties", Map.of("nickname", "카카오사용자"),
+                        "kakao_account", Map.of(
+                                "email", "kakao@example.com",
+                                "profile", Map.of("nickname", "프로필닉네임")
+                        )
+                ),
+                "id"
+        );
+
+        OAuth2ProviderUserInfo userInfo = resolver.resolve(oauth2User);
+
+        assertThat(resolver.supports(SocialProviderType.KAKAO)).isTrue();
+        assertThat(userInfo.provider()).isEqualTo(SocialProviderType.KAKAO);
+        assertThat(userInfo.providerUserId()).isEqualTo("123456789");
+        assertThat(userInfo.email()).isEqualTo("kakao@example.com");
+        assertThat(userInfo.nickname()).isEqualTo("카카오사용자");
+    }
+
+    @Test
+    @DisplayName("Kakao 계정 이메일과 properties 닉네임이 없어도 고유 식별자를 정규화한다")
+    void resolvesKakaoUserInfoWithoutOptionalFields() {
+        OAuth2User oauth2User = new DefaultOAuth2User(
+                List.of(),
+                Map.of(
+                        "id", 987654321L,
+                        "kakao_account", Map.of(
+                                "profile", Map.of("nickname", "프로필닉네임")
+                        )
+                ),
+                "id"
+        );
+
+        OAuth2ProviderUserInfo userInfo = resolver.resolve(oauth2User);
+
+        assertThat(userInfo.providerUserId()).isEqualTo("987654321");
+        assertThat(userInfo.email()).isNull();
+        assertThat(userInfo.nickname()).isEqualTo("프로필닉네임");
+    }
+}

--- a/src/test/java/matchuri/backend/domain/auth/support/oauth2/OAuth2MemberServiceTest.java
+++ b/src/test/java/matchuri/backend/domain/auth/support/oauth2/OAuth2MemberServiceTest.java
@@ -110,4 +110,28 @@ class OAuth2MemberServiceTest {
         assertThat(memberCaptor.getValue().getNickname()).isEqualTo("example_google_1");
         assertThat(createdMember.getNickname()).isEqualTo("example_google_1");
     }
+
+    @Test
+    @DisplayName("소셜 provider 이메일이 없으면 user_provider 규칙으로 임시 닉네임을 생성한다")
+    void createsFallbackTemporaryNicknameWhenEmailIsMissing() {
+        String providerUserId = "kakao-user-1";
+        ArgumentCaptor<Member> memberCaptor = ArgumentCaptor.forClass(Member.class);
+
+        when(memberRepository.findBySocialProviderTypeAndSocialProviderUserId(SocialProviderType.KAKAO,
+                providerUserId))
+                .thenReturn(Optional.empty());
+        when(memberRepository.existsByNickname("user_kakao")).thenReturn(false);
+        when(memberRepository.saveAndFlush(any(Member.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        Member createdMember = oAuth2MemberService.findOrCreateMember(
+                SocialProviderType.KAKAO,
+                providerUserId,
+                null
+        );
+
+        verify(memberRepository).saveAndFlush(memberCaptor.capture());
+        assertThat(memberCaptor.getValue().getNickname()).isEqualTo("user_kakao");
+        assertThat(createdMember.getNickname()).isEqualTo("user_kakao");
+    }
 }

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -64,7 +64,9 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/auth/refresh'].post.responses['403'].content['application/json'].examples.inactiveMember.value.error.code")
                         .value("MEMBER_INACTIVE_MEMBER"))
-                .andExpect(jsonPath("$.paths['/api/v1/auth/oauth2/google'].get.security").isEmpty())
+                .andExpect(jsonPath("$.paths['/api/v1/auth/oauth2/{provider}'].get.summary")
+                        .value("소셜 OAuth2 로그인 시작"))
+                .andExpect(jsonPath("$.paths['/api/v1/auth/oauth2/{provider}'].get.security").isEmpty())
                 .andExpect(jsonPath("$.paths['/api/v1/auth/oauth2/exchange'].post.security").isEmpty())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/auth/oauth2/exchange'].post.responses['200'].content['application/json'].schema.$ref")

--- a/src/test/java/matchuri/backend/global/security/OAuth2RedirectServiceTest.java
+++ b/src/test/java/matchuri/backend/global/security/OAuth2RedirectServiceTest.java
@@ -40,7 +40,7 @@ class OAuth2RedirectServiceTest {
         MatchuriProperties.Auth auth = new MatchuriProperties.Auth();
         MatchuriProperties.OAuth2 oauth2 = new MatchuriProperties.OAuth2();
         oauth2.setFrontendBaseUrl("http://localhost:3000");
-        oauth2.setSuccessPath("/auth/callback/google");
+        oauth2.setSuccessPath("/auth/callback");
         oauth2.setFailurePath("/login");
         oauth2.setExchangeCodeExpirationSeconds(300);
         auth.setOauth2(oauth2);

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -25,6 +25,21 @@ spring:
               - openid
               - profile
               - email
+          kakao:
+            client-id: test-kakao-client-id
+            client-secret: test-kakao-client-secret
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            scope:
+              - profile_nickname
+              - account_email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
 
 logging:
   level:
@@ -41,7 +56,7 @@ matchuri:
       - /api/v1/restriction-ingredients
       - /api/v1/menu-items
       - /api/v1/menu-items/**
-      - /api/v1/auth/oauth2/google
+      - /api/v1/auth/oauth2/**
       - /oauth2/authorization/**
       - /login/oauth2/code/**
       - /docs/**
@@ -75,7 +90,7 @@ matchuri:
       max-age: 3600
     oauth2:
       frontend-base-url: http://localhost:3000
-      success-path: /auth/callback/google
+      success-path: /auth/callback
       failure-path: /login
       exchange-code-expiration-seconds: 300
     cookie:


### PR DESCRIPTION
## 관련 이슈
Closes #182

## 📝 작업 내용
- OAuth2 로그인 시작 경로를 `/api/v1/auth/oauth2/{provider}`로 공통화했습니다.
- Kakao OAuth2 client registration과 `KakaoOAuth2UserInfoResolver`를 추가했습니다.
- OAuth2 성공 callback을 `/auth/callback/{provider}` 기준으로 생성하도록 일반화했습니다.
- `POST /api/v1/auth/oauth2/exchange`에서 `GOOGLE`, `KAKAO` provider를 허용하도록 변경했습니다.
- Kakao 로그인 시작, authorization redirect, user info 정규화, exchange code 교환 테스트를 추가했습니다.
- OAuth2 API 문서, API 상태표, 보안 문서, 운영 런북, 실행 계획 문서를 Kakao 지원 기준으로 갱신했습니다.

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
  - Kakao user info 응답의 nested map 파싱과 optional email 처리
  - provider별 callback URL 생성 방식
  - `SocialProviderType.isOAuth2LoginSupported()`로 Naver enum은 유지하되 아직 실제 로그인은 막는 정책
- 알려진 제한 사항:
  - Kakao Developers redirect URI 등록, `MATCHURI_KAKAO_CLIENT_ID`, `MATCHURI_KAKAO_CLIENT_SECRET` 운영 주입, 실제 브라우저 검증은 배포 환경 설정 후 진행해야 합니다.
  - `backend/`는 현재 루트 `.gitignore`에 포함되어 있어 루트 `git status`에는 백엔드 코드 변경이 표시되지 않습니다.
