### PR TITLE
[Feat] 비회원 전용 개인 메뉴 추천 API

### DIFF
--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
@@ -6,17 +6,21 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import matchuri.backend.api.recommendation.dto.docs.GuestPersonalRecommendationApiResponse;
 import matchuri.backend.api.recommendation.dto.docs.PersonalRecommendationCandidateListApiResponse;
 import matchuri.backend.api.recommendation.dto.docs.PersonalRecommendationDetailApiResponse;
 import matchuri.backend.api.recommendation.dto.docs.PersonalRecommendationRequestApiResponse;
 import matchuri.backend.api.recommendation.dto.docs.PersonalRecommendationSummaryPageApiResponse;
 import matchuri.backend.api.recommendation.dto.docs.RecommendationApiExamples;
 import matchuri.backend.api.recommendation.dto.docs.SelectPersonalRecommendationApiResponse;
+import matchuri.backend.api.recommendation.dto.request.CreateGuestPersonalRecommendationRequest;
 import matchuri.backend.api.recommendation.dto.request.CreatePersonalRecommendationRequest;
 import matchuri.backend.api.recommendation.dto.request.SelectPersonalRecommendationRequest;
+import matchuri.backend.api.recommendation.dto.response.GuestPersonalRecommendationResponse;
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationCandidateListResponse;
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationDetailResponse;
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationRequestResponse;
@@ -27,6 +31,33 @@ import matchuri.backend.global.api.PageResponse;
 
 @Tag(name = "Personal Recommendation", description = "개인 메뉴 추천 API")
 public interface RecommendationApi {
+
+    @Operation(
+            summary = "비회원 개인 추천 요청",
+            description = """
+                    비회원이 입력한 취향 정보를 바탕으로 개인 메뉴 추천을 실행합니다.
+
+                    추천 이력은 저장하지 않으며, `restriction ingredient`, `disliked menu item`을 제외한 후보만 반환합니다.
+                    """
+    )
+    @SecurityRequirements
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "비회원 추천 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = GuestPersonalRecommendationApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = RecommendationApiExamples.GUEST_PERSONAL_RECOMMENDATION_CREATE_SUCCESS
+                            )
+                    )
+            )
+    })
+    ApiResponse<GuestPersonalRecommendationResponse> createGuestPersonalRecommendation(
+            CreateGuestPersonalRecommendationRequest request
+    );
 
     @Operation(
             summary = "내 개인 추천 이력 목록 조회",

--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationController.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationController.java
@@ -3,13 +3,17 @@ package matchuri.backend.api.recommendation;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import matchuri.backend.api.recommendation.dto.request.CreateGuestPersonalRecommendationRequest;
 import matchuri.backend.api.recommendation.dto.request.CreatePersonalRecommendationRequest;
 import matchuri.backend.api.recommendation.dto.request.SelectPersonalRecommendationRequest;
+import matchuri.backend.api.recommendation.dto.response.GuestPersonalRecommendationResponse;
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationCandidateListResponse;
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationDetailResponse;
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationRequestResponse;
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationResponse;
 import matchuri.backend.api.recommendation.dto.response.SelectPersonalRecommendationResponse;
+import matchuri.backend.domain.recommendation.command.GuestPersonalRecommendationCommand;
+import matchuri.backend.domain.recommendation.result.GuestPersonalRecommendationResult;
 import matchuri.backend.domain.recommendation.result.PersonalRecommendationCandidateResult;
 import matchuri.backend.domain.recommendation.result.PersonalRecommendationResult;
 import matchuri.backend.domain.recommendation.result.PersonalRecommendationSummaryResult;
@@ -36,6 +40,17 @@ public class RecommendationController implements RecommendationApi {
 
     private final RecommendationService recommendationService;
     private final RecommendationMapper recommendationMapper;
+
+    @Override
+    @PostMapping("/guest/recommendations")
+    public ApiResponse<GuestPersonalRecommendationResponse> createGuestPersonalRecommendation(
+            @Valid @RequestBody CreateGuestPersonalRecommendationRequest request
+    ) {
+        GuestPersonalRecommendationCommand command = recommendationMapper.toGuestCommand(request);
+        GuestPersonalRecommendationResult result = recommendationService.createGuestPersonalRecommendation(command);
+
+        return ApiResponse.success(recommendationMapper.toGuestResponse(result));
+    }
 
     @Override
     @GetMapping("/personal/recommendations")

--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationMapper.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationMapper.java
@@ -6,13 +6,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import matchuri.backend.api.recommendation.dto.request.CreateGuestPersonalRecommendationRequest;
 import matchuri.backend.api.recommendation.dto.request.CreatePersonalRecommendationRequest;
+import matchuri.backend.api.recommendation.dto.response.GuestPersonalRecommendationCandidateResponse;
+import matchuri.backend.api.recommendation.dto.response.GuestPersonalRecommendationResponse;
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationCandidateListResponse;
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationCandidateResponse;
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationDetailResponse;
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationRequestResponse;
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationResponse;
 import matchuri.backend.api.recommendation.dto.response.SelectPersonalRecommendationResponse;
+import matchuri.backend.domain.recommendation.command.GuestPersonalRecommendationCommand;
+import matchuri.backend.domain.recommendation.result.GuestPersonalRecommendationCandidateResult;
+import matchuri.backend.domain.recommendation.result.GuestPersonalRecommendationResult;
 import matchuri.backend.domain.recommendation.result.PersonalRecommendationCandidateResult;
 import matchuri.backend.domain.recommendation.result.PersonalRecommendationResult;
 import matchuri.backend.domain.recommendation.result.PersonalRecommendationSummaryResult;
@@ -26,10 +32,31 @@ public class RecommendationMapper {
     private final ObjectMapper objectMapper;
 
     public String toContextJson(CreatePersonalRecommendationRequest request) {
-        try {
-            Map<String, Object> contextJson = request.contextJson() == null ? Map.of() : request.contextJson();
+        return toContextJson(request.contextJson());
+    }
 
-            return objectMapper.writeValueAsString(contextJson);
+    public GuestPersonalRecommendationCommand toGuestCommand(CreateGuestPersonalRecommendationRequest request) {
+        return new GuestPersonalRecommendationCommand(
+                request.attributeCategoryIds(),
+                request.restrictionIngredientIds(),
+                request.dislikedMenuItemIds(),
+                toContextJson(request.contextJson())
+        );
+    }
+
+    public GuestPersonalRecommendationResponse toGuestResponse(GuestPersonalRecommendationResult result) {
+        return new GuestPersonalRecommendationResponse(
+                result.candidates().stream()
+                        .map(this::toGuestCandidateResponse)
+                        .toList()
+        );
+    }
+
+    private String toContextJson(Map<String, Object> contextJson) {
+        try {
+            Map<String, Object> normalizedContextJson = contextJson == null ? Map.of() : contextJson;
+
+            return objectMapper.writeValueAsString(normalizedContextJson);
         } catch (JsonProcessingException exception) {
             throw new IllegalArgumentException("contextJson을 JSON 문자열로 변환할 수 없습니다.", exception);
         }
@@ -91,6 +118,17 @@ public class RecommendationMapper {
     private PersonalRecommendationCandidateResponse toCandidateResponse(PersonalRecommendationCandidateResult result) {
         return new PersonalRecommendationCandidateResponse(
                 result.id(),
+                result.menuId(),
+                result.menuName(),
+                result.rankNo(),
+                result.score()
+        );
+    }
+
+    private GuestPersonalRecommendationCandidateResponse toGuestCandidateResponse(
+            GuestPersonalRecommendationCandidateResult result
+    ) {
+        return new GuestPersonalRecommendationCandidateResponse(
                 result.menuId(),
                 result.menuName(),
                 result.rankNo(),

--- a/src/main/java/matchuri/backend/api/recommendation/dto/docs/GuestPersonalRecommendationApiResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/docs/GuestPersonalRecommendationApiResponse.java
@@ -1,0 +1,20 @@
+package matchuri.backend.api.recommendation.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.recommendation.dto.response.GuestPersonalRecommendationResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+public record GuestPersonalRecommendationApiResponse(
+        @Schema(description = "요청 성공 여부입니다.", example = "true")
+        boolean success,
+
+        @Schema(description = "비회원 개인 추천 결과입니다.")
+        GuestPersonalRecommendationResponse data,
+
+        @Schema(description = "실패 시 오류 정보입니다.", nullable = true)
+        ErrorResponse error
+) {
+    public static GuestPersonalRecommendationApiResponse mock() {
+        return new GuestPersonalRecommendationApiResponse(true, GuestPersonalRecommendationResponse.mock(), null);
+    }
+}

--- a/src/main/java/matchuri/backend/api/recommendation/dto/docs/RecommendationApiExamples.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/docs/RecommendationApiExamples.java
@@ -5,6 +5,35 @@ public final class RecommendationApiExamples {
     private RecommendationApiExamples() {
     }
 
+    public static final String GUEST_PERSONAL_RECOMMENDATION_CREATE_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "candidates": [
+                  {
+                    "menuId": 1001,
+                    "menuName": "비빔밥",
+                    "rankNo": 1,
+                    "score": 93.5
+                  },
+                  {
+                    "menuId": 1002,
+                    "menuName": "돈까스",
+                    "rankNo": 2,
+                    "score": 86.0
+                  },
+                  {
+                    "menuId": 1003,
+                    "menuName": "쌀국수",
+                    "rankNo": 3,
+                    "score": 81.5
+                  }
+                ]
+              },
+              "error": null
+            }
+            """;
+
     public static final String PERSONAL_RECOMMENDATION_LIST_SUCCESS = """
             {
               "success": true,

--- a/src/main/java/matchuri/backend/api/recommendation/dto/request/CreateGuestPersonalRecommendationRequest.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/request/CreateGuestPersonalRecommendationRequest.java
@@ -1,0 +1,24 @@
+package matchuri.backend.api.recommendation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+import java.util.Map;
+
+public record CreateGuestPersonalRecommendationRequest(
+        @Schema(description = "선호 attribute category ID 목록입니다.", example = "[101,102]")
+        List<@Positive Long> attributeCategoryIds,
+
+        @Schema(description = "제외할 restriction ingredient ID 목록입니다.", example = "[201]")
+        List<@Positive Long> restrictionIngredientIds,
+
+        @Schema(description = "제외할 disliked menu item ID 목록입니다.", example = "[301]")
+        List<@Positive Long> dislikedMenuItemIds,
+
+        @Schema(
+                description = "추천 요청 컨텍스트입니다. MVP에서는 선택 입력이며 mealTime, partySize, budgetLevel 같은 느슨한 JSON 값으로 시작합니다.",
+                example = "{\"mealTime\":\"LUNCH\",\"budgetLevel\":2}"
+        )
+        Map<String, Object> contextJson
+) {
+}

--- a/src/main/java/matchuri/backend/api/recommendation/dto/request/CreateGuestPersonalRecommendationRequest.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/request/CreateGuestPersonalRecommendationRequest.java
@@ -17,7 +17,7 @@ public record CreateGuestPersonalRecommendationRequest(
 
         @Schema(
                 description = "추천 요청 컨텍스트입니다. MVP에서는 선택 입력이며 mealTime, partySize, budgetLevel 같은 느슨한 JSON 값으로 시작합니다.",
-                example = "{\"mealTime\":\"LUNCH\",\"budgetLevel\":2}"
+                example = "{\"mealTime\":\"LUNCH\"}"
         )
         Map<String, Object> contextJson
 ) {

--- a/src/main/java/matchuri/backend/api/recommendation/dto/request/CreatePersonalRecommendationRequest.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/request/CreatePersonalRecommendationRequest.java
@@ -6,7 +6,7 @@ import java.util.Map;
 public record CreatePersonalRecommendationRequest(
         @Schema(
                 description = "추천 요청 컨텍스트입니다. MVP에서는 선택 입력이며 mealTime, partySize, budgetLevel 같은 느슨한 JSON 값으로 시작합니다.",
-                example = "{\"mealTime\":\"LUNCH\",\"budgetLevel\":2}"
+                example = "{\"mealTime\":\"LUNCH\"}"
         )
         Map<String, Object> contextJson
 ) {

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/GuestPersonalRecommendationCandidateResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/GuestPersonalRecommendationCandidateResponse.java
@@ -1,0 +1,26 @@
+package matchuri.backend.api.recommendation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GuestPersonalRecommendationCandidateResponse(
+        @Schema(description = "추천된 메뉴 ID입니다.", example = "1001")
+        Long menuId,
+
+        @Schema(description = "추천된 메뉴명입니다.", example = "비빔밥")
+        String menuName,
+
+        @Schema(description = "추천 순위입니다.", example = "1")
+        Integer rankNo,
+
+        @Schema(description = "추천 점수입니다.", example = "93.5")
+        Double score
+) {
+    public static GuestPersonalRecommendationCandidateResponse mockBibimbap() {
+        return new GuestPersonalRecommendationCandidateResponse(
+                1001L,
+                "비빔밥",
+                1,
+                93.5
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/GuestPersonalRecommendationResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/GuestPersonalRecommendationResponse.java
@@ -1,0 +1,15 @@
+package matchuri.backend.api.recommendation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record GuestPersonalRecommendationResponse(
+        @Schema(description = "비회원 개인 추천 후보 목록입니다.")
+        List<GuestPersonalRecommendationCandidateResponse> candidates
+) {
+    public static GuestPersonalRecommendationResponse mock() {
+        return new GuestPersonalRecommendationResponse(List.of(
+                GuestPersonalRecommendationCandidateResponse.mockBibimbap()
+        ));
+    }
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/algorithm/guest/GuestPersonalMenuRecommendationAlgorithmV1.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/algorithm/guest/GuestPersonalMenuRecommendationAlgorithmV1.java
@@ -1,0 +1,21 @@
+package matchuri.backend.domain.recommendation.algorithm.guest;
+
+import matchuri.backend.domain.recommendation.algorithm.RecommendationAlgorithmType;
+import matchuri.backend.domain.recommendation.algorithm.support.SingleParticipantMenuRecommendationAlgorithm;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GuestPersonalMenuRecommendationAlgorithmV1 extends SingleParticipantMenuRecommendationAlgorithm {
+
+    private static final String VERSION = "v1";
+
+    @Override
+    public RecommendationAlgorithmType type() {
+        return RecommendationAlgorithmType.GUEST_PERSONAL;
+    }
+
+    @Override
+    public String version() {
+        return VERSION;
+    }
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/algorithm/personal/PersonalMenuRecommendationAlgorithmV1.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/algorithm/personal/PersonalMenuRecommendationAlgorithmV1.java
@@ -1,21 +1,11 @@
 package matchuri.backend.domain.recommendation.algorithm.personal;
 
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import matchuri.backend.domain.recommendation.algorithm.MenuRecommendationAlgorithm;
 import matchuri.backend.domain.recommendation.algorithm.RecommendationAlgorithmType;
-import matchuri.backend.domain.recommendation.algorithm.input.MenuRecommendationInput;
-import matchuri.backend.domain.recommendation.algorithm.input.MenuRecommendationProfile;
-import matchuri.backend.domain.recommendation.algorithm.input.TasteProfileSnapshot;
-import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendationCandidateResult;
-import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendationResult;
+import matchuri.backend.domain.recommendation.algorithm.support.SingleParticipantMenuRecommendationAlgorithm;
 import org.springframework.stereotype.Component;
 
 @Component
-public class PersonalMenuRecommendationAlgorithmV1 implements MenuRecommendationAlgorithm {
+public class PersonalMenuRecommendationAlgorithmV1 extends SingleParticipantMenuRecommendationAlgorithm {
 
     private static final String VERSION = "v1";
 
@@ -27,133 +17,5 @@ public class PersonalMenuRecommendationAlgorithmV1 implements MenuRecommendation
     @Override
     public String version() {
         return VERSION;
-    }
-
-    /**
-     * 회원의 제한 재료, 비선호 메뉴, 최근 선택 메뉴를 제외한 뒤 취향과 선택 이력 기반 점수로 개인 추천 후보를 만든다.
-     *
-     * @param input 개인 추천에 필요한 취향 profile과 메뉴 후보 snapshot
-     * @return 점수순으로 정렬된 개인 추천 후보 결과
-     */
-    @Override
-    public MenuRecommendationResult recommend(MenuRecommendationInput input) {
-        TasteProfileSnapshot participant = input.participants().getFirst();
-
-        List<ScoredMenu> scoredMenus = input.menus().stream()
-                .filter(menu -> !containsAny(menu.ingredientIds(), participant.restrictionIngredientIds()))
-                .filter(menu -> !participant.dislikedMenuItemIds().contains(menu.menuId()))
-                .filter(menu -> !input.recentSelectedMenuIds().contains(menu.menuId()))
-                .map(menu -> score(menu, participant, input.selectedAttributeCategoryFrequency()))
-                .sorted(Comparator.comparing(ScoredMenu::totalScore).reversed()
-                        .thenComparing(scoredMenu -> scoredMenu.menu().menuId()))
-                .limit(input.candidateLimit())
-                .toList();
-
-        List<MenuRecommendationCandidateResult> candidates = toCandidates(scoredMenus);
-
-        return new MenuRecommendationResult(type(), version(), candidates);
-    }
-
-    private ScoredMenu score(
-            MenuRecommendationProfile menu,
-            TasteProfileSnapshot participant,
-            Map<Long, Long> selectedAttributeCategoryFrequency
-    ) {
-        long categoryMatchingCount = countMatches(
-                menu.attributeCategoryIds(),
-                participant.preferredAttributeCategoryIds()
-        );
-        long historyWeightMatchingCount = menu.attributeCategoryIds().stream()
-                .mapToLong(categoryId -> selectedAttributeCategoryFrequency.getOrDefault(categoryId, 0L))
-                .sum();
-
-        double categoryMatchingScore = calculateCategoryMatchingScore(
-                categoryMatchingCount,
-                participant.preferredAttributeCategoryIds().size()
-        );
-        double historyWeightScore = calculateHistoryWeightScore(
-                historyWeightMatchingCount,
-                selectedAttributeCategoryFrequency
-        );
-        double totalScore = categoryMatchingScore + historyWeightScore;
-
-        return new ScoredMenu(
-                menu,
-                categoryMatchingCount,
-                historyWeightMatchingCount,
-                categoryMatchingScore,
-                historyWeightScore,
-                totalScore
-        );
-    }
-
-    private List<MenuRecommendationCandidateResult> toCandidates(List<ScoredMenu> scoredMenus) {
-        return java.util.stream.IntStream.range(0, scoredMenus.size())
-                .mapToObj(index -> {
-                    ScoredMenu scoredMenu = scoredMenus.get(index);
-
-                    return new MenuRecommendationCandidateResult(
-                            scoredMenu.menu().menuId(),
-                            index + 1,
-                            scoredMenu.totalScore(),
-                            Map.of(
-                                    "categoryMatchingCount", scoredMenu.categoryMatchingCount(),
-                                    "historyWeightMatchingCount", scoredMenu.historyWeightMatchingCount(),
-                                    "categoryMatchingScore", scoredMenu.categoryMatchingScore(),
-                                    "historyWeightScore", scoredMenu.historyWeightScore()
-                            ),
-                            Map.of()
-                    );
-                })
-                .toList();
-    }
-
-    private double calculateCategoryMatchingScore(long matchingCount, int preferredCategoryCount) {
-        if (preferredCategoryCount == 0) {
-            return 0;
-        }
-
-        return matchingCount * (50.0 / preferredCategoryCount);
-    }
-
-    private double calculateHistoryWeightScore(
-            long historyWeightMatchingCount,
-            Map<Long, Long> selectedAttributeCategoryFrequency
-    ) {
-        long maxFrequency = selectedAttributeCategoryFrequency.values().stream()
-                .mapToLong(Long::longValue)
-                .max()
-                .orElse(0);
-
-        if (maxFrequency == 0) {
-            return 0;
-        }
-
-        return historyWeightMatchingCount * (50.0 / maxFrequency);
-    }
-
-    private long countMatches(List<Long> sourceIds, List<Long> targetIds) {
-        Set<Long> targetIdSet = new HashSet<>(targetIds);
-
-        return sourceIds.stream()
-                .filter(targetIdSet::contains)
-                .count();
-    }
-
-    private boolean containsAny(List<Long> sourceIds, List<Long> targetIds) {
-        Set<Long> targetIdSet = new HashSet<>(targetIds);
-
-        return sourceIds.stream()
-                .anyMatch(targetIdSet::contains);
-    }
-
-    private record ScoredMenu(
-            MenuRecommendationProfile menu,
-            long categoryMatchingCount,
-            long historyWeightMatchingCount,
-            double categoryMatchingScore,
-            double historyWeightScore,
-            double totalScore
-    ) {
     }
 }

--- a/src/main/java/matchuri/backend/domain/recommendation/algorithm/support/SingleParticipantMenuRecommendationAlgorithm.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/algorithm/support/SingleParticipantMenuRecommendationAlgorithm.java
@@ -1,0 +1,142 @@
+package matchuri.backend.domain.recommendation.algorithm.support;
+
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.IntStream;
+import matchuri.backend.domain.recommendation.algorithm.MenuRecommendationAlgorithm;
+import matchuri.backend.domain.recommendation.algorithm.input.MenuRecommendationInput;
+import matchuri.backend.domain.recommendation.algorithm.input.MenuRecommendationProfile;
+import matchuri.backend.domain.recommendation.algorithm.input.TasteProfileSnapshot;
+import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendationCandidateResult;
+import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendationResult;
+
+public abstract class SingleParticipantMenuRecommendationAlgorithm implements MenuRecommendationAlgorithm {
+
+    /**
+     * 단일 참여자의 제한 재료, 비선호 메뉴, 최근 선택 메뉴를 제외한 뒤 취향과 선택 이력 기반 점수로 추천 후보를 만든다.
+     *
+     * @param input 단일 참여자 취향 profile과 메뉴 후보 snapshot
+     * @return 점수순으로 정렬된 추천 후보 결과
+     */
+    @Override
+    public MenuRecommendationResult recommend(MenuRecommendationInput input) {
+        TasteProfileSnapshot participant = input.participants().getFirst();
+
+        List<ScoredMenu> scoredMenus = input.menus().stream()
+                .filter(menu -> !containsAny(menu.ingredientIds(), participant.restrictionIngredientIds()))
+                .filter(menu -> !participant.dislikedMenuItemIds().contains(menu.menuId()))
+                .filter(menu -> !input.recentSelectedMenuIds().contains(menu.menuId()))
+                .map(menu -> score(menu, participant, input.selectedAttributeCategoryFrequency()))
+                .sorted(Comparator.comparing(ScoredMenu::totalScore).reversed()
+                        .thenComparing(scoredMenu -> scoredMenu.menu().menuId()))
+                .limit(input.candidateLimit())
+                .toList();
+
+        return new MenuRecommendationResult(type(), version(), toCandidates(scoredMenus));
+    }
+
+    private ScoredMenu score(
+            MenuRecommendationProfile menu,
+            TasteProfileSnapshot participant,
+            Map<Long, Long> selectedAttributeCategoryFrequency
+    ) {
+        long categoryMatchingCount = countMatches(
+                menu.attributeCategoryIds(),
+                participant.preferredAttributeCategoryIds()
+        );
+        long historyWeightMatchingCount = menu.attributeCategoryIds().stream()
+                .mapToLong(categoryId -> selectedAttributeCategoryFrequency.getOrDefault(categoryId, 0L))
+                .sum();
+
+        double categoryMatchingScore = calculateCategoryMatchingScore(
+                categoryMatchingCount,
+                participant.preferredAttributeCategoryIds().size()
+        );
+        double historyWeightScore = calculateHistoryWeightScore(
+                historyWeightMatchingCount,
+                selectedAttributeCategoryFrequency
+        );
+
+        return new ScoredMenu(
+                menu,
+                categoryMatchingCount,
+                historyWeightMatchingCount,
+                categoryMatchingScore,
+                historyWeightScore,
+                categoryMatchingScore + historyWeightScore
+        );
+    }
+
+    private List<MenuRecommendationCandidateResult> toCandidates(List<ScoredMenu> scoredMenus) {
+        return IntStream.range(0, scoredMenus.size())
+                .mapToObj(index -> {
+                    ScoredMenu scoredMenu = scoredMenus.get(index);
+
+                    return new MenuRecommendationCandidateResult(
+                            scoredMenu.menu().menuId(),
+                            index + 1,
+                            scoredMenu.totalScore(),
+                            Map.of(
+                                    "categoryMatchingCount", scoredMenu.categoryMatchingCount(),
+                                    "historyWeightMatchingCount", scoredMenu.historyWeightMatchingCount(),
+                                    "categoryMatchingScore", scoredMenu.categoryMatchingScore(),
+                                    "historyWeightScore", scoredMenu.historyWeightScore()
+                            ),
+                            Map.of()
+                    );
+                })
+                .toList();
+    }
+
+    private double calculateCategoryMatchingScore(long matchingCount, int preferredCategoryCount) {
+        if (preferredCategoryCount == 0) {
+            return 0;
+        }
+
+        return matchingCount * (50.0 / preferredCategoryCount);
+    }
+
+    private double calculateHistoryWeightScore(
+            long historyWeightMatchingCount,
+            Map<Long, Long> selectedAttributeCategoryFrequency
+    ) {
+        long maxFrequency = selectedAttributeCategoryFrequency.values().stream()
+                .mapToLong(Long::longValue)
+                .max()
+                .orElse(0);
+
+        if (maxFrequency == 0) {
+            return 0;
+        }
+
+        return historyWeightMatchingCount * (50.0 / maxFrequency);
+    }
+
+    private long countMatches(List<Long> sourceIds, List<Long> targetIds) {
+        Set<Long> targetIdSet = new HashSet<>(targetIds);
+
+        return sourceIds.stream()
+                .filter(targetIdSet::contains)
+                .count();
+    }
+
+    private boolean containsAny(List<Long> sourceIds, List<Long> targetIds) {
+        Set<Long> targetIdSet = new HashSet<>(targetIds);
+
+        return sourceIds.stream()
+                .anyMatch(targetIdSet::contains);
+    }
+
+    private record ScoredMenu(
+            MenuRecommendationProfile menu,
+            long categoryMatchingCount,
+            long historyWeightMatchingCount,
+            double categoryMatchingScore,
+            double historyWeightScore,
+            double totalScore
+    ) {
+    }
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/command/GuestPersonalRecommendationCommand.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/command/GuestPersonalRecommendationCommand.java
@@ -1,0 +1,17 @@
+package matchuri.backend.domain.recommendation.command;
+
+import java.util.List;
+
+public record GuestPersonalRecommendationCommand(
+        List<Long> attributeCategoryIds,
+        List<Long> restrictionIngredientIds,
+        List<Long> dislikedMenuItemIds,
+        String contextJson
+) {
+    public GuestPersonalRecommendationCommand {
+        attributeCategoryIds = attributeCategoryIds == null ? List.of() : List.copyOf(attributeCategoryIds);
+        restrictionIngredientIds = restrictionIngredientIds == null ? List.of() : List.copyOf(restrictionIngredientIds);
+        dislikedMenuItemIds = dislikedMenuItemIds == null ? List.of() : List.copyOf(dislikedMenuItemIds);
+        contextJson = contextJson == null ? "{}" : contextJson;
+    }
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/exception/GuestRecommendationErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/exception/GuestRecommendationErrorCode.java
@@ -1,0 +1,38 @@
+package matchuri.backend.domain.recommendation.exception;
+
+import java.text.MessageFormat;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import matchuri.backend.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GuestRecommendationErrorCode implements ErrorCode {
+
+    DUPLICATE_ATTRIBUTE_CATEGORY(HttpStatus.BAD_REQUEST,
+            "중복된 attribute category ID가 포함되어 있습니다. attributeCategoryIds : {0}"),
+    DUPLICATE_RESTRICTION_INGREDIENT(HttpStatus.BAD_REQUEST,
+            "중복된 restriction ingredient ID가 포함되어 있습니다. restrictionIngredientIds : {0}"),
+    DUPLICATE_DISLIKED_MENU_ITEM(HttpStatus.BAD_REQUEST,
+            "중복된 disliked menu item ID가 포함되어 있습니다. dislikedMenuItemIds : {0}"),
+    INVALID_ATTRIBUTE_CATEGORY(HttpStatus.BAD_REQUEST,
+            "유효하지 않거나 비활성화된 attribute category ID가 포함되어 있습니다. attributeCategoryIds : {0}"),
+    INVALID_RESTRICTION_INGREDIENT(HttpStatus.BAD_REQUEST,
+            "유효하지 않거나 비활성화된 restriction ingredient ID가 포함되어 있습니다. restrictionIngredientIds : {0}"),
+    INVALID_DISLIKED_MENU_ITEM(HttpStatus.BAD_REQUEST,
+            "유효하지 않거나 비활성화된 disliked menu item ID가 포함되어 있습니다. dislikedMenuItemIds : {0}");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String format(Object... args) {
+        return MessageFormat.format(message, args);
+    }
+
+    @Override
+    public String getDomainPrefix() {
+        return "GUEST_RECOMMENDATION_";
+    }
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/result/GuestPersonalRecommendationCandidateResult.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/result/GuestPersonalRecommendationCandidateResult.java
@@ -1,0 +1,9 @@
+package matchuri.backend.domain.recommendation.result;
+
+public record GuestPersonalRecommendationCandidateResult(
+        Long menuId,
+        String menuName,
+        Integer rankNo,
+        Double score
+) {
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/result/GuestPersonalRecommendationResult.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/result/GuestPersonalRecommendationResult.java
@@ -1,0 +1,11 @@
+package matchuri.backend.domain.recommendation.result;
+
+import java.util.List;
+
+public record GuestPersonalRecommendationResult(
+        List<GuestPersonalRecommendationCandidateResult> candidates
+) {
+    public GuestPersonalRecommendationResult {
+        candidates = candidates == null ? List.of() : List.copyOf(candidates);
+    }
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationService.java
@@ -1,6 +1,8 @@
 package matchuri.backend.domain.recommendation.service;
 
 import java.util.List;
+import matchuri.backend.domain.recommendation.command.GuestPersonalRecommendationCommand;
+import matchuri.backend.domain.recommendation.result.GuestPersonalRecommendationResult;
 import matchuri.backend.domain.recommendation.result.PersonalRecommendationCandidateResult;
 import matchuri.backend.domain.recommendation.result.PersonalRecommendationResult;
 import matchuri.backend.domain.recommendation.result.PersonalRecommendationSummaryResult;
@@ -10,6 +12,8 @@ import org.springframework.data.domain.Page;
 
 public interface RecommendationService {
     PersonalRecommendationResult createPersonalRecommendation(String contextJson);
+
+    GuestPersonalRecommendationResult createGuestPersonalRecommendation(GuestPersonalRecommendationCommand command);
 
     PersonalRecommendationResult getPersonalRecommendation(Long personalRecommendationId);
 

--- a/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
@@ -3,8 +3,11 @@ package matchuri.backend.domain.recommendation.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +22,8 @@ import matchuri.backend.domain.menu.entity.Ingredient;
 import matchuri.backend.domain.menu.entity.MenuAttributeCategory;
 import matchuri.backend.domain.menu.entity.MenuIngredient;
 import matchuri.backend.domain.menu.entity.MenuItem;
+import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
+import matchuri.backend.domain.menu.repository.IngredientRepository;
 import matchuri.backend.domain.menu.repository.MenuIngredientRepository;
 import matchuri.backend.domain.menu.repository.MenuItemRepository;
 import matchuri.backend.domain.recommendation.algorithm.MenuRecommendationAlgorithm;
@@ -31,11 +36,15 @@ import matchuri.backend.domain.recommendation.algorithm.input.RecommendationCont
 import matchuri.backend.domain.recommendation.algorithm.input.TasteProfileSnapshot;
 import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendationCandidateResult;
 import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendationResult;
+import matchuri.backend.domain.recommendation.command.GuestPersonalRecommendationCommand;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCandidate;
+import matchuri.backend.domain.recommendation.exception.GuestRecommendationErrorCode;
 import matchuri.backend.domain.recommendation.exception.RecommendationErrorCode;
 import matchuri.backend.domain.recommendation.repository.PersonalRecommendationCandidateRepository;
 import matchuri.backend.domain.recommendation.repository.PersonalRecommendationRepository;
+import matchuri.backend.domain.recommendation.result.GuestPersonalRecommendationCandidateResult;
+import matchuri.backend.domain.recommendation.result.GuestPersonalRecommendationResult;
 import matchuri.backend.domain.recommendation.result.PersonalRecommendationCandidateResult;
 import matchuri.backend.domain.recommendation.result.PersonalRecommendationResult;
 import matchuri.backend.domain.recommendation.result.PersonalRecommendationSummaryResult;
@@ -52,9 +61,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class RecommendationServiceImpl implements RecommendationService {
 
     private static final int RECENT_SELECTED_MENU_EXCLUSION_COUNT = 3;
+    private static final int RECOMMENDATION_CANDIDATE_LIMIT = 3;
+    private static final String GUEST_PARTICIPANT_KEY = "guest";
 
     private final ActiveMemberReader activeMemberReader;
     private final PersonalRecommendationRepository personalRecommendationRepository;
+    private final AttributeCategoryRepository attributeCategoryRepository;
+    private final IngredientRepository ingredientRepository;
     private final MenuItemRepository menuItemRepository;
     private final MenuIngredientRepository menuIngredientRepository;
     private final PersonalRecommendationCandidateRepository personalRecommendationCandidateRepository;
@@ -92,7 +105,7 @@ public class RecommendationServiceImpl implements RecommendationService {
                 List.of(toTasteProfileSnapshot(member, tasteProfile)),
                 toMenuRecommendationProfiles(menuItems),
                 RecommendationContextSnapshot.of(contextJson),
-                3,
+                RECOMMENDATION_CANDIDATE_LIMIT,
                 findRecentlySelectedMenuIds(recommendations),
                 countSelectedAttributeCategoryFrequency(recommendations)
         );
@@ -109,6 +122,58 @@ public class RecommendationServiceImpl implements RecommendationService {
                 saveRecommendationCandidates(savedPersonalRecommendation, recommendationResult, menuItemById);
 
         return PersonalRecommendationResult.of(savedPersonalRecommendation, savedCandidates);
+    }
+
+    /**
+     * 비회원이 요청한 취향 입력을 기반으로 저장 없는 개인 메뉴 후보를 생성한다.
+     *
+     * @param command 비회원 추천 요청 취향 입력
+     * @return 비회원 추천 후보 목록
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public GuestPersonalRecommendationResult createGuestPersonalRecommendation(
+            GuestPersonalRecommendationCommand command
+    ) {
+        validateGuestRecommendationCommand(command);
+
+        MenuRecommendationAlgorithm algorithm =
+                menuRecommendationAlgorithmResolver.resolve(RecommendationAlgorithmType.GUEST_PERSONAL);
+        List<MenuItem> menuItems = menuItemRepository.searchActiveMenuItems(
+                null,
+                List.of(),
+                true,
+                List.of(),
+                true
+        );
+        Map<Long, MenuItem> menuItemById = menuItems.stream()
+                .collect(Collectors.toMap(MenuItem::getId, Function.identity()));
+        MenuRecommendationInput input = new MenuRecommendationInput(
+                RecommendationTargetType.GUEST_PERSONAL,
+                List.of(toGuestTasteProfileSnapshot(command)),
+                toMenuRecommendationProfiles(menuItems),
+                RecommendationContextSnapshot.of(command.contextJson()),
+                RECOMMENDATION_CANDIDATE_LIMIT,
+                List.of(),
+                Map.of()
+        );
+
+        MenuRecommendationResult recommendationResult = algorithm.recommend(input);
+
+        List<GuestPersonalRecommendationCandidateResult> candidates = recommendationResult.candidates().stream()
+                .map(candidate -> {
+                    MenuItem menuItem = menuItemById.get(candidate.menuId());
+
+                    return new GuestPersonalRecommendationCandidateResult(
+                            candidate.menuId(),
+                            menuItem.getName(),
+                            candidate.rankNo(),
+                            candidate.score()
+                    );
+                })
+                .toList();
+
+        return new GuestPersonalRecommendationResult(candidates);
     }
 
     @Override
@@ -202,6 +267,16 @@ public class RecommendationServiceImpl implements RecommendationService {
         );
     }
 
+    private TasteProfileSnapshot toGuestTasteProfileSnapshot(GuestPersonalRecommendationCommand command) {
+        return new TasteProfileSnapshot(
+                null,
+                GUEST_PARTICIPANT_KEY,
+                command.attributeCategoryIds(),
+                command.restrictionIngredientIds(),
+                command.dislikedMenuItemIds()
+        );
+    }
+
     private List<MenuRecommendationProfile> toMenuRecommendationProfiles(List<MenuItem> menuItems) {
         Map<Long, List<Long>> ingredientIdsByMenuId = menuIngredientRepository.findAll().stream()
                 .collect(Collectors.groupingBy(
@@ -222,6 +297,73 @@ public class RecommendationServiceImpl implements RecommendationService {
                         ingredientIdsByMenuId.getOrDefault(menuItem.getId(), List.of())
                 ))
                 .toList();
+    }
+
+    private void validateGuestRecommendationCommand(GuestPersonalRecommendationCommand command) {
+        validateNoDuplicateIds(
+                command.attributeCategoryIds(),
+                GuestRecommendationErrorCode.DUPLICATE_ATTRIBUTE_CATEGORY
+        );
+        validateNoDuplicateIds(
+                command.restrictionIngredientIds(),
+                GuestRecommendationErrorCode.DUPLICATE_RESTRICTION_INGREDIENT
+        );
+        validateNoDuplicateIds(
+                command.dislikedMenuItemIds(),
+                GuestRecommendationErrorCode.DUPLICATE_DISLIKED_MENU_ITEM
+        );
+
+        validateActiveAttributeCategoryIds(command.attributeCategoryIds());
+        validateActiveRestrictionIngredientIds(command.restrictionIngredientIds());
+        validateActiveDislikedMenuItemIds(command.dislikedMenuItemIds());
+    }
+
+    private void validateNoDuplicateIds(List<Long> ids, GuestRecommendationErrorCode errorCode) {
+        if (ids.size() == new LinkedHashSet<>(ids).size()) {
+            return;
+        }
+
+        throw new BusinessException(errorCode, ids);
+    }
+
+    private void validateActiveAttributeCategoryIds(List<Long> attributeCategoryIds) {
+        if (attributeCategoryIds.stream().anyMatch(Objects::isNull)) {
+            throw new BusinessException(GuestRecommendationErrorCode.INVALID_ATTRIBUTE_CATEGORY, attributeCategoryIds);
+        }
+
+        List<AttributeCategory> attributeCategories = attributeCategoryRepository.findAllByIdInAndActiveTrue(
+                attributeCategoryIds);
+        if (attributeCategories.size() != attributeCategoryIds.size()) {
+            throw new BusinessException(GuestRecommendationErrorCode.INVALID_ATTRIBUTE_CATEGORY, attributeCategoryIds);
+        }
+    }
+
+    private void validateActiveRestrictionIngredientIds(List<Long> restrictionIngredientIds) {
+        if (restrictionIngredientIds.stream().anyMatch(Objects::isNull)) {
+            throw new BusinessException(
+                    GuestRecommendationErrorCode.INVALID_RESTRICTION_INGREDIENT,
+                    restrictionIngredientIds
+            );
+        }
+
+        List<Ingredient> ingredients = ingredientRepository.findAllByIdInAndActiveTrue(restrictionIngredientIds);
+        if (ingredients.size() != restrictionIngredientIds.size()) {
+            throw new BusinessException(
+                    GuestRecommendationErrorCode.INVALID_RESTRICTION_INGREDIENT,
+                    restrictionIngredientIds
+            );
+        }
+    }
+
+    private void validateActiveDislikedMenuItemIds(List<Long> dislikedMenuItemIds) {
+        if (dislikedMenuItemIds.stream().anyMatch(Objects::isNull)) {
+            throw new BusinessException(GuestRecommendationErrorCode.INVALID_DISLIKED_MENU_ITEM, dislikedMenuItemIds);
+        }
+
+        List<MenuItem> menuItems = menuItemRepository.findAllByIdInAndActiveTrue(dislikedMenuItemIds);
+        if (menuItems.size() != dislikedMenuItemIds.size()) {
+            throw new BusinessException(GuestRecommendationErrorCode.INVALID_DISLIKED_MENU_ITEM, dislikedMenuItemIds);
+        }
     }
 
     private List<Long> findRecentlySelectedMenuIds(List<PersonalRecommendation> recommendations) {

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -2,3 +2,15 @@ matchuri:
   seed:
     enabled: true
     sample-members-enabled: true
+
+spring:
+  jpa:
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+        use_sql_comments: false
+
+logging:
+  level:
+    org.hibernate.SQL: debug

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -88,6 +88,7 @@ matchuri:
       - /api/v1/auth/email/confirm
       - /api/v1/auth/recovery/login-id
       - /api/v1/auth/recovery/password
+      - /api/v1/guest/recommendations
     public-options-api-patterns:
       - /**
     cors:

--- a/src/test/java/matchuri/backend/api/recommendation/GuestRecommendationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/recommendation/GuestRecommendationIntegrationTest.java
@@ -1,0 +1,125 @@
+package matchuri.backend.api.recommendation;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import matchuri.backend.domain.menu.entity.AttributeCategory;
+import matchuri.backend.domain.menu.entity.CategoryType;
+import matchuri.backend.domain.menu.entity.Ingredient;
+import matchuri.backend.domain.menu.entity.MenuAttributeCategory;
+import matchuri.backend.domain.menu.entity.MenuIngredient;
+import matchuri.backend.domain.menu.entity.MenuItem;
+import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
+import matchuri.backend.domain.menu.repository.IngredientRepository;
+import matchuri.backend.domain.menu.repository.MenuAttributeCategoryRepository;
+import matchuri.backend.domain.menu.repository.MenuIngredientRepository;
+import matchuri.backend.domain.menu.repository.MenuItemRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class GuestRecommendationIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private AttributeCategoryRepository attributeCategoryRepository;
+
+    @Autowired
+    private IngredientRepository ingredientRepository;
+
+    @Autowired
+    private MenuItemRepository menuItemRepository;
+
+    @Autowired
+    private MenuAttributeCategoryRepository menuAttributeCategoryRepository;
+
+    @Autowired
+    private MenuIngredientRepository menuIngredientRepository;
+
+    @BeforeEach
+    void setUp() {
+        menuIngredientRepository.deleteAll();
+        menuAttributeCategoryRepository.deleteAll();
+        menuItemRepository.deleteAll();
+        attributeCategoryRepository.deleteAll();
+        ingredientRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("비회원 추천 API는 인증 없이 취향 입력 기반 후보를 반환한다")
+    void createGuestPersonalRecommendationReturnsCandidatesWithoutAuthentication() throws Exception {
+        AttributeCategory spicy = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 10));
+        Ingredient peanut = ingredientRepository.save(new Ingredient("PEANUT", "땅콩", true, 10));
+
+        MenuItem bibimbap = menuItemRepository.save(new MenuItem("BIBIMBAP", "비빔밥", "채소와 밥"));
+        MenuItem peanutNoodle = menuItemRepository.save(new MenuItem("PEANUT_NOODLE", "땅콩면", "땅콩 소스 면"));
+        MenuItem porkCutlet = menuItemRepository.save(new MenuItem("PORK_CUTLET", "돈까스", "튀김 메뉴"));
+        MenuItem riceNoodle = menuItemRepository.save(new MenuItem("RICE_NOODLE", "쌀국수", "가벼운 국물 메뉴"));
+
+        menuAttributeCategoryRepository.save(new MenuAttributeCategory(bibimbap, spicy));
+        menuAttributeCategoryRepository.save(new MenuAttributeCategory(peanutNoodle, spicy));
+        menuAttributeCategoryRepository.save(new MenuAttributeCategory(porkCutlet, spicy));
+        menuIngredientRepository.save(new MenuIngredient(peanutNoodle, peanut));
+
+        Map<String, Object> request = Map.of(
+                "attributeCategoryIds", List.of(spicy.getId()),
+                "restrictionIngredientIds", List.of(peanut.getId()),
+                "dislikedMenuItemIds", List.of(porkCutlet.getId()),
+                "contextJson", Map.of("mealTime", "LUNCH")
+        );
+
+        mockMvc.perform(post("/api/v1/guest/recommendations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.error").value(nullValue()))
+                .andExpect(jsonPath("$.data.candidates.length()").value(2))
+                .andExpect(jsonPath("$.data.candidates[0].menuId").value(bibimbap.getId()))
+                .andExpect(jsonPath("$.data.candidates[0].menuName").value("비빔밥"))
+                .andExpect(jsonPath("$.data.candidates[0].rankNo").value(1))
+                .andExpect(jsonPath("$.data.candidates[0].id").doesNotExist())
+                .andExpect(jsonPath("$.data.requestId").doesNotExist())
+                .andExpect(jsonPath("$.data.candidates[1].menuId").value(riceNoodle.getId()));
+    }
+
+    @Test
+    @DisplayName("비회원 추천 API는 중복된 attribute category ID를 거부한다")
+    void createGuestPersonalRecommendationRejectsDuplicateAttributeCategoryIds() throws Exception {
+        Map<String, Object> request = Map.of(
+                "attributeCategoryIds", List.of(1L, 1L),
+                "restrictionIngredientIds", List.of(),
+                "dislikedMenuItemIds", List.of(),
+                "contextJson", Map.of()
+        );
+
+        mockMvc.perform(post("/api/v1/guest/recommendations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("GUEST_RECOMMENDATION_DUPLICATE_ATTRIBUTE_CATEGORY"));
+    }
+}

--- a/src/test/java/matchuri/backend/domain/recommendation/algorithm/guest/GuestPersonalMenuRecommendationAlgorithmV1Test.java
+++ b/src/test/java/matchuri/backend/domain/recommendation/algorithm/guest/GuestPersonalMenuRecommendationAlgorithmV1Test.java
@@ -1,0 +1,54 @@
+package matchuri.backend.domain.recommendation.algorithm.guest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import matchuri.backend.domain.recommendation.algorithm.RecommendationAlgorithmType;
+import matchuri.backend.domain.recommendation.algorithm.RecommendationTargetType;
+import matchuri.backend.domain.recommendation.algorithm.input.MenuRecommendationInput;
+import matchuri.backend.domain.recommendation.algorithm.input.MenuRecommendationProfile;
+import matchuri.backend.domain.recommendation.algorithm.input.RecommendationContextSnapshot;
+import matchuri.backend.domain.recommendation.algorithm.input.TasteProfileSnapshot;
+import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendationResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GuestPersonalMenuRecommendationAlgorithmV1Test {
+
+    private final GuestPersonalMenuRecommendationAlgorithmV1 algorithm = new GuestPersonalMenuRecommendationAlgorithmV1();
+
+    @Test
+    @DisplayName("비회원 취향 입력으로 제한 재료와 비선호 메뉴를 제외한 후보를 반환한다")
+    void recommendGuestPersonalCandidates() {
+        TasteProfileSnapshot participant = new TasteProfileSnapshot(
+                null,
+                "guest",
+                List.of(10L),
+                List.of(100L),
+                List.of(3L)
+        );
+        MenuRecommendationInput input = new MenuRecommendationInput(
+                RecommendationTargetType.GUEST_PERSONAL,
+                List.of(participant),
+                List.of(
+                        new MenuRecommendationProfile(1L, "M1", "메뉴1", List.of(10L), List.of()),
+                        new MenuRecommendationProfile(2L, "M2", "메뉴2", List.of(10L), List.of(100L)),
+                        new MenuRecommendationProfile(3L, "M3", "메뉴3", List.of(10L), List.of()),
+                        new MenuRecommendationProfile(4L, "M4", "메뉴4", List.of(), List.of())
+                ),
+                RecommendationContextSnapshot.of("{}"),
+                3,
+                List.of(),
+                Map.of()
+        );
+
+        MenuRecommendationResult result = algorithm.recommend(input);
+
+        assertThat(result.algorithmType()).isEqualTo(RecommendationAlgorithmType.GUEST_PERSONAL);
+        assertThat(result.algorithmVersion()).isEqualTo("v1");
+        assertThat(result.candidates())
+                .extracting(candidate -> candidate.menuId())
+                .containsExactly(1L, 4L);
+    }
+}

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -223,6 +223,18 @@ class OpenApiDocumentationIntegrationTest {
         mockMvc.perform(get("/docs/openapi"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith("application/json"))
+                .andExpect(jsonPath("$.paths['/api/v1/guest/recommendations'].post.summary")
+                        .value("비회원 개인 추천 요청"))
+                .andExpect(jsonPath("$.paths['/api/v1/guest/recommendations'].post.security").isEmpty())
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/guest/recommendations'].post.responses['200'].content['application/json'].schema.$ref")
+                        .value("#/components/schemas/GuestPersonalRecommendationApiResponse"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/guest/recommendations'].post.responses['200'].content['application/json'].examples.success.value.data.candidates[0].menuName")
+                        .value("비빔밥"))
+                .andExpect(jsonPath(
+                        "$.components.schemas.CreateGuestPersonalRecommendationRequest.properties.attributeCategoryIds.description")
+                        .value(org.hamcrest.Matchers.containsString("attribute category ID 목록")))
                 .andExpect(jsonPath("$.paths['/api/v1/personal/recommendations'].get.summary")
                         .value("내 개인 추천 이력 목록 조회"))
                 .andExpect(jsonPath(

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -70,6 +70,7 @@ matchuri:
       - /api/v1/auth/email/confirm
       - /api/v1/auth/recovery/login-id
       - /api/v1/auth/recovery/password
+      - /api/v1/guest/recommendations
     public-options-api-patterns:
       - /**
     cors:


### PR DESCRIPTION
## 관련 이슈
Closes #185 

## 📝 작업 내용
- 비회원 개인 메뉴 추천 API `POST /api/v1/guest/recommendations`를 추가했습니다.
- 비회원 취향 입력 request DTO와 추천 후보 response DTO를 추가했습니다.
- `GuestPersonalMenuRecommendationAlgorithmV1` 구현체를 추가했습니다.
- 기존 개인 추천 v1과 비회원 추천 v1이 단일 참여자 추천 계산 로직을 공유하도록 공통 알고리즘 지원 클래스를 분리했습니다.
- 비회원 추천은 추천 이력을 저장하지 않고, 요청 취향 입력 기반 후보 목록만 동기 반환하도록 구현했습니다.
- 비회원 추천 API를 공개 POST 경로에 추가해 인증 없이 호출 가능하도록 했습니다.
- OpenAPI 문서 예시와 `docs/api/recommendation.md`를 갱신했습니다.
- 비회원 추천 알고리즘 단위 테스트, 비회원 API 통합 테스트, OpenAPI 문서 테스트를 추가했습니다.

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
  - 비회원 추천이 저장 없이 후보 목록만 반환하는 API 계약이 적절한지 확인 부탁드립니다.
  - 이후 비회원에 대한 요청 제한을 설정해주시길 바랍니다.

- 알려진 제한 사항:
  - 비회원 추천 이력은 저장하지 않습니다.
  - 비회원 추천 후보 선택 API는 포함하지 않습니다.
  - 응답에는 `requestId`, `candidateId`, score breakdown, 추천 사유가 포함되지 않습니다.
  - 그룹 추천 API는 후속 작업에서 별도 구현합니다.

검증:
- `./gradlew --no-daemon clean build`
