### PR TITLE
[Feat] 그룹 목록 조회 API

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -37,6 +37,7 @@ import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupVoteResponse;
 import matchuri.backend.api.group.dto.response.JoinGroupResponse;
 import matchuri.backend.api.group.dto.response.LeaveGroupResponse;
+import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.global.api.ApiResponse;
 import matchuri.backend.global.api.PageResponse;
 
@@ -70,13 +71,14 @@ public interface GroupApi {
     ApiResponse<CreateGroupResponse> createGroup(@Valid CreateGroupRequest request);
 
     @Operation(
-            summary = "내 그룹 목록 조회 (Mock API)",
+            summary = "내 그룹 목록 조회",
             description = """
                     내가 속한 그룹 목록을 조회합니다.
 
-                    Mock API 상태:
-                    - query parameter는 받지만 필터링과 페이징은 아직 수행하지 않습니다.
-                    - 항상 같은 그룹 목록 더미 응답을 반환합니다.
+                    - 로그인한 활성 회원만 사용할 수 있습니다.
+                    - 현재 회원이 `ACTIVE` 멤버로 속한 그룹만 반환합니다.
+                    - 삭제된 그룹은 목록에서 제외합니다.
+                    - 그룹 추천 구현 전까지 `latestRecommendationStatus`는 null일 수 있습니다.
                     """
     )
     @ApiResponses({
@@ -95,7 +97,7 @@ public interface GroupApi {
     })
     ApiResponse<PageResponse<GroupSummaryResponse>> getMyGroups(
             @Parameter(description = "그룹 상태 필터입니다. 생략하면 전체 상태를 조회합니다.", example = "ACTIVE")
-            String status,
+            GroupRoomStatus status,
 
             @Parameter(description = "0부터 시작하는 페이지 번호입니다.", example = "0")
             @Min(0)

--- a/src/main/java/matchuri/backend/api/group/GroupController.java
+++ b/src/main/java/matchuri/backend/api/group/GroupController.java
@@ -1,7 +1,8 @@
 package matchuri.backend.api.group;
 
 import jakarta.validation.Valid;
-import java.util.List;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.api.group.dto.request.CreateGroupRecommendationRequest;
 import matchuri.backend.api.group.dto.request.CreateGroupRequest;
@@ -19,10 +20,14 @@ import matchuri.backend.api.group.dto.response.GroupVoteResponse;
 import matchuri.backend.api.group.dto.response.JoinGroupResponse;
 import matchuri.backend.api.group.dto.response.LeaveGroupResponse;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
+import matchuri.backend.domain.group.command.GetMyGroupsCommand;
+import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.result.CreateGroupResult;
+import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.service.GroupService;
 import matchuri.backend.global.api.ApiResponse;
 import matchuri.backend.global.api.PageResponse;
+import org.springframework.data.domain.Page;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -54,14 +59,18 @@ public class GroupController implements GroupApi {
     @Override
     @GetMapping
     public ApiResponse<PageResponse<GroupSummaryResponse>> getMyGroups(
-            @RequestParam(required = false) String status,
-            @RequestParam(defaultValue = "0")
+            @RequestParam(required = false) GroupRoomStatus status,
+            @Min(0) @RequestParam(defaultValue = "0")
             Integer page,
 
-            @RequestParam(defaultValue = "20")
+            @Min(1) @Max(100) @RequestParam(defaultValue = "20")
             Integer size
     ) {
-        return ApiResponse.success(PageResponse.mock(List.of(GroupSummaryResponse.mockActive()), page, size, 1L));
+        GetMyGroupsCommand command = groupMapper.toGetMyGroupsCommand(status, page, size);
+        Page<GroupSummaryResult> results = groupService.getMyGroups(command);
+        PageResponse<GroupSummaryResponse> response = PageResponse.of(results, groupMapper::toGroupSummaryResponse);
+
+        return ApiResponse.success(response);
     }
 
     @Override

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -2,8 +2,12 @@ package matchuri.backend.api.group;
 
 import matchuri.backend.api.group.dto.request.CreateGroupRequest;
 import matchuri.backend.api.group.dto.response.CreateGroupResponse;
+import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
+import matchuri.backend.domain.group.command.GetMyGroupsCommand;
+import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.result.CreateGroupResult;
+import matchuri.backend.domain.group.result.GroupSummaryResult;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -21,6 +25,21 @@ public class GroupMapper {
         return new CreateGroupResponse(
                 result.groupId(),
                 result.status()
+        );
+    }
+
+    public GetMyGroupsCommand toGetMyGroupsCommand(GroupRoomStatus status, int page, int size) {
+        return new GetMyGroupsCommand(status, page, size);
+    }
+
+    public GroupSummaryResponse toGroupSummaryResponse(GroupSummaryResult result) {
+        return new GroupSummaryResponse(
+                result.id(),
+                result.name(),
+                result.status(),
+                result.memberCount(),
+                result.latestRecommendationStatus(),
+                result.createdAt()
         );
     }
 }

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -26,7 +26,7 @@ public final class GroupApiExamples {
                     "name": "오늘 점심 메뉴 회의",
                     "status": "ACTIVE",
                     "memberCount": 4,
-                    "latestRecommendationStatus": "OPEN",
+                    "latestRecommendationStatus": null,
                     "createdAt": "2026-05-06T12:00:00"
                   }
                 ],

--- a/src/main/java/matchuri/backend/domain/group/command/GetMyGroupsCommand.java
+++ b/src/main/java/matchuri/backend/domain/group/command/GetMyGroupsCommand.java
@@ -1,0 +1,10 @@
+package matchuri.backend.domain.group.command;
+
+import matchuri.backend.domain.group.entity.GroupRoomStatus;
+
+public record GetMyGroupsCommand(
+        GroupRoomStatus status,
+        int page,
+        int size
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRoomMemberCountProjection.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRoomMemberCountProjection.java
@@ -1,0 +1,8 @@
+package matchuri.backend.domain.group.repository;
+
+public interface GroupRoomMemberCountProjection {
+
+    Long getRoomId();
+
+    long getMemberCount();
+}

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRoomMemberRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRoomMemberRepository.java
@@ -1,7 +1,53 @@
 package matchuri.backend.domain.group.repository;
 
+import java.util.List;
 import matchuri.backend.domain.group.entity.GroupRoomMember;
+import matchuri.backend.domain.group.entity.GroupRoomStatus;
+import matchuri.backend.domain.group.entity.GroupMemberStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface GroupRoomMemberRepository extends JpaRepository<GroupRoomMember, Long> {
+
+    @Query(
+            value = """
+                    select groupMember
+                    from GroupRoomMember groupMember
+                    join fetch groupMember.room room
+                    where groupMember.member.id = :memberId
+                      and groupMember.status = matchuri.backend.domain.group.entity.GroupMemberStatus.ACTIVE
+                      and room.status <> matchuri.backend.domain.group.entity.GroupRoomStatus.DELETED
+                      and (:roomStatus is null or room.status = :roomStatus)
+                    order by room.createdAt desc, room.id desc
+                    """,
+            countQuery = """
+                    select count(groupMember)
+                    from GroupRoomMember groupMember
+                    join groupMember.room room
+                    where groupMember.member.id = :memberId
+                      and groupMember.status = matchuri.backend.domain.group.entity.GroupMemberStatus.ACTIVE
+                      and room.status <> matchuri.backend.domain.group.entity.GroupRoomStatus.DELETED
+                      and (:roomStatus is null or room.status = :roomStatus)
+                    """
+    )
+    Page<GroupRoomMember> findMyActiveMemberships(
+            @Param("memberId") Long memberId,
+            @Param("roomStatus") GroupRoomStatus roomStatus,
+            Pageable pageable
+    );
+
+    @Query("""
+            select groupMember.room.id as roomId, count(groupMember) as memberCount
+            from GroupRoomMember groupMember
+            where groupMember.room.id in :roomIds
+              and groupMember.status = :memberStatus
+            group by groupMember.room.id
+            """)
+    List<GroupRoomMemberCountProjection> countMembersByRoomIdsAndStatus(
+            @Param("roomIds") List<Long> roomIds,
+            @Param("memberStatus") GroupMemberStatus memberStatus
+    );
 }

--- a/src/main/java/matchuri/backend/domain/group/result/GroupSummaryResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupSummaryResult.java
@@ -1,0 +1,15 @@
+package matchuri.backend.domain.group.result;
+
+import java.time.LocalDateTime;
+import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
+import matchuri.backend.domain.group.entity.GroupRoomStatus;
+
+public record GroupSummaryResult(
+        Long id,
+        String name,
+        GroupRoomStatus status,
+        int memberCount,
+        GroupRecommendationStatus latestRecommendationStatus,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/service/GroupService.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupService.java
@@ -1,9 +1,14 @@
 package matchuri.backend.domain.group.service;
 
 import matchuri.backend.domain.group.command.CreateGroupCommand;
+import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.result.CreateGroupResult;
+import matchuri.backend.domain.group.result.GroupSummaryResult;
+import org.springframework.data.domain.Page;
 
 public interface GroupService {
 
     CreateGroupResult createGroup(CreateGroupCommand command);
+
+    Page<GroupSummaryResult> getMyGroups(GetMyGroupsCommand command);
 }

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -1,12 +1,24 @@
 package matchuri.backend.domain.group.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
+import matchuri.backend.domain.group.command.GetMyGroupsCommand;
+import matchuri.backend.domain.group.entity.GroupMemberStatus;
 import matchuri.backend.domain.group.entity.GroupRoom;
+import matchuri.backend.domain.group.entity.GroupRoomMember;
+import matchuri.backend.domain.group.repository.GroupRoomMemberCountProjection;
+import matchuri.backend.domain.group.repository.GroupRoomMemberRepository;
 import matchuri.backend.domain.group.repository.GroupRoomRepository;
 import matchuri.backend.domain.group.result.CreateGroupResult;
+import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.support.member.ActiveMemberReader;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +29,7 @@ public class GroupServiceImpl implements GroupService {
 
     private final ActiveMemberReader activeMemberReader;
     private final GroupRoomRepository groupRoomRepository;
+    private final GroupRoomMemberRepository groupRoomMemberRepository;
 
     @Override
     public CreateGroupResult createGroup(CreateGroupCommand command) {
@@ -31,5 +44,52 @@ public class GroupServiceImpl implements GroupService {
         GroupRoom savedGroupRoom = groupRoomRepository.save(groupRoom);
 
         return new CreateGroupResult(savedGroupRoom.getId(), savedGroupRoom.getStatus());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<@NonNull GroupSummaryResult> getMyGroups(GetMyGroupsCommand command) {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        Page<GroupRoomMember> memberships = groupRoomMemberRepository.findMyActiveMemberships(
+                member.getId(),
+                command.status(),
+                PageRequest.of(command.page(), command.size())
+        );
+        Map<Long, Long> activeMemberCounts = countActiveMembers(memberships);
+
+        return memberships.map(membership -> toSummaryResult(membership, activeMemberCounts));
+    }
+
+    private Map<Long, Long> countActiveMembers(Page<GroupRoomMember> memberships) {
+        List<Long> roomIds = memberships.getContent().stream()
+                .map(membership -> membership.getRoom().getId())
+                .toList();
+
+        if (roomIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return groupRoomMemberRepository.countMembersByRoomIdsAndStatus(roomIds, GroupMemberStatus.ACTIVE)
+                .stream()
+                .collect(Collectors.toMap(
+                        GroupRoomMemberCountProjection::getRoomId,
+                        GroupRoomMemberCountProjection::getMemberCount
+                ));
+    }
+
+    private GroupSummaryResult toSummaryResult(
+            GroupRoomMember membership,
+            Map<Long, Long> activeMemberCounts
+    ) {
+        GroupRoom room = membership.getRoom();
+
+        return new GroupSummaryResult(
+                room.getId(),
+                room.getName(),
+                room.getStatus(),
+                activeMemberCounts.getOrDefault(room.getId(), 0L).intValue(),
+                null,
+                room.getCreatedAt()
+        );
     }
 }

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -2,6 +2,7 @@ package matchuri.backend.api.group;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -10,10 +11,13 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Date;
 import javax.crypto.SecretKey;
 import matchuri.backend.domain.group.entity.GroupMemberRole;
 import matchuri.backend.domain.group.entity.GroupMemberStatus;
+import matchuri.backend.domain.group.entity.GroupRoom;
+import matchuri.backend.domain.group.entity.GroupRoomMember;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.repository.GroupRoomMemberRepository;
 import matchuri.backend.domain.group.repository.GroupRoomRepository;
@@ -132,6 +136,64 @@ class GroupIntegrationTest {
         assertThat(groupRoomMemberRepository.count()).isZero();
     }
 
+    @Test
+    @DisplayName("내 그룹 목록은 현재 회원이 활성 멤버인 삭제되지 않은 그룹만 조회한다")
+    void getMyGroupsReturnsActiveMembershipRoomsOnly() throws Exception {
+        Member member = saveMember("group-list-user", "목록사용자");
+        Member coworker = saveMember("group-coworker", "동료");
+        Member other = saveMember("other-owner", "다른방장");
+        GroupRoom visibleGroup = saveGroupOwnedBy(member, "같이 먹는 점심");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                visibleGroup,
+                coworker,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        GroupRoom deletedGroup = GroupRoom.createOwnedBy("삭제된 그룹", member, null, null);
+        deletedGroup.delete();
+        groupRoomRepository.save(deletedGroup);
+        GroupRoom leftGroup = saveGroupOwnedBy(member, "나간 그룹");
+        leaveOwnerMembership(leftGroup, member);
+        saveGroupOwnedBy(other, "다른 사람 그룹");
+
+        mockMvc.perform(get("/api/v1/groups")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member)))
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.content.length()").value(1))
+                .andExpect(jsonPath("$.data.content[0].id").value(visibleGroup.getId()))
+                .andExpect(jsonPath("$.data.content[0].name").value("같이 먹는 점심"))
+                .andExpect(jsonPath("$.data.content[0].status").value(GroupRoomStatus.ACTIVE.name()))
+                .andExpect(jsonPath("$.data.content[0].memberCount").value(2))
+                .andExpect(jsonPath("$.data.content[0].latestRecommendationStatus").value(nullValue()))
+                .andExpect(jsonPath("$.data.pageInfo.totalElements").value(1))
+                .andExpect(jsonPath("$.data.pageInfo.totalPages").value(1));
+    }
+
+    @Test
+    @DisplayName("내 그룹 목록은 그룹 상태 필터와 페이지네이션을 적용한다")
+    void getMyGroupsAppliesStatusFilterAndPagination() throws Exception {
+        Member member = saveMember("group-filter-user", "필터사용자");
+        saveGroupOwnedBy(member, "활성 그룹");
+        GroupRoom closedGroup = GroupRoom.createOwnedBy("닫힌 그룹", member, null, null);
+        closedGroup.close();
+        groupRoomRepository.save(closedGroup);
+
+        mockMvc.perform(get("/api/v1/groups")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member)))
+                        .param("status", GroupRoomStatus.CLOSED.name())
+                        .param("page", "0")
+                        .param("size", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content.length()").value(1))
+                .andExpect(jsonPath("$.data.content[0].id").value(closedGroup.getId()))
+                .andExpect(jsonPath("$.data.content[0].status").value(GroupRoomStatus.CLOSED.name()))
+                .andExpect(jsonPath("$.data.pageInfo.size").value(1))
+                .andExpect(jsonPath("$.data.pageInfo.totalElements").value(1));
+    }
+
     private Member saveMember(String loginId, String nickname) {
         return memberRepository.save(Member.builder()
                 .loginId(loginId)
@@ -143,6 +205,20 @@ class GroupIntegrationTest {
                 .memberRole(MemberRole.MEMBER)
                 .status(MemberStatus.ACTIVE)
                 .build());
+    }
+
+    private GroupRoom saveGroupOwnedBy(Member member, String name) {
+        return groupRoomRepository.save(GroupRoom.createOwnedBy(name, member, null, null));
+    }
+
+    private void leaveOwnerMembership(GroupRoom groupRoom, Member member) {
+        GroupRoomMember membership = groupRoomMemberRepository.findAll().stream()
+                .filter(candidate -> candidate.getRoom().getId().equals(groupRoom.getId()))
+                .filter(candidate -> candidate.getMember().getId().equals(member.getId()))
+                .findFirst()
+                .orElseThrow();
+        membership.leave(LocalDateTime.now());
+        groupRoomMemberRepository.save(membership);
     }
 
     private String bearer(String accessToken) {

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -1,5 +1,6 @@
 package matchuri.backend.global.docs;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -302,10 +303,10 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/groups'].post.responses['200'].content['application/json'].examples.success.value.data.groupId")
                         .value(3001))
                 .andExpect(jsonPath("$.paths['/api/v1/groups'].get.summary")
-                        .value("내 그룹 목록 조회 (Mock API)"))
+                        .value("내 그룹 목록 조회"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups'].get.responses['200'].content['application/json'].examples.success.value.data.content[0].latestRecommendationStatus")
-                        .value("OPEN"))
+                        .value(nullValue()))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}'].get.responses['200'].content['application/json'].examples.success.value.data.activeRecommendation.voteProgress.votedMemberCount")
                         .value(3))


### PR DESCRIPTION
## 관련 이슈
Closes #189 

## 📝 작업 내용
- `GET /api/v1/groups`를 mock 응답에서 실제 service 호출로 전환
- 현재 로그인 회원이 ACTIVE 멤버로 속한 그룹만 조회
- 삭제된 그룹은 제외
- page, size, 필요 시 status 필터 반영
- memberCount는 그룹별 ACTIVE 멤버 수로 계산
- latestRecommendationStatus는 아직 그룹 추천 전이라 null 허용

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항

### 응답 예시

```json
{
  "success": true,
  "data": {
    "content": [
      {
        "id": 3,
        "name": "오늘 점심 메뉴 회의 테스트 뀨",
        "status": "ACTIVE",
        "memberCount": 1,
        "latestRecommendationStatus": null,
        "createdAt": "2026-05-13T09:39:06.646187"
      },
      {
        "id": 2,
        "name": "오늘 점심 메뉴 회의 123",
        "status": "ACTIVE",
        "memberCount": 1,
        "latestRecommendationStatus": null,
        "createdAt": "2026-05-13T08:39:29.851286"
      },
      {
        "id": 1,
        "name": "오늘 점심 메뉴 회의 123",
        "status": "ACTIVE",
        "memberCount": 1,
        "latestRecommendationStatus": null,
        "createdAt": "2026-05-13T08:31:36.313872"
      }
    ],
    "pageInfo": {
      "page": 0,
      "size": 20,
      "totalElements": 3,
      "totalPages": 1,
      "first": true,
      "last": true,
      "hasNext": false,
      "hasPrevious": false
    }
  },
  "error": null
}
```
