### PR TITLE
[Feat] 그룹 상세 조회 API

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -110,13 +110,14 @@ public interface GroupApi {
     );
 
     @Operation(
-            summary = "그룹 상세 조회 (Mock API)",
+            summary = "그룹 상세 조회",
             description = """
                     그룹 방 상세와 현재 멤버, 진행 중인 그룹 추천 상태를 조회합니다.
 
-                    Mock API 상태:
-                    - `groupId` 존재 여부와 멤버 권한 검증은 아직 수행하지 않습니다.
-                    - 최신 스키마의 그룹 추천 저장 책임은 `group_recommendations` 기준입니다.
+                    - 로그인한 활성 회원만 사용할 수 있습니다.
+                    - 현재 회원이 해당 그룹의 `ACTIVE` 멤버일 때만 조회할 수 있습니다.
+                    - 삭제된 그룹은 조회할 수 없습니다.
+                    - 그룹 추천 구현 전까지 `activeRecommendation`은 null입니다.
                     """
     )
     @ApiResponses({

--- a/src/main/java/matchuri/backend/api/group/GroupController.java
+++ b/src/main/java/matchuri/backend/api/group/GroupController.java
@@ -23,6 +23,7 @@ import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.result.CreateGroupResult;
+import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.service.GroupService;
 import matchuri.backend.global.api.ApiResponse;
@@ -76,7 +77,9 @@ public class GroupController implements GroupApi {
     @Override
     @GetMapping("/{groupId}")
     public ApiResponse<GroupDetailResponse> getGroup(@PathVariable Long groupId) {
-        return ApiResponse.success(GroupDetailResponse.mockActive());
+        GroupDetailResult result = groupService.getGroup(groupId);
+
+        return ApiResponse.success(groupMapper.toGroupDetailResponse(result));
     }
 
     @Override

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -2,11 +2,15 @@ package matchuri.backend.api.group;
 
 import matchuri.backend.api.group.dto.request.CreateGroupRequest;
 import matchuri.backend.api.group.dto.response.CreateGroupResponse;
+import matchuri.backend.api.group.dto.response.GroupDetailResponse;
+import matchuri.backend.api.group.dto.response.GroupMemberSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.result.CreateGroupResult;
+import matchuri.backend.domain.group.result.GroupDetailResult;
+import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import org.springframework.stereotype.Component;
 
@@ -40,6 +44,30 @@ public class GroupMapper {
                 result.memberCount(),
                 result.latestRecommendationStatus(),
                 result.createdAt()
+        );
+    }
+
+    public GroupDetailResponse toGroupDetailResponse(GroupDetailResult result) {
+        return new GroupDetailResponse(
+                result.id(),
+                result.name(),
+                result.latitude(),
+                result.longitude(),
+                result.status(),
+                result.members().stream()
+                        .map(this::toGroupMemberSummaryResponse)
+                        .toList(),
+                null
+        );
+    }
+
+    private GroupMemberSummaryResponse toGroupMemberSummaryResponse(GroupMemberSummaryResult result) {
+        return new GroupMemberSummaryResponse(
+                result.memberId(),
+                result.nickname(),
+                result.role(),
+                result.status(),
+                result.joinedAt()
         );
     }
 }

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -84,42 +84,7 @@ public final class GroupApiExamples {
                     "joinedAt": "2026-05-06T12:02:00"
                   }
                 ],
-                "activeRecommendation": {
-                  "sessionId": 5001,
-                  "status": "OPEN",
-                  "candidates": [
-                    {
-                      "candidateId": 8001,
-                      "menuId": 1001,
-                      "menuName": "비빔밥",
-                      "rankNo": 1,
-                      "score": 91.5,
-                      "voteCount": 3
-                    },
-                    {
-                      "candidateId": 8002,
-                      "menuId": 1002,
-                      "menuName": "돈까스",
-                      "rankNo": 2,
-                      "score": 84.0,
-                      "voteCount": 1
-                    },
-                    {
-                      "candidateId": 8003,
-                      "menuId": 1003,
-                      "menuName": "쌀국수",
-                      "rankNo": 3,
-                      "score": 79.5,
-                      "voteCount": 0
-                    }
-                  ],
-                  "voteProgress": {
-                    "totalMemberCount": 4,
-                    "votedMemberCount": 3
-                  },
-                  "finalCandidate": null,
-                  "createdAt": "2026-05-06T12:05:00"
-                }
+                "activeRecommendation": null
               },
               "error": null
             }

--- a/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
@@ -10,18 +10,18 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum GroupErrorCode implements ErrorCode {
 
-    GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 그룹을 찾을 수 없습니다. groupId : {0}"),
-    GROUP_NOT_ACTIVE(HttpStatus.CONFLICT, "활성 상태의 그룹이 아닙니다. groupId : {0}"),
-    GROUP_ACCESS_DENIED(HttpStatus.FORBIDDEN, "그룹 접근 권한이 없습니다. groupId : {0}"),
-    GROUP_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "그룹 삭제 권한이 없습니다. groupId : {0}"),
-    GROUP_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 그룹의 활성 멤버를 찾을 수 없습니다. groupId : {0}, memberId : {1}"),
-    GROUP_MEMBER_ALREADY_LEFT(HttpStatus.CONFLICT, "이미 나간 그룹 멤버입니다. groupId : {0}, memberId : {1}"),
-    GROUP_OWNER_LEAVE_NOT_ALLOWED(HttpStatus.CONFLICT, "그룹 방장은 나가기 대신 그룹 삭제를 사용해야 합니다. groupId : {0}"),
-    GROUP_ALREADY_JOINED(HttpStatus.CONFLICT, "이미 참여 중인 그룹입니다. groupId : {0}, memberId : {1}"),
-    GROUP_INVITE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 그룹 초대 코드를 찾을 수 없습니다. inviteCode : {0}"),
-    GROUP_INVITE_EXPIRED(HttpStatus.CONFLICT, "만료된 그룹 초대 코드입니다. inviteCode : {0}"),
-    GROUP_INVITE_REVOKED(HttpStatus.CONFLICT, "취소된 그룹 초대 코드입니다. inviteCode : {0}"),
-    GROUP_INVITE_CODE_GENERATION_FAILED(HttpStatus.CONFLICT, "그룹 초대 코드 생성에 실패했습니다.");
+    NOT_FOUND(HttpStatus.NOT_FOUND, "해당 그룹을 찾을 수 없습니다. groupId : {0}"),
+    NOT_ACTIVE(HttpStatus.CONFLICT, "활성 상태의 그룹이 아닙니다. groupId : {0}"),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "그룹 접근 권한이 없습니다. groupId : {0}"),
+    DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "그룹 삭제 권한이 없습니다. groupId : {0}"),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 그룹의 활성 멤버를 찾을 수 없습니다. groupId : {0}, memberId : {1}"),
+    MEMBER_ALREADY_LEFT(HttpStatus.CONFLICT, "이미 나간 그룹 멤버입니다. groupId : {0}, memberId : {1}"),
+    OWNER_LEAVE_NOT_ALLOWED(HttpStatus.CONFLICT, "그룹 방장은 나가기 대신 그룹 삭제를 사용해야 합니다. groupId : {0}"),
+    ALREADY_JOINED(HttpStatus.CONFLICT, "이미 참여 중인 그룹입니다. groupId : {0}, memberId : {1}"),
+    INVITE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 그룹 초대 코드를 찾을 수 없습니다. inviteCode : {0}"),
+    INVITE_EXPIRED(HttpStatus.CONFLICT, "만료된 그룹 초대 코드입니다. inviteCode : {0}"),
+    INVITE_REVOKED(HttpStatus.CONFLICT, "취소된 그룹 초대 코드입니다. inviteCode : {0}"),
+    INVITE_CODE_GENERATION_FAILED(HttpStatus.CONFLICT, "그룹 초대 코드 생성에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRoomMemberRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRoomMemberRepository.java
@@ -50,4 +50,34 @@ public interface GroupRoomMemberRepository extends JpaRepository<GroupRoomMember
             @Param("roomIds") List<Long> roomIds,
             @Param("memberStatus") GroupMemberStatus memberStatus
     );
+
+    @Query("""
+            select count(groupMember) > 0
+            from GroupRoomMember groupMember
+            join groupMember.room room
+            where room.id = :roomId
+              and room.status <> matchuri.backend.domain.group.entity.GroupRoomStatus.DELETED
+              and groupMember.member.id = :memberId
+              and groupMember.status = matchuri.backend.domain.group.entity.GroupMemberStatus.ACTIVE
+            """)
+    boolean existsActiveMembershipInNotDeletedRoom(
+            @Param("roomId") Long roomId,
+            @Param("memberId") Long memberId
+    );
+
+    @Query("""
+            select groupMember
+            from GroupRoomMember groupMember
+            join fetch groupMember.member member
+            where groupMember.room.id = :roomId
+              and groupMember.status = matchuri.backend.domain.group.entity.GroupMemberStatus.ACTIVE
+            order by
+              case
+                when groupMember.role = matchuri.backend.domain.group.entity.GroupMemberRole.OWNER then 0
+                else 1
+              end,
+              groupMember.joinedAt asc,
+              groupMember.id asc
+            """)
+    List<GroupRoomMember> findActiveMembersByRoomId(@Param("roomId") Long roomId);
 }

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRoomRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRoomRepository.java
@@ -1,7 +1,11 @@
 package matchuri.backend.domain.group.repository;
 
+import java.util.Optional;
 import matchuri.backend.domain.group.entity.GroupRoom;
+import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GroupRoomRepository extends JpaRepository<GroupRoom, Long> {
+
+    Optional<GroupRoom> findByIdAndStatusNot(Long id, GroupRoomStatus status);
 }

--- a/src/main/java/matchuri/backend/domain/group/result/GroupDetailResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupDetailResult.java
@@ -1,0 +1,15 @@
+package matchuri.backend.domain.group.result;
+
+import java.math.BigDecimal;
+import java.util.List;
+import matchuri.backend.domain.group.entity.GroupRoomStatus;
+
+public record GroupDetailResult(
+        Long id,
+        String name,
+        BigDecimal latitude,
+        BigDecimal longitude,
+        GroupRoomStatus status,
+        List<GroupMemberSummaryResult> members
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/result/GroupMemberSummaryResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupMemberSummaryResult.java
@@ -1,0 +1,14 @@
+package matchuri.backend.domain.group.result;
+
+import java.time.LocalDateTime;
+import matchuri.backend.domain.group.entity.GroupMemberRole;
+import matchuri.backend.domain.group.entity.GroupMemberStatus;
+
+public record GroupMemberSummaryResult(
+        Long memberId,
+        String nickname,
+        GroupMemberRole role,
+        GroupMemberStatus status,
+        LocalDateTime joinedAt
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/service/GroupService.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupService.java
@@ -3,6 +3,7 @@ package matchuri.backend.domain.group.service;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.result.CreateGroupResult;
+import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import org.springframework.data.domain.Page;
 
@@ -11,4 +12,6 @@ public interface GroupService {
     CreateGroupResult createGroup(CreateGroupCommand command);
 
     Page<GroupSummaryResult> getMyGroups(GetMyGroupsCommand command);
+
+    GroupDetailResult getGroup(Long groupId);
 }

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -9,13 +9,18 @@ import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.entity.GroupMemberStatus;
 import matchuri.backend.domain.group.entity.GroupRoom;
 import matchuri.backend.domain.group.entity.GroupRoomMember;
+import matchuri.backend.domain.group.entity.GroupRoomStatus;
+import matchuri.backend.domain.group.exception.GroupErrorCode;
 import matchuri.backend.domain.group.repository.GroupRoomMemberCountProjection;
 import matchuri.backend.domain.group.repository.GroupRoomMemberRepository;
 import matchuri.backend.domain.group.repository.GroupRoomRepository;
 import matchuri.backend.domain.group.result.CreateGroupResult;
+import matchuri.backend.domain.group.result.GroupDetailResult;
+import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.support.member.ActiveMemberReader;
+import matchuri.backend.global.exception.BusinessException;
 import org.jspecify.annotations.NonNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -60,6 +65,32 @@ public class GroupServiceImpl implements GroupService {
         return memberships.map(membership -> toSummaryResult(membership, activeMemberCounts));
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public GroupDetailResult getGroup(Long groupId) {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        GroupRoom room = groupRoomRepository.findByIdAndStatusNot(groupId, GroupRoomStatus.DELETED)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.NOT_FOUND, groupId));
+
+        if (!groupRoomMemberRepository.existsActiveMembershipInNotDeletedRoom(groupId, member.getId())) {
+            throw new BusinessException(GroupErrorCode.ACCESS_DENIED, groupId);
+        }
+
+        List<GroupMemberSummaryResult> members = groupRoomMemberRepository.findActiveMembersByRoomId(groupId)
+                .stream()
+                .map(this::toMemberSummaryResult)
+                .toList();
+
+        return new GroupDetailResult(
+                room.getId(),
+                room.getName(),
+                room.getLatitude(),
+                room.getLongitude(),
+                room.getStatus(),
+                members
+        );
+    }
+
     private Map<Long, Long> countActiveMembers(Page<GroupRoomMember> memberships) {
         List<Long> roomIds = memberships.getContent().stream()
                 .map(membership -> membership.getRoom().getId())
@@ -90,6 +121,18 @@ public class GroupServiceImpl implements GroupService {
                 activeMemberCounts.getOrDefault(room.getId(), 0L).intValue(),
                 null,
                 room.getCreatedAt()
+        );
+    }
+
+    private GroupMemberSummaryResult toMemberSummaryResult(GroupRoomMember membership) {
+        Member member = membership.getMember();
+
+        return new GroupMemberSummaryResult(
+                member.getId(),
+                member.getNickname(),
+                membership.getRole(),
+                membership.getStatus(),
+                membership.getJoinedAt()
         );
     }
 }

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -194,6 +194,70 @@ class GroupIntegrationTest {
                 .andExpect(jsonPath("$.data.pageInfo.totalElements").value(1));
     }
 
+    @Test
+    @DisplayName("그룹 상세 조회는 활성 멤버에게 그룹과 활성 멤버 목록을 반환한다")
+    void getGroupReturnsDetailAndActiveMembers() throws Exception {
+        Member owner = saveMember("detail-owner", "상세방장");
+        Member activeMember = saveMember("detail-member", "상세멤버");
+        Member leftMember = saveMember("detail-left", "나간멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "상세 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                activeMember,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        GroupRoomMember leftMembership = groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                leftMember,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        leftMembership.leave(LocalDateTime.now());
+        groupRoomMemberRepository.save(leftMembership);
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(groupRoom.getId()))
+                .andExpect(jsonPath("$.data.name").value("상세 그룹"))
+                .andExpect(jsonPath("$.data.status").value(GroupRoomStatus.ACTIVE.name()))
+                .andExpect(jsonPath("$.data.members.length()").value(2))
+                .andExpect(jsonPath("$.data.members[0].memberId").value(owner.getId()))
+                .andExpect(jsonPath("$.data.members[0].nickname").value("상세방장"))
+                .andExpect(jsonPath("$.data.members[0].role").value(GroupMemberRole.OWNER.name()))
+                .andExpect(jsonPath("$.data.members[1].memberId").value(activeMember.getId()))
+                .andExpect(jsonPath("$.data.members[1].nickname").value("상세멤버"))
+                .andExpect(jsonPath("$.data.activeRecommendation").value(nullValue()));
+    }
+
+    @Test
+    @DisplayName("그룹 상세 조회는 비멤버 접근을 거절한다")
+    void getGroupFailsForNonMember() throws Exception {
+        Member owner = saveMember("forbidden-owner", "권한방장");
+        Member other = saveMember("forbidden-other", "권한없음");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "권한 그룹");
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(other))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("GROUP_ACCESS_DENIED"));
+    }
+
+    @Test
+    @DisplayName("그룹 상세 조회는 삭제된 그룹을 찾을 수 없음으로 처리한다")
+    void getGroupFailsForDeletedGroup() throws Exception {
+        Member owner = saveMember("deleted-detail-owner", "삭제상세방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "삭제 상세 그룹");
+        groupRoom.delete();
+        groupRoomRepository.save(groupRoom);
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("GROUP_NOT_FOUND"));
+    }
+
     private Member saveMember(String loginId, String nickname) {
         return memberRepository.save(Member.builder()
                 .loginId(loginId)

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -308,8 +308,8 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/groups'].get.responses['200'].content['application/json'].examples.success.value.data.content[0].latestRecommendationStatus")
                         .value(nullValue()))
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/groups/{groupId}'].get.responses['200'].content['application/json'].examples.success.value.data.activeRecommendation.voteProgress.votedMemberCount")
-                        .value(3))
+                        "$.paths['/api/v1/groups/{groupId}'].get.responses['200'].content['application/json'].examples.success.value.data.activeRecommendation")
+                        .value(nullValue()))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}/invites'].post.responses['200'].content['application/json'].examples.success.value.data.inviteCode")
                         .value("LUNCH42"))


### PR DESCRIPTION
## 관련 이슈
Closes #190 

## 📝 작업 내용
- `GET /api/v1/groups/{groupId}` 추가
- 현재 로그인한 사용자가 해당 그룹의 `ACTIVE` 멤버일 때만 조회
- 삭제된 그룹은 `GROUP_NOT_FOUND`, 비멤버나 LEFT 멤버는 `GROUP_ACCESS_DENIED`로 처리

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항

```json
{
  "success": true,
  "data": {
    "id": 2,
    "name": "오늘 점심 메뉴 회의2",
    "latitude": 37.498095,
    "longitude": 127.02761,
    "status": "ACTIVE",
    "members": [
      {
        "memberId": 3,
        "nickname": "matchuri-admin",
        "role": "OWNER",
        "status": "ACTIVE",
        "joinedAt": "2026-05-14T15:05:17.532447"
      }
    ],
    "activeRecommendation": null
  },
  "error": null
}

```