### PR TITLE
[Feat] 그룹 초대 코드 생성 API

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -137,12 +137,14 @@ public interface GroupApi {
     ApiResponse<GroupDetailResponse> getGroup(Long groupId);
 
     @Operation(
-            summary = "그룹 초대 코드 생성 (Mock API)",
+            summary = "그룹 초대 코드 생성",
             description = """
                     그룹에 참여할 수 있는 초대 코드를 생성합니다.
 
-                    Mock API 상태:
-                    - 그룹 멤버 권한과 만료 정책 저장은 아직 수행하지 않습니다.
+                    구현 기준:
+                    - `OWNER` 역할의 활성 멤버만 초대 코드를 생성할 수 있습니다.
+                    - 그룹이 `ACTIVE` 상태일 때만 생성할 수 있습니다.
+                    - 초대 코드는 생성 시점부터 24시간 뒤 만료됩니다.
                     - 실제 저장 테이블은 `group_invites` 기준입니다.
                     """
     )

--- a/src/main/java/matchuri/backend/api/group/GroupController.java
+++ b/src/main/java/matchuri/backend/api/group/GroupController.java
@@ -20,8 +20,10 @@ import matchuri.backend.api.group.dto.response.GroupVoteResponse;
 import matchuri.backend.api.group.dto.response.JoinGroupResponse;
 import matchuri.backend.api.group.dto.response.LeaveGroupResponse;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
+import matchuri.backend.domain.group.command.CreateGroupInviteCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
+import matchuri.backend.domain.group.result.CreateGroupInviteResult;
 import matchuri.backend.domain.group.result.CreateGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
@@ -85,7 +87,10 @@ public class GroupController implements GroupApi {
     @Override
     @PostMapping("/{groupId}/invites")
     public ApiResponse<CreateGroupInviteResponse> createInvite(@PathVariable Long groupId) {
-        return ApiResponse.success(CreateGroupInviteResponse.mockActive());
+        CreateGroupInviteCommand command = groupMapper.toCreateGroupInviteCommand(groupId);
+        CreateGroupInviteResult result = groupService.createInvite(command);
+
+        return ApiResponse.success(groupMapper.toCreateGroupInviteResponse(result));
     }
 
     @Override

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -1,13 +1,16 @@
 package matchuri.backend.api.group;
 
 import matchuri.backend.api.group.dto.request.CreateGroupRequest;
+import matchuri.backend.api.group.dto.response.CreateGroupInviteResponse;
 import matchuri.backend.api.group.dto.response.CreateGroupResponse;
 import matchuri.backend.api.group.dto.response.GroupDetailResponse;
 import matchuri.backend.api.group.dto.response.GroupMemberSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
+import matchuri.backend.domain.group.command.CreateGroupInviteCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
+import matchuri.backend.domain.group.result.CreateGroupInviteResult;
 import matchuri.backend.domain.group.result.CreateGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
@@ -28,6 +31,19 @@ public class GroupMapper {
     public CreateGroupResponse toCreateGroupResponse(CreateGroupResult result) {
         return new CreateGroupResponse(
                 result.groupId(),
+                result.status()
+        );
+    }
+
+    public CreateGroupInviteCommand toCreateGroupInviteCommand(Long groupId) {
+        return new CreateGroupInviteCommand(groupId);
+    }
+
+    public CreateGroupInviteResponse toCreateGroupInviteResponse(CreateGroupInviteResult result) {
+        return new CreateGroupInviteResponse(
+                result.groupId(),
+                result.inviteCode(),
+                result.expiresAt(),
                 result.status()
         );
     }

--- a/src/main/java/matchuri/backend/domain/group/command/CreateGroupInviteCommand.java
+++ b/src/main/java/matchuri/backend/domain/group/command/CreateGroupInviteCommand.java
@@ -1,0 +1,4 @@
+package matchuri.backend.domain.group.command;
+
+public record CreateGroupInviteCommand(Long groupId) {
+}

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRoom.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRoom.java
@@ -17,6 +17,7 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -84,5 +85,17 @@ public class GroupRoom extends BaseEntity {
 
     public void delete() {
         this.status = GroupRoomStatus.DELETED;
+    }
+
+    public boolean isActive() {
+        return this.status == GroupRoomStatus.ACTIVE;
+    }
+
+    public GroupRoomMember getGroupRoomHostMember() {
+        Long hostMemberId = this.hostMember.getId();
+        return this.groupRoomMembers.stream()
+                .filter(groupRoomMember -> Objects.equals(groupRoomMember.getMember().getId(), hostMemberId))
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRoomMember.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRoomMember.java
@@ -75,4 +75,8 @@ public class GroupRoomMember extends BaseEntity {
         this.status = GroupMemberStatus.KICKED;
         this.leftAt = leftAt;
     }
+
+    public boolean isOwner() {
+        return this.role == GroupMemberRole.OWNER;
+    }
 }

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupInviteRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupInviteRepository.java
@@ -1,0 +1,9 @@
+package matchuri.backend.domain.group.repository;
+
+import matchuri.backend.domain.group.entity.GroupInvite;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupInviteRepository extends JpaRepository<GroupInvite, Long> {
+
+    boolean existsByInviteCode(String inviteCode);
+}

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRoomMemberRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRoomMemberRepository.java
@@ -1,6 +1,7 @@
 package matchuri.backend.domain.group.repository;
 
 import java.util.List;
+import java.util.Optional;
 import matchuri.backend.domain.group.entity.GroupRoomMember;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.entity.GroupMemberStatus;
@@ -61,6 +62,20 @@ public interface GroupRoomMemberRepository extends JpaRepository<GroupRoomMember
               and groupMember.status = matchuri.backend.domain.group.entity.GroupMemberStatus.ACTIVE
             """)
     boolean existsActiveMembershipInNotDeletedRoom(
+            @Param("roomId") Long roomId,
+            @Param("memberId") Long memberId
+    );
+
+    @Query("""
+            select groupMember
+            from GroupRoomMember groupMember
+            join groupMember.room room
+            where room.id = :roomId
+              and room.status <> matchuri.backend.domain.group.entity.GroupRoomStatus.DELETED
+              and groupMember.member.id = :memberId
+              and groupMember.status = matchuri.backend.domain.group.entity.GroupMemberStatus.ACTIVE
+            """)
+    Optional<GroupRoomMember> findActiveMembershipInNotDeletedRoom(
             @Param("roomId") Long roomId,
             @Param("memberId") Long memberId
     );

--- a/src/main/java/matchuri/backend/domain/group/result/CreateGroupInviteResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/CreateGroupInviteResult.java
@@ -1,0 +1,12 @@
+package matchuri.backend.domain.group.result;
+
+import java.time.LocalDateTime;
+import matchuri.backend.domain.group.entity.GroupInviteStatus;
+
+public record CreateGroupInviteResult(
+        Long groupId,
+        String inviteCode,
+        LocalDateTime expiresAt,
+        GroupInviteStatus status
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/service/GroupService.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupService.java
@@ -1,7 +1,9 @@
 package matchuri.backend.domain.group.service;
 
 import matchuri.backend.domain.group.command.CreateGroupCommand;
+import matchuri.backend.domain.group.command.CreateGroupInviteCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
+import matchuri.backend.domain.group.result.CreateGroupInviteResult;
 import matchuri.backend.domain.group.result.CreateGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
@@ -10,6 +12,8 @@ import org.springframework.data.domain.Page;
 public interface GroupService {
 
     CreateGroupResult createGroup(CreateGroupCommand command);
+
+    CreateGroupInviteResult createInvite(CreateGroupInviteCommand command);
 
     Page<GroupSummaryResult> getMyGroups(GetMyGroupsCommand command);
 

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -67,7 +67,7 @@ public class GroupServiceImpl implements GroupService {
     @Override
     public CreateGroupInviteResult createInvite(CreateGroupInviteCommand command) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
-        GroupRoom room = groupRoomRepository.findById(command.groupId())
+        GroupRoom room = groupRoomRepository.findByIdAndStatusNot(command.groupId(), GroupRoomStatus.DELETED)
                 .orElseThrow(() -> new BusinessException(GroupErrorCode.NOT_FOUND, command.groupId()));
 
         if (!room.isActive()) {

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -3,6 +3,7 @@ package matchuri.backend.domain.group.service;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
@@ -66,18 +67,23 @@ public class GroupServiceImpl implements GroupService {
     @Override
     public CreateGroupInviteResult createInvite(CreateGroupInviteCommand command) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
-        GroupRoom room = groupRoomRepository.findByIdAndStatusNot(command.groupId(), GroupRoomStatus.DELETED)
+        GroupRoom room = groupRoomRepository.findById(command.groupId())
                 .orElseThrow(() -> new BusinessException(GroupErrorCode.NOT_FOUND, command.groupId()));
 
-        if (room.getStatus() != GroupRoomStatus.ACTIVE) {
+        if (!room.isActive()) {
             throw new BusinessException(GroupErrorCode.NOT_ACTIVE, command.groupId());
         }
 
-        GroupRoomMember membership = groupRoomMemberRepository
-                .findActiveMembershipInNotDeletedRoom(command.groupId(), member.getId())
-                .orElseThrow(() -> new BusinessException(GroupErrorCode.ACCESS_DENIED, command.groupId()));
+        long memberId = member.getId();
+        long hostMemberId = room.getHostMember().getId();
 
-        if (membership.getRole() != GroupMemberRole.OWNER) {
+        if (memberId != hostMemberId) {
+            throw new BusinessException(GroupErrorCode.ACCESS_DENIED, command.groupId());
+        }
+
+        GroupRoomMember membership = room.getGroupRoomHostMember();
+
+        if (!membership.isOwner()) {
             throw new BusinessException(GroupErrorCode.ACCESS_DENIED, command.groupId());
         }
 

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -1,23 +1,30 @@
 package matchuri.backend.domain.group.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
+import matchuri.backend.domain.group.command.CreateGroupInviteCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
+import matchuri.backend.domain.group.entity.GroupInvite;
+import matchuri.backend.domain.group.entity.GroupMemberRole;
 import matchuri.backend.domain.group.entity.GroupMemberStatus;
 import matchuri.backend.domain.group.entity.GroupRoom;
 import matchuri.backend.domain.group.entity.GroupRoomMember;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.exception.GroupErrorCode;
+import matchuri.backend.domain.group.repository.GroupInviteRepository;
 import matchuri.backend.domain.group.repository.GroupRoomMemberCountProjection;
 import matchuri.backend.domain.group.repository.GroupRoomMemberRepository;
 import matchuri.backend.domain.group.repository.GroupRoomRepository;
+import matchuri.backend.domain.group.result.CreateGroupInviteResult;
 import matchuri.backend.domain.group.result.CreateGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
+import matchuri.backend.domain.group.support.GroupInviteCodeGenerator;
 import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.support.member.ActiveMemberReader;
 import matchuri.backend.global.exception.BusinessException;
@@ -32,9 +39,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class GroupServiceImpl implements GroupService {
 
+    private static final int INVITE_EXPIRATION_HOURS = 24;
+    private static final int MAX_INVITE_CODE_GENERATION_ATTEMPTS = 5;
+
     private final ActiveMemberReader activeMemberReader;
     private final GroupRoomRepository groupRoomRepository;
     private final GroupRoomMemberRepository groupRoomMemberRepository;
+    private final GroupInviteRepository groupInviteRepository;
+    private final GroupInviteCodeGenerator groupInviteCodeGenerator;
 
     @Override
     public CreateGroupResult createGroup(CreateGroupCommand command) {
@@ -49,6 +61,35 @@ public class GroupServiceImpl implements GroupService {
         GroupRoom savedGroupRoom = groupRoomRepository.save(groupRoom);
 
         return new CreateGroupResult(savedGroupRoom.getId(), savedGroupRoom.getStatus());
+    }
+
+    @Override
+    public CreateGroupInviteResult createInvite(CreateGroupInviteCommand command) {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        GroupRoom room = groupRoomRepository.findByIdAndStatusNot(command.groupId(), GroupRoomStatus.DELETED)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.NOT_FOUND, command.groupId()));
+
+        if (room.getStatus() != GroupRoomStatus.ACTIVE) {
+            throw new BusinessException(GroupErrorCode.NOT_ACTIVE, command.groupId());
+        }
+
+        GroupRoomMember membership = groupRoomMemberRepository
+                .findActiveMembershipInNotDeletedRoom(command.groupId(), member.getId())
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.ACCESS_DENIED, command.groupId()));
+
+        if (membership.getRole() != GroupMemberRole.OWNER) {
+            throw new BusinessException(GroupErrorCode.ACCESS_DENIED, command.groupId());
+        }
+
+        LocalDateTime expiresAt = LocalDateTime.now().plusHours(INVITE_EXPIRATION_HOURS);
+        GroupInvite groupInvite = createUniqueInvite(room, member, expiresAt);
+
+        return new CreateGroupInviteResult(
+                room.getId(),
+                groupInvite.getInviteCode(),
+                groupInvite.getExpiresAt(),
+                groupInvite.getStatus()
+        );
     }
 
     @Override
@@ -122,6 +163,18 @@ public class GroupServiceImpl implements GroupService {
                 null,
                 room.getCreatedAt()
         );
+    }
+
+    private GroupInvite createUniqueInvite(GroupRoom room, Member member, LocalDateTime expiresAt) {
+        for (int attempt = 0; attempt < MAX_INVITE_CODE_GENERATION_ATTEMPTS; attempt++) {
+            String inviteCode = groupInviteCodeGenerator.generate();
+
+            if (!groupInviteRepository.existsByInviteCode(inviteCode)) {
+                return groupInviteRepository.save(new GroupInvite(room, member, inviteCode, expiresAt));
+            }
+        }
+
+        throw new BusinessException(GroupErrorCode.INVITE_CODE_GENERATION_FAILED);
     }
 
     private GroupMemberSummaryResult toMemberSummaryResult(GroupRoomMember membership) {

--- a/src/main/java/matchuri/backend/domain/group/support/GroupInviteCodeGenerator.java
+++ b/src/main/java/matchuri/backend/domain/group/support/GroupInviteCodeGenerator.java
@@ -1,0 +1,23 @@
+package matchuri.backend.domain.group.support;
+
+import java.security.SecureRandom;
+import org.springframework.stereotype.Component;
+
+@Component
+    public class GroupInviteCodeGenerator {
+
+        private static final String ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+        private static final int CODE_LENGTH = 8;
+
+        private final SecureRandom secureRandom = new SecureRandom();
+
+        public String generate() {
+            StringBuilder code = new StringBuilder(CODE_LENGTH);
+
+        for (int index = 0; index < CODE_LENGTH; index++) {
+            code.append(ALPHABET.charAt(secureRandom.nextInt(ALPHABET.length())));
+        }
+
+        return code.toString();
+    }
+}

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -19,6 +19,7 @@ import matchuri.backend.domain.group.entity.GroupMemberStatus;
 import matchuri.backend.domain.group.entity.GroupRoom;
 import matchuri.backend.domain.group.entity.GroupRoomMember;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
+import matchuri.backend.domain.group.repository.GroupInviteRepository;
 import matchuri.backend.domain.group.repository.GroupRoomMemberRepository;
 import matchuri.backend.domain.group.repository.GroupRoomRepository;
 import matchuri.backend.domain.member.entity.Member;
@@ -59,6 +60,9 @@ class GroupIntegrationTest {
     @Autowired
     private GroupRoomMemberRepository groupRoomMemberRepository;
 
+    @Autowired
+    private GroupInviteRepository groupInviteRepository;
+
     @BeforeEach
     void setUp() {
         clearData();
@@ -70,6 +74,7 @@ class GroupIntegrationTest {
     }
 
     private void clearData() {
+        groupInviteRepository.deleteAll();
         groupRoomMemberRepository.deleteAll();
         groupRoomRepository.deleteAll();
         memberRepository.deleteAll();
@@ -256,6 +261,85 @@ class GroupIntegrationTest {
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.error.code").value("GROUP_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("그룹 초대 코드 생성은 OWNER가 활성 초대를 저장하고 반환한다")
+    void createInviteCreatesActiveInviteForOwner() throws Exception {
+        Member owner = saveMember("invite-owner", "초대방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "초대 그룹");
+        LocalDateTime beforeExpectedExpiry = LocalDateTime.now().plusHours(24);
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/invites", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.groupId").value(groupRoom.getId()))
+                .andExpect(jsonPath("$.data.inviteCode").isString())
+                .andExpect(jsonPath("$.data.expiresAt").isNotEmpty())
+                .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+
+        LocalDateTime afterExpectedExpiry = LocalDateTime.now().plusHours(24);
+        var savedInvite = groupInviteRepository.findAll().getFirst();
+
+        assertThat(savedInvite.getRoom().getId()).isEqualTo(groupRoom.getId());
+        assertThat(savedInvite.getCreatedByMember().getId()).isEqualTo(owner.getId());
+        assertThat(savedInvite.getInviteCode()).hasSize(8);
+        assertThat(savedInvite.getExpiresAt()).isBetween(beforeExpectedExpiry, afterExpectedExpiry);
+        assertThat(savedInvite.getStatus().name()).isEqualTo("ACTIVE");
+    }
+
+    @Test
+    @DisplayName("그룹 초대 코드 생성은 OWNER가 아니면 거절한다")
+    void createInviteFailsForNonOwnerMember() throws Exception {
+        Member owner = saveMember("invite-non-owner-host", "초대방장2");
+        Member member = saveMember("invite-non-owner-member", "초대멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "멤버 초대 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                member,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/invites", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("GROUP_ACCESS_DENIED"));
+
+        assertThat(groupInviteRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("그룹 초대 코드 생성은 활성 상태가 아닌 그룹이면 실패한다")
+    void createInviteFailsForNotActiveGroup() throws Exception {
+        Member owner = saveMember("closed-invite-owner", "닫힌초대방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "닫힌 초대 그룹");
+        groupRoom.close();
+        groupRoomRepository.save(groupRoom);
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/invites", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("GROUP_NOT_ACTIVE"));
+
+        assertThat(groupInviteRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("그룹 초대 코드 생성은 삭제된 그룹이면 찾을 수 없음으로 처리한다")
+    void createInviteFailsForDeletedGroup() throws Exception {
+        Member owner = saveMember("deleted-invite-owner", "삭제초대방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "삭제 초대 그룹");
+        groupRoom.delete();
+        groupRoomRepository.save(groupRoom);
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/invites", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("GROUP_NOT_FOUND"));
+
+        assertThat(groupInviteRepository.count()).isZero();
     }
 
     private Member saveMember(String loginId, String nickname) {


### PR DESCRIPTION
## 관련 이슈
Closes #191 

## 📝 작업 내용
- `POST /api/v1/groups/{groupId}/invites` 추가

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [ ] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [ ] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [ ] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [ ] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항

- 초대 코드는 그룹의 `OWNER`만 생성 가능
- 초대 코드는 중복되지 않으며 중복 방지를 위해 현재 최대 5번 loop로 초대코드를 생성한다.
- 초대 코드는 8자 영문 + 숫자 조합
- 요청값은 swagger-ui 참고

### 응답 결과

```json
{
  "success": true,
  "data": {
    "groupId": 3,
    "inviteCode": "45LVVDXE",
    "expiresAt": "2026-05-16T08:24:29.9915963",
    "status": "ACTIVE"
  },
  "error": null
}
```