### PR TITLE
[Feat] 초대 코드 그룹 입장 API 구현

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -165,13 +165,15 @@ public interface GroupApi {
     ApiResponse<CreateGroupInviteResponse> createInvite(Long groupId);
 
     @Operation(
-            summary = "초대 코드로 그룹 참여 (Mock API)",
+            summary = "초대 코드로 그룹 참여",
             description = """
                     초대 코드로 그룹에 참여합니다.
 
-                    Mock API 상태:
-                    - 초대 코드 존재 여부, 만료 여부, 중복 가입 검증은 아직 수행하지 않습니다.
-                    - request body validation만 수행합니다.
+                    구현 기준:
+                    - 초대 코드 존재 여부, 취소 여부, 만료 여부를 검증합니다.
+                    - 연결된 그룹이 `ACTIVE` 상태일 때만 참여할 수 있습니다.
+                    - 이미 `ACTIVE` 멤버이면 중복 참여로 실패합니다.
+                    - 과거 `LEFT` 멤버는 기존 membership을 재활성화합니다.
                     """
     )
     @ApiResponses({

--- a/src/main/java/matchuri/backend/api/group/GroupController.java
+++ b/src/main/java/matchuri/backend/api/group/GroupController.java
@@ -22,11 +22,13 @@ import matchuri.backend.api.group.dto.response.LeaveGroupResponse;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.CreateGroupInviteCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
+import matchuri.backend.domain.group.command.JoinGroupCommand;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.result.CreateGroupInviteResult;
 import matchuri.backend.domain.group.result.CreateGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
+import matchuri.backend.domain.group.result.JoinGroupResult;
 import matchuri.backend.domain.group.service.GroupService;
 import matchuri.backend.global.api.ApiResponse;
 import matchuri.backend.global.api.PageResponse;
@@ -96,7 +98,10 @@ public class GroupController implements GroupApi {
     @Override
     @PostMapping("/join")
     public ApiResponse<JoinGroupResponse> joinGroup(@Valid @RequestBody JoinGroupRequest request) {
-        return ApiResponse.success(JoinGroupResponse.mockJoined());
+        JoinGroupCommand command = groupMapper.toJoinGroupCommand(request);
+        JoinGroupResult result = groupService.joinGroup(command);
+
+        return ApiResponse.success(groupMapper.toJoinGroupResponse(result));
     }
 
     @Override

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -1,20 +1,24 @@
 package matchuri.backend.api.group;
 
 import matchuri.backend.api.group.dto.request.CreateGroupRequest;
+import matchuri.backend.api.group.dto.request.JoinGroupRequest;
 import matchuri.backend.api.group.dto.response.CreateGroupInviteResponse;
 import matchuri.backend.api.group.dto.response.CreateGroupResponse;
 import matchuri.backend.api.group.dto.response.GroupDetailResponse;
 import matchuri.backend.api.group.dto.response.GroupMemberSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
+import matchuri.backend.api.group.dto.response.JoinGroupResponse;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.CreateGroupInviteCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
+import matchuri.backend.domain.group.command.JoinGroupCommand;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.result.CreateGroupInviteResult;
 import matchuri.backend.domain.group.result.CreateGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
+import matchuri.backend.domain.group.result.JoinGroupResult;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -45,6 +49,17 @@ public class GroupMapper {
                 result.inviteCode(),
                 result.expiresAt(),
                 result.status()
+        );
+    }
+
+    public JoinGroupCommand toJoinGroupCommand(JoinGroupRequest request) {
+        return new JoinGroupCommand(request.inviteCode());
+    }
+
+    public JoinGroupResponse toJoinGroupResponse(JoinGroupResult result) {
+        return new JoinGroupResponse(
+                result.groupId(),
+                result.memberStatus()
         );
     }
 

--- a/src/main/java/matchuri/backend/domain/group/command/JoinGroupCommand.java
+++ b/src/main/java/matchuri/backend/domain/group/command/JoinGroupCommand.java
@@ -1,0 +1,4 @@
+package matchuri.backend.domain.group.command;
+
+public record JoinGroupCommand(String inviteCode) {
+}

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRoomMember.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRoomMember.java
@@ -76,6 +76,12 @@ public class GroupRoomMember extends BaseEntity {
         this.leftAt = leftAt;
     }
 
+    public void rejoin(LocalDateTime joinedAt) {
+        this.status = GroupMemberStatus.ACTIVE;
+        this.joinedAt = joinedAt;
+        this.leftAt = null;
+    }
+
     public boolean isOwner() {
         return this.role == GroupMemberRole.OWNER;
     }

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupInviteRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupInviteRepository.java
@@ -1,9 +1,20 @@
 package matchuri.backend.domain.group.repository;
 
+import java.util.Optional;
 import matchuri.backend.domain.group.entity.GroupInvite;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface GroupInviteRepository extends JpaRepository<GroupInvite, Long> {
 
     boolean existsByInviteCode(String inviteCode);
+
+    @Query("""
+            select groupInvite
+            from GroupInvite groupInvite
+            join fetch groupInvite.room room
+            where groupInvite.inviteCode = :inviteCode
+            """)
+    Optional<GroupInvite> findByInviteCodeWithRoom(@Param("inviteCode") String inviteCode);
 }

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRoomMemberRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRoomMemberRepository.java
@@ -80,6 +80,8 @@ public interface GroupRoomMemberRepository extends JpaRepository<GroupRoomMember
             @Param("memberId") Long memberId
     );
 
+    Optional<GroupRoomMember> findByRoomIdAndMemberId(Long roomId, Long memberId);
+
     @Query("""
             select groupMember
             from GroupRoomMember groupMember

--- a/src/main/java/matchuri/backend/domain/group/result/JoinGroupResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/JoinGroupResult.java
@@ -1,0 +1,9 @@
+package matchuri.backend.domain.group.result;
+
+import matchuri.backend.domain.group.entity.GroupMemberStatus;
+
+public record JoinGroupResult(
+        Long groupId,
+        GroupMemberStatus memberStatus
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/service/GroupService.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupService.java
@@ -3,10 +3,12 @@ package matchuri.backend.domain.group.service;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.CreateGroupInviteCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
+import matchuri.backend.domain.group.command.JoinGroupCommand;
 import matchuri.backend.domain.group.result.CreateGroupInviteResult;
 import matchuri.backend.domain.group.result.CreateGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
+import matchuri.backend.domain.group.result.JoinGroupResult;
 import org.springframework.data.domain.Page;
 
 public interface GroupService {
@@ -14,6 +16,8 @@ public interface GroupService {
     CreateGroupResult createGroup(CreateGroupCommand command);
 
     CreateGroupInviteResult createInvite(CreateGroupInviteCommand command);
+
+    JoinGroupResult joinGroup(JoinGroupCommand command);
 
     Page<GroupSummaryResult> getMyGroups(GetMyGroupsCommand command);
 

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -9,7 +9,9 @@ import lombok.RequiredArgsConstructor;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.CreateGroupInviteCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
+import matchuri.backend.domain.group.command.JoinGroupCommand;
 import matchuri.backend.domain.group.entity.GroupInvite;
+import matchuri.backend.domain.group.entity.GroupInviteStatus;
 import matchuri.backend.domain.group.entity.GroupMemberRole;
 import matchuri.backend.domain.group.entity.GroupMemberStatus;
 import matchuri.backend.domain.group.entity.GroupRoom;
@@ -25,6 +27,7 @@ import matchuri.backend.domain.group.result.CreateGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
+import matchuri.backend.domain.group.result.JoinGroupResult;
 import matchuri.backend.domain.group.support.GroupInviteCodeGenerator;
 import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.support.member.ActiveMemberReader;
@@ -96,6 +99,24 @@ public class GroupServiceImpl implements GroupService {
                 groupInvite.getExpiresAt(),
                 groupInvite.getStatus()
         );
+    }
+
+    @Override
+    public JoinGroupResult joinGroup(JoinGroupCommand command) {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        GroupInvite groupInvite = groupInviteRepository.findByInviteCodeWithRoom(command.inviteCode())
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.INVITE_NOT_FOUND, command.inviteCode()));
+
+        validateJoinableInvite(groupInvite, command.inviteCode());
+
+        GroupRoom room = groupInvite.getRoom();
+        if (!room.isActive()) {
+            throw new BusinessException(GroupErrorCode.NOT_ACTIVE, room.getId());
+        }
+
+        GroupRoomMember membership = joinOrRejoinMember(room, member);
+
+        return new JoinGroupResult(room.getId(), membership.getStatus());
     }
 
     @Override
@@ -181,6 +202,46 @@ public class GroupServiceImpl implements GroupService {
         }
 
         throw new BusinessException(GroupErrorCode.INVITE_CODE_GENERATION_FAILED);
+    }
+
+    private void validateJoinableInvite(GroupInvite groupInvite, String inviteCode) {
+        if (groupInvite.getStatus() == GroupInviteStatus.REVOKED) {
+            throw new BusinessException(GroupErrorCode.INVITE_REVOKED, inviteCode);
+        }
+
+        if (groupInvite.getStatus() == GroupInviteStatus.EXPIRED) {
+            throw new BusinessException(GroupErrorCode.INVITE_EXPIRED, inviteCode);
+        }
+
+        if (groupInvite.getExpiresAt() != null && !groupInvite.getExpiresAt().isAfter(LocalDateTime.now())) {
+            groupInvite.expire();
+            throw new BusinessException(GroupErrorCode.INVITE_EXPIRED, inviteCode);
+        }
+    }
+
+    private GroupRoomMember joinOrRejoinMember(GroupRoom room, Member member) {
+        return groupRoomMemberRepository.findByRoomIdAndMemberId(room.getId(), member.getId())
+                .map(membership -> rejoinExistingMembership(room, member, membership))
+                .orElseGet(() -> groupRoomMemberRepository.save(
+                        new GroupRoomMember(room, member, GroupMemberRole.MEMBER, LocalDateTime.now())
+                ));
+    }
+
+    private GroupRoomMember rejoinExistingMembership(
+            GroupRoom room,
+            Member member,
+            GroupRoomMember membership
+    ) {
+        if (membership.getStatus() == GroupMemberStatus.ACTIVE) {
+            throw new BusinessException(GroupErrorCode.ALREADY_JOINED, room.getId(), member.getId());
+        }
+
+        if (membership.getStatus() == GroupMemberStatus.LEFT) {
+            membership.rejoin(LocalDateTime.now());
+            return membership;
+        }
+
+        throw new BusinessException(GroupErrorCode.ACCESS_DENIED, room.getId());
     }
 
     private GroupMemberSummaryResult toMemberSummaryResult(GroupRoomMember membership) {

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -14,6 +14,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Date;
 import javax.crypto.SecretKey;
+import matchuri.backend.domain.group.entity.GroupInvite;
 import matchuri.backend.domain.group.entity.GroupMemberRole;
 import matchuri.backend.domain.group.entity.GroupMemberStatus;
 import matchuri.backend.domain.group.entity.GroupRoom;
@@ -342,6 +343,183 @@ class GroupIntegrationTest {
         assertThat(groupInviteRepository.count()).isZero();
     }
 
+    @Test
+    @DisplayName("초대 코드 입장은 신규 멤버를 ACTIVE 멤버로 저장한다")
+    void joinGroupCreatesActiveMember() throws Exception {
+        Member owner = saveMember("join-owner", "입장방장");
+        Member newMember = saveMember("join-new-member", "입장멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "입장 그룹");
+        GroupInvite invite = saveInvite(groupRoom, owner, "JOIN2026", LocalDateTime.now().plusHours(1));
+
+        mockMvc.perform(post("/api/v1/groups/join")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(newMember)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "inviteCode": "%s"
+                                }
+                                """.formatted(invite.getInviteCode())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.groupId").value(groupRoom.getId()))
+                .andExpect(jsonPath("$.data.memberStatus").value(GroupMemberStatus.ACTIVE.name()));
+
+        GroupRoomMember savedMembership = groupRoomMemberRepository
+                .findByRoomIdAndMemberId(groupRoom.getId(), newMember.getId())
+                .orElseThrow();
+
+        assertThat(savedMembership.getRole()).isEqualTo(GroupMemberRole.MEMBER);
+        assertThat(savedMembership.getStatus()).isEqualTo(GroupMemberStatus.ACTIVE);
+        assertThat(savedMembership.getJoinedAt()).isNotNull();
+        assertThat(savedMembership.getLeftAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("초대 코드 입장은 LEFT 멤버의 기존 membership을 재활성화한다")
+    void joinGroupReactivatesLeftMember() throws Exception {
+        Member owner = saveMember("rejoin-owner", "재입장방장");
+        Member leftMember = saveMember("rejoin-left-member", "재입장멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "재입장 그룹");
+        GroupRoomMember membership = groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                leftMember,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now().minusDays(2)
+        ));
+        membership.leave(LocalDateTime.now().minusDays(1));
+        groupRoomMemberRepository.save(membership);
+        LocalDateTime previousJoinedAt = membership.getJoinedAt();
+        GroupInvite invite = saveInvite(groupRoom, owner, "REJOIN26", LocalDateTime.now().plusHours(1));
+
+        mockMvc.perform(post("/api/v1/groups/join")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(leftMember)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "inviteCode": "%s"
+                                }
+                                """.formatted(invite.getInviteCode())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.groupId").value(groupRoom.getId()))
+                .andExpect(jsonPath("$.data.memberStatus").value(GroupMemberStatus.ACTIVE.name()));
+
+        GroupRoomMember rejoinedMembership = groupRoomMemberRepository
+                .findByRoomIdAndMemberId(groupRoom.getId(), leftMember.getId())
+                .orElseThrow();
+
+        assertThat(rejoinedMembership.getId()).isEqualTo(membership.getId());
+        assertThat(rejoinedMembership.getStatus()).isEqualTo(GroupMemberStatus.ACTIVE);
+        assertThat(rejoinedMembership.getLeftAt()).isNull();
+        assertThat(rejoinedMembership.getJoinedAt()).isAfter(previousJoinedAt);
+    }
+
+    @Test
+    @DisplayName("초대 코드 입장은 이미 활성 멤버이면 중복 참여로 실패한다")
+    void joinGroupFailsForAlreadyActiveMember() throws Exception {
+        Member owner = saveMember("already-join-owner", "중복방장");
+        Member activeMember = saveMember("already-join-member", "중복멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "중복 입장 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                activeMember,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        GroupInvite invite = saveInvite(groupRoom, owner, "ACTIVE26", LocalDateTime.now().plusHours(1));
+
+        mockMvc.perform(post("/api/v1/groups/join")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(activeMember)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "inviteCode": "%s"
+                                }
+                                """.formatted(invite.getInviteCode())))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("GROUP_ALREADY_JOINED"));
+    }
+
+    @Test
+    @DisplayName("초대 코드 입장은 존재하지 않는 코드이면 실패한다")
+    void joinGroupFailsForMissingInvite() throws Exception {
+        Member member = saveMember("missing-invite-member", "없는초대멤버");
+
+        mockMvc.perform(post("/api/v1/groups/join")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "inviteCode": "MISSING1"
+                                }
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("GROUP_INVITE_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("초대 코드 입장은 만료된 코드이면 실패한다")
+    void joinGroupFailsForExpiredInvite() throws Exception {
+        Member owner = saveMember("expired-invite-owner", "만료초대방장");
+        Member member = saveMember("expired-invite-member", "만료초대멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "만료 입장 그룹");
+        GroupInvite invite = saveInvite(groupRoom, owner, "EXPIRED1", LocalDateTime.now().minusMinutes(1));
+
+        mockMvc.perform(post("/api/v1/groups/join")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "inviteCode": "%s"
+                                }
+                                """.formatted(invite.getInviteCode())))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("GROUP_INVITE_EXPIRED"));
+    }
+
+    @Test
+    @DisplayName("초대 코드 입장은 취소된 코드이면 실패한다")
+    void joinGroupFailsForRevokedInvite() throws Exception {
+        Member owner = saveMember("revoked-invite-owner", "취소초대방장");
+        Member member = saveMember("revoked-invite-member", "취소초대멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "취소 입장 그룹");
+        GroupInvite invite = saveInvite(groupRoom, owner, "REVOKED1", LocalDateTime.now().plusHours(1));
+        invite.revoke();
+        groupInviteRepository.save(invite);
+
+        mockMvc.perform(post("/api/v1/groups/join")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "inviteCode": "%s"
+                                }
+                                """.formatted(invite.getInviteCode())))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("GROUP_INVITE_REVOKED"));
+    }
+
+    @Test
+    @DisplayName("초대 코드 입장은 연결된 그룹이 ACTIVE가 아니면 실패한다")
+    void joinGroupFailsForNotActiveGroup() throws Exception {
+        Member owner = saveMember("not-active-join-owner", "닫힌입장방장");
+        Member member = saveMember("not-active-join-member", "닫힌입장멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "닫힌 입장 그룹");
+        groupRoom.close();
+        groupRoomRepository.save(groupRoom);
+        GroupInvite invite = saveInvite(groupRoom, owner, "CLOSED26", LocalDateTime.now().plusHours(1));
+
+        mockMvc.perform(post("/api/v1/groups/join")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "inviteCode": "%s"
+                                }
+                                """.formatted(invite.getInviteCode())))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("GROUP_NOT_ACTIVE"));
+    }
+
     private Member saveMember(String loginId, String nickname) {
         return memberRepository.save(Member.builder()
                 .loginId(loginId)
@@ -357,6 +535,15 @@ class GroupIntegrationTest {
 
     private GroupRoom saveGroupOwnedBy(Member member, String name) {
         return groupRoomRepository.save(GroupRoom.createOwnedBy(name, member, null, null));
+    }
+
+    private GroupInvite saveInvite(
+            GroupRoom groupRoom,
+            Member createdByMember,
+            String inviteCode,
+            LocalDateTime expiresAt
+    ) {
+        return groupInviteRepository.save(new GroupInvite(groupRoom, createdByMember, inviteCode, expiresAt));
     }
 
     private void leaveOwnerMembership(GroupRoom groupRoom, Member member) {


### PR DESCRIPTION
## 관련 이슈
Closes #192 

## 📝 작업 내용
- `POST /api/v1/grops/join`

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 신규 멤버 입장 성공
- LEFT 멤버 재입장 성공
- 이미 활성 멤버 중복 입장 실패
- 없는 초대 코드, 만료 코드, 취소 코드 실패
- 비활성 그룹 입장 실패
- 초대 코드만으로 그룹에 입장할 수 있도록 설계했습니다

### 요청 예시

```json
{
  "inviteCode": "63CK7WC2"
}

```

### 응답 결과

```json
{
  "success": true,
  "data": {
    "groupId": 1,
    "memberStatus": "ACTIVE"
  },
  "error": null
}
```

