### PR TITLE
[Feat] 그룹 나가기 API

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -193,12 +193,14 @@ public interface GroupApi {
     ApiResponse<JoinGroupResponse> joinGroup(@Valid JoinGroupRequest request);
 
     @Operation(
-            summary = "그룹 탈퇴 (Mock API)",
+            summary = "그룹 탈퇴",
             description = """
                     현재 회원이 그룹에서 탈퇴합니다.
 
-                    Mock API 상태:
-                    - 그룹 멤버 여부와 소유자 탈퇴 정책은 아직 검증하지 않습니다.
+                    구현 기준:
+                    - 현재 회원의 활성 membership을 `LEFT`로 전환합니다.
+                    - `OWNER`는 나갈 수 없으며 그룹 삭제 API를 사용해야 합니다.
+                    - 이미 나간 멤버와 비멤버 접근은 상태에 맞는 에러로 처리합니다.
                     - 실제 저장 테이블은 `group_room_members` 기준입니다.
                     """
     )

--- a/src/main/java/matchuri/backend/api/group/GroupController.java
+++ b/src/main/java/matchuri/backend/api/group/GroupController.java
@@ -23,12 +23,14 @@ import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.CreateGroupInviteCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.command.JoinGroupCommand;
+import matchuri.backend.domain.group.command.LeaveGroupCommand;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.result.CreateGroupInviteResult;
 import matchuri.backend.domain.group.result.CreateGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
+import matchuri.backend.domain.group.result.LeaveGroupResult;
 import matchuri.backend.domain.group.service.GroupService;
 import matchuri.backend.global.api.ApiResponse;
 import matchuri.backend.global.api.PageResponse;
@@ -107,7 +109,10 @@ public class GroupController implements GroupApi {
     @Override
     @PostMapping("/{groupId}/leave")
     public ApiResponse<LeaveGroupResponse> leaveGroup(@PathVariable Long groupId) {
-        return ApiResponse.success(LeaveGroupResponse.mockLeft());
+        LeaveGroupCommand command = groupMapper.toLeaveGroupCommand(groupId);
+        LeaveGroupResult result = groupService.leaveGroup(command);
+
+        return ApiResponse.success(groupMapper.toLeaveGroupResponse(result));
     }
 
     @Override

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -8,10 +8,12 @@ import matchuri.backend.api.group.dto.response.GroupDetailResponse;
 import matchuri.backend.api.group.dto.response.GroupMemberSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
 import matchuri.backend.api.group.dto.response.JoinGroupResponse;
+import matchuri.backend.api.group.dto.response.LeaveGroupResponse;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.CreateGroupInviteCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.command.JoinGroupCommand;
+import matchuri.backend.domain.group.command.LeaveGroupCommand;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.result.CreateGroupInviteResult;
 import matchuri.backend.domain.group.result.CreateGroupResult;
@@ -19,6 +21,7 @@ import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
+import matchuri.backend.domain.group.result.LeaveGroupResult;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -60,6 +63,18 @@ public class GroupMapper {
         return new JoinGroupResponse(
                 result.groupId(),
                 result.memberStatus()
+        );
+    }
+
+    public LeaveGroupCommand toLeaveGroupCommand(Long groupId) {
+        return new LeaveGroupCommand(groupId);
+    }
+
+    public LeaveGroupResponse toLeaveGroupResponse(LeaveGroupResult result) {
+        return new LeaveGroupResponse(
+                result.groupId(),
+                result.memberStatus(),
+                result.leftAt()
         );
     }
 

--- a/src/main/java/matchuri/backend/domain/group/command/LeaveGroupCommand.java
+++ b/src/main/java/matchuri/backend/domain/group/command/LeaveGroupCommand.java
@@ -1,0 +1,4 @@
+package matchuri.backend.domain.group.command;
+
+public record LeaveGroupCommand(Long groupId) {
+}

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRoom.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRoom.java
@@ -18,6 +18,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -97,5 +98,11 @@ public class GroupRoom extends BaseEntity {
                 .filter(groupRoomMember -> Objects.equals(groupRoomMember.getMember().getId(), hostMemberId))
                 .findFirst()
                 .orElse(null);
+    }
+
+    public Optional<GroupRoomMember> getGroupRoomMemberById (long memberId) {
+        return this.groupRoomMembers.stream()
+                .filter(groupRoomMember -> groupRoomMember.getMember().getId() == memberId)
+                .findFirst();
     }
 }

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRoomMember.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRoomMember.java
@@ -85,4 +85,12 @@ public class GroupRoomMember extends BaseEntity {
     public boolean isOwner() {
         return this.role == GroupMemberRole.OWNER;
     }
+
+    public boolean isActive() {
+        return this.status == GroupMemberStatus.ACTIVE;
+    }
+
+    public boolean isLeft() {
+        return this.status == GroupMemberStatus.LEFT;
+    }
 }

--- a/src/main/java/matchuri/backend/domain/group/result/LeaveGroupResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/LeaveGroupResult.java
@@ -1,0 +1,11 @@
+package matchuri.backend.domain.group.result;
+
+import java.time.LocalDateTime;
+import matchuri.backend.domain.group.entity.GroupMemberStatus;
+
+public record LeaveGroupResult(
+        Long groupId,
+        GroupMemberStatus memberStatus,
+        LocalDateTime leftAt
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/service/GroupService.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupService.java
@@ -4,11 +4,13 @@ import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.CreateGroupInviteCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.command.JoinGroupCommand;
+import matchuri.backend.domain.group.command.LeaveGroupCommand;
 import matchuri.backend.domain.group.result.CreateGroupInviteResult;
 import matchuri.backend.domain.group.result.CreateGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
+import matchuri.backend.domain.group.result.LeaveGroupResult;
 import org.springframework.data.domain.Page;
 
 public interface GroupService {
@@ -18,6 +20,8 @@ public interface GroupService {
     CreateGroupInviteResult createInvite(CreateGroupInviteCommand command);
 
     JoinGroupResult joinGroup(JoinGroupCommand command);
+
+    LeaveGroupResult leaveGroup(LeaveGroupCommand command);
 
     Page<GroupSummaryResult> getMyGroups(GetMyGroupsCommand command);
 

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -123,17 +123,18 @@ public class GroupServiceImpl implements GroupService {
     @Override
     public LeaveGroupResult leaveGroup(LeaveGroupCommand command) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        Long memberId = member.getId();
         GroupRoom room = groupRoomRepository.findByIdAndStatusNot(command.groupId(), GroupRoomStatus.DELETED)
                 .orElseThrow(() -> new BusinessException(GroupErrorCode.NOT_FOUND, command.groupId()));
-        GroupRoomMember membership = groupRoomMemberRepository.findByRoomIdAndMemberId(room.getId(), member.getId())
-                .orElseThrow(() -> new BusinessException(GroupErrorCode.MEMBER_NOT_FOUND, room.getId(), member.getId()));
+        GroupRoomMember membership = room.getGroupRoomMemberById(memberId)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.MEMBER_NOT_FOUND, room.getId(), memberId));
 
-        if (membership.getStatus() == GroupMemberStatus.LEFT) {
-            throw new BusinessException(GroupErrorCode.MEMBER_ALREADY_LEFT, room.getId(), member.getId());
+        if (membership.isLeft()) {
+            throw new BusinessException(GroupErrorCode.MEMBER_ALREADY_LEFT, room.getId(), memberId);
         }
 
-        if (membership.getStatus() != GroupMemberStatus.ACTIVE) {
-            throw new BusinessException(GroupErrorCode.MEMBER_NOT_FOUND, room.getId(), member.getId());
+        if (!membership.isActive()) {
+            throw new BusinessException(GroupErrorCode.MEMBER_NOT_FOUND, room.getId(), memberId);
         }
 
         if (membership.isOwner()) {

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -3,13 +3,13 @@ package matchuri.backend.domain.group.service;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.CreateGroupInviteCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.command.JoinGroupCommand;
+import matchuri.backend.domain.group.command.LeaveGroupCommand;
 import matchuri.backend.domain.group.entity.GroupInvite;
 import matchuri.backend.domain.group.entity.GroupInviteStatus;
 import matchuri.backend.domain.group.entity.GroupMemberRole;
@@ -28,6 +28,7 @@ import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
+import matchuri.backend.domain.group.result.LeaveGroupResult;
 import matchuri.backend.domain.group.support.GroupInviteCodeGenerator;
 import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.support.member.ActiveMemberReader;
@@ -117,6 +118,32 @@ public class GroupServiceImpl implements GroupService {
         GroupRoomMember membership = joinOrRejoinMember(room, member);
 
         return new JoinGroupResult(room.getId(), membership.getStatus());
+    }
+
+    @Override
+    public LeaveGroupResult leaveGroup(LeaveGroupCommand command) {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        GroupRoom room = groupRoomRepository.findByIdAndStatusNot(command.groupId(), GroupRoomStatus.DELETED)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.NOT_FOUND, command.groupId()));
+        GroupRoomMember membership = groupRoomMemberRepository.findByRoomIdAndMemberId(room.getId(), member.getId())
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.MEMBER_NOT_FOUND, room.getId(), member.getId()));
+
+        if (membership.getStatus() == GroupMemberStatus.LEFT) {
+            throw new BusinessException(GroupErrorCode.MEMBER_ALREADY_LEFT, room.getId(), member.getId());
+        }
+
+        if (membership.getStatus() != GroupMemberStatus.ACTIVE) {
+            throw new BusinessException(GroupErrorCode.MEMBER_NOT_FOUND, room.getId(), member.getId());
+        }
+
+        if (membership.isOwner()) {
+            throw new BusinessException(GroupErrorCode.OWNER_LEAVE_NOT_ALLOWED, room.getId());
+        }
+
+        LocalDateTime leftAt = LocalDateTime.now();
+        membership.leave(leftAt);
+
+        return new LeaveGroupResult(room.getId(), membership.getStatus(), membership.getLeftAt());
     }
 
     @Override

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -520,6 +520,108 @@ class GroupIntegrationTest {
                 .andExpect(jsonPath("$.error.code").value("GROUP_NOT_ACTIVE"));
     }
 
+    @Test
+    @DisplayName("그룹 나가기는 일반 멤버를 LEFT 상태로 전환한다")
+    void leaveGroupChangesMemberStatusToLeft() throws Exception {
+        Member owner = saveMember("leave-owner", "탈퇴방장");
+        Member member = saveMember("leave-member", "탈퇴멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "탈퇴 그룹");
+        GroupRoomMember membership = groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                member,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        LocalDateTime beforeLeave = LocalDateTime.now();
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/leave", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.groupId").value(groupRoom.getId()))
+                .andExpect(jsonPath("$.data.memberStatus").value(GroupMemberStatus.LEFT.name()))
+                .andExpect(jsonPath("$.data.leftAt").isNotEmpty());
+
+        LocalDateTime afterLeave = LocalDateTime.now();
+        GroupRoomMember savedMembership = groupRoomMemberRepository.findById(membership.getId()).orElseThrow();
+
+        assertThat(savedMembership.getStatus()).isEqualTo(GroupMemberStatus.LEFT);
+        assertThat(savedMembership.getLeftAt()).isBetween(beforeLeave, afterLeave);
+    }
+
+    @Test
+    @DisplayName("그룹 나가기는 OWNER이면 거절한다")
+    void leaveGroupFailsForOwner() throws Exception {
+        Member owner = saveMember("owner-leave-owner", "방장탈퇴");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "방장 탈퇴 그룹");
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/leave", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("GROUP_OWNER_LEAVE_NOT_ALLOWED"));
+
+        GroupRoomMember ownerMembership = groupRoomMemberRepository
+                .findByRoomIdAndMemberId(groupRoom.getId(), owner.getId())
+                .orElseThrow();
+        assertThat(ownerMembership.getStatus()).isEqualTo(GroupMemberStatus.ACTIVE);
+        assertThat(ownerMembership.getLeftAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("그룹 나가기는 이미 LEFT 멤버이면 실패한다")
+    void leaveGroupFailsForAlreadyLeftMember() throws Exception {
+        Member owner = saveMember("already-left-owner", "이미나감방장");
+        Member member = saveMember("already-left-member", "이미나감멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "이미 나간 그룹");
+        GroupRoomMember membership = groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                member,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        membership.leave(LocalDateTime.now());
+        groupRoomMemberRepository.save(membership);
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/leave", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("GROUP_MEMBER_ALREADY_LEFT"));
+    }
+
+    @Test
+    @DisplayName("그룹 나가기는 그룹 멤버가 아니면 실패한다")
+    void leaveGroupFailsForNonMember() throws Exception {
+        Member owner = saveMember("leave-nonmember-owner", "비멤버방장");
+        Member other = saveMember("leave-nonmember-other", "비멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "비멤버 탈퇴 그룹");
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/leave", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(other))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("GROUP_MEMBER_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("그룹 나가기는 삭제된 그룹이면 찾을 수 없음으로 처리한다")
+    void leaveGroupFailsForDeletedGroup() throws Exception {
+        Member owner = saveMember("deleted-leave-owner", "삭제탈퇴방장");
+        Member member = saveMember("deleted-leave-member", "삭제탈퇴멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "삭제 탈퇴 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                member,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        groupRoom.delete();
+        groupRoomRepository.save(groupRoom);
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/leave", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("GROUP_NOT_FOUND"));
+    }
+
     private Member saveMember(String loginId, String nickname) {
         return memberRepository.save(Member.builder()
                 .loginId(loginId)


### PR DESCRIPTION
## 관련 이슈
Closes #193 

## 📝 작업 내용
- `GET /api/v1/groups/{groupId}/leave` 추가

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항

- 일반 멤버 나가기 성공

```json
{
  "success": true,
  "data": {
    "groupId": 1,
    "memberStatus": "LEFT",
    "leftAt": "2026-05-17T19:44:36.7859587"
  },
  "error": null
}
```

- 이미 나간 멤버 재요청 실패

```json
{
  "success": false,
  "data": null,
  "error": {
    "status": 409,
    "code": "GROUP_MEMBER_ALREADY_LEFT",
    "message": "이미 나간 그룹 멤버입니다. groupId : 1, memberId : 1",
    "details": []
  }
}
```

- OWNER 나가기 거절

```json
{
  "success": false,
  "data": null,
  "error": {
    "status": 409,
    "code": "GROUP_OWNER_LEAVE_NOT_ALLOWED",
    "message": "그룹 방장은 나가기 대신 그룹 삭제를 사용해야 합니다. groupId : 1",
    "details": []
  }
}
```