### PR TITLE
[Feat] 그룹 삭제 API 구현

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -13,6 +13,7 @@ import jakarta.validation.constraints.Min;
 import matchuri.backend.api.group.dto.docs.CreateGroupApiResponse;
 import matchuri.backend.api.group.dto.docs.CreateGroupInviteApiResponse;
 import matchuri.backend.api.group.dto.docs.CreateGroupRecommendationApiResponse;
+import matchuri.backend.api.group.dto.docs.DeleteGroupApiResponse;
 import matchuri.backend.api.group.dto.docs.FinalizeGroupRecommendationApiResponse;
 import matchuri.backend.api.group.dto.docs.GroupApiExamples;
 import matchuri.backend.api.group.dto.docs.GroupDetailApiResponse;
@@ -29,6 +30,7 @@ import matchuri.backend.api.group.dto.request.VoteGroupRecommendationRequest;
 import matchuri.backend.api.group.dto.response.CreateGroupInviteResponse;
 import matchuri.backend.api.group.dto.response.CreateGroupRecommendationResponse;
 import matchuri.backend.api.group.dto.response.CreateGroupResponse;
+import matchuri.backend.api.group.dto.response.DeleteGroupResponse;
 import matchuri.backend.api.group.dto.response.FinalizeGroupRecommendationResponse;
 import matchuri.backend.api.group.dto.response.GroupDetailResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateListResponse;
@@ -219,6 +221,34 @@ public interface GroupApi {
             )
     })
     ApiResponse<LeaveGroupResponse> leaveGroup(Long groupId);
+
+    @Operation(
+            summary = "그룹 삭제",
+            description = """
+                    그룹을 삭제 상태로 전환합니다.
+
+                    구현 기준:
+                    - 현재 회원이 해당 그룹의 `ACTIVE` OWNER 멤버일 때만 삭제할 수 있습니다.
+                    - 그룹은 `DELETED` 상태로 전환됩니다.
+                    - 해당 그룹의 `ACTIVE` 초대 코드는 `REVOKED`로 전환됩니다.
+                    - 해당 그룹의 `ACTIVE` 멤버는 후속 조회에서 노출되지 않도록 `LEFT`로 전환됩니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "그룹 삭제 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = DeleteGroupApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = GroupApiExamples.DELETE_GROUP_SUCCESS
+                            )
+                    )
+            )
+    })
+    ApiResponse<DeleteGroupResponse> deleteGroup(Long groupId);
 
     @Operation(
             summary = "그룹 추천 시작 (Mock API)",

--- a/src/main/java/matchuri/backend/api/group/GroupController.java
+++ b/src/main/java/matchuri/backend/api/group/GroupController.java
@@ -11,6 +11,7 @@ import matchuri.backend.api.group.dto.request.VoteGroupRecommendationRequest;
 import matchuri.backend.api.group.dto.response.CreateGroupInviteResponse;
 import matchuri.backend.api.group.dto.response.CreateGroupRecommendationResponse;
 import matchuri.backend.api.group.dto.response.CreateGroupResponse;
+import matchuri.backend.api.group.dto.response.DeleteGroupResponse;
 import matchuri.backend.api.group.dto.response.FinalizeGroupRecommendationResponse;
 import matchuri.backend.api.group.dto.response.GroupDetailResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateListResponse;
@@ -21,12 +22,14 @@ import matchuri.backend.api.group.dto.response.JoinGroupResponse;
 import matchuri.backend.api.group.dto.response.LeaveGroupResponse;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.CreateGroupInviteCommand;
+import matchuri.backend.domain.group.command.DeleteGroupCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.command.JoinGroupCommand;
 import matchuri.backend.domain.group.command.LeaveGroupCommand;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.result.CreateGroupInviteResult;
 import matchuri.backend.domain.group.result.CreateGroupResult;
+import matchuri.backend.domain.group.result.DeleteGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
@@ -36,6 +39,7 @@ import matchuri.backend.global.api.ApiResponse;
 import matchuri.backend.global.api.PageResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -113,6 +117,15 @@ public class GroupController implements GroupApi {
         LeaveGroupResult result = groupService.leaveGroup(command);
 
         return ApiResponse.success(groupMapper.toLeaveGroupResponse(result));
+    }
+
+    @Override
+    @DeleteMapping("/{groupId}")
+    public ApiResponse<DeleteGroupResponse> deleteGroup(@PathVariable Long groupId) {
+        DeleteGroupCommand command = groupMapper.toDeleteGroupCommand(groupId);
+        DeleteGroupResult result = groupService.deleteGroup(command);
+
+        return ApiResponse.success(groupMapper.toDeleteGroupResponse(result));
     }
 
     @Override

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -4,6 +4,7 @@ import matchuri.backend.api.group.dto.request.CreateGroupRequest;
 import matchuri.backend.api.group.dto.request.JoinGroupRequest;
 import matchuri.backend.api.group.dto.response.CreateGroupInviteResponse;
 import matchuri.backend.api.group.dto.response.CreateGroupResponse;
+import matchuri.backend.api.group.dto.response.DeleteGroupResponse;
 import matchuri.backend.api.group.dto.response.GroupDetailResponse;
 import matchuri.backend.api.group.dto.response.GroupMemberSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
@@ -11,12 +12,14 @@ import matchuri.backend.api.group.dto.response.JoinGroupResponse;
 import matchuri.backend.api.group.dto.response.LeaveGroupResponse;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.CreateGroupInviteCommand;
+import matchuri.backend.domain.group.command.DeleteGroupCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.command.JoinGroupCommand;
 import matchuri.backend.domain.group.command.LeaveGroupCommand;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.result.CreateGroupInviteResult;
 import matchuri.backend.domain.group.result.CreateGroupResult;
+import matchuri.backend.domain.group.result.DeleteGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
@@ -75,6 +78,18 @@ public class GroupMapper {
                 result.groupId(),
                 result.memberStatus(),
                 result.leftAt()
+        );
+    }
+
+    public DeleteGroupCommand toDeleteGroupCommand(Long groupId) {
+        return new DeleteGroupCommand(groupId);
+    }
+
+    public DeleteGroupResponse toDeleteGroupResponse(DeleteGroupResult result) {
+        return new DeleteGroupResponse(
+                result.groupId(),
+                result.status(),
+                result.deletedAt()
         );
     }
 

--- a/src/main/java/matchuri/backend/api/group/dto/docs/DeleteGroupApiResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/DeleteGroupApiResponse.java
@@ -1,0 +1,9 @@
+package matchuri.backend.api.group.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.group.dto.response.DeleteGroupResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "그룹 삭제 API의 공통 응답 envelope입니다.")
+public record DeleteGroupApiResponse(boolean success, DeleteGroupResponse data, ErrorResponse error) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -126,6 +126,18 @@ public final class GroupApiExamples {
             }
             """;
 
+    public static final String DELETE_GROUP_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "groupId": 3001,
+                "status": "DELETED",
+                "deletedAt": "2026-05-18T12:30:00"
+              },
+              "error": null
+            }
+            """;
+
     public static final String CREATE_RECOMMENDATION_SUCCESS = """
             {
               "success": true,

--- a/src/main/java/matchuri/backend/api/group/dto/response/DeleteGroupResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/DeleteGroupResponse.java
@@ -1,0 +1,17 @@
+package matchuri.backend.api.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import matchuri.backend.domain.group.entity.GroupRoomStatus;
+
+public record DeleteGroupResponse(
+        @Schema(description = "삭제된 그룹 ID입니다.", example = "3001")
+        Long groupId,
+
+        @Schema(description = "삭제 후 그룹 상태입니다.", example = "DELETED")
+        GroupRoomStatus status,
+
+        @Schema(description = "삭제 처리 시각입니다.", example = "2026-05-18T12:30:00")
+        LocalDateTime deletedAt
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/command/DeleteGroupCommand.java
+++ b/src/main/java/matchuri/backend/domain/group/command/DeleteGroupCommand.java
@@ -1,0 +1,4 @@
+package matchuri.backend.domain.group.command;
+
+public record DeleteGroupCommand(Long groupId) {
+}

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupInviteRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupInviteRepository.java
@@ -1,7 +1,9 @@
 package matchuri.backend.domain.group.repository;
 
+import java.util.List;
 import java.util.Optional;
 import matchuri.backend.domain.group.entity.GroupInvite;
+import matchuri.backend.domain.group.entity.GroupInviteStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +11,8 @@ import org.springframework.data.repository.query.Param;
 public interface GroupInviteRepository extends JpaRepository<GroupInvite, Long> {
 
     boolean existsByInviteCode(String inviteCode);
+
+    List<GroupInvite> findAllByRoomIdAndStatus(Long roomId, GroupInviteStatus status);
 
     @Query("""
             select groupInvite

--- a/src/main/java/matchuri/backend/domain/group/result/DeleteGroupResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/DeleteGroupResult.java
@@ -1,0 +1,11 @@
+package matchuri.backend.domain.group.result;
+
+import java.time.LocalDateTime;
+import matchuri.backend.domain.group.entity.GroupRoomStatus;
+
+public record DeleteGroupResult(
+        Long groupId,
+        GroupRoomStatus status,
+        LocalDateTime deletedAt
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/service/GroupService.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupService.java
@@ -2,11 +2,13 @@ package matchuri.backend.domain.group.service;
 
 import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.CreateGroupInviteCommand;
+import matchuri.backend.domain.group.command.DeleteGroupCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.command.JoinGroupCommand;
 import matchuri.backend.domain.group.command.LeaveGroupCommand;
 import matchuri.backend.domain.group.result.CreateGroupInviteResult;
 import matchuri.backend.domain.group.result.CreateGroupResult;
+import matchuri.backend.domain.group.result.DeleteGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
@@ -22,6 +24,8 @@ public interface GroupService {
     JoinGroupResult joinGroup(JoinGroupCommand command);
 
     LeaveGroupResult leaveGroup(LeaveGroupCommand command);
+
+    DeleteGroupResult deleteGroup(DeleteGroupCommand command);
 
     Page<GroupSummaryResult> getMyGroups(GetMyGroupsCommand command);
 

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.CreateGroupInviteCommand;
+import matchuri.backend.domain.group.command.DeleteGroupCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.command.JoinGroupCommand;
 import matchuri.backend.domain.group.command.LeaveGroupCommand;
@@ -24,6 +25,7 @@ import matchuri.backend.domain.group.repository.GroupRoomMemberRepository;
 import matchuri.backend.domain.group.repository.GroupRoomRepository;
 import matchuri.backend.domain.group.result.CreateGroupInviteResult;
 import matchuri.backend.domain.group.result.CreateGroupResult;
+import matchuri.backend.domain.group.result.DeleteGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
@@ -145,6 +147,27 @@ public class GroupServiceImpl implements GroupService {
         membership.leave(leftAt);
 
         return new LeaveGroupResult(room.getId(), membership.getStatus(), membership.getLeftAt());
+    }
+
+    @Override
+    public DeleteGroupResult deleteGroup(DeleteGroupCommand command) {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        GroupRoom room = groupRoomRepository.findByIdAndStatusNot(command.groupId(), GroupRoomStatus.DELETED)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.NOT_FOUND, command.groupId()));
+        GroupRoomMember membership = groupRoomMemberRepository
+                .findActiveMembershipInNotDeletedRoom(room.getId(), member.getId())
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.ACCESS_DENIED, room.getId()));
+
+        if (!membership.isOwner()) {
+            throw new BusinessException(GroupErrorCode.DELETE_FORBIDDEN, room.getId());
+        }
+
+        LocalDateTime deletedAt = LocalDateTime.now();
+        room.delete();
+        revokeActiveInvites(room);
+        leaveActiveMembers(room, deletedAt);
+
+        return new DeleteGroupResult(room.getId(), room.getStatus(), deletedAt);
     }
 
     @Override
@@ -270,6 +293,16 @@ public class GroupServiceImpl implements GroupService {
         }
 
         throw new BusinessException(GroupErrorCode.ACCESS_DENIED, room.getId());
+    }
+
+    private void revokeActiveInvites(GroupRoom room) {
+        groupInviteRepository.findAllByRoomIdAndStatus(room.getId(), GroupInviteStatus.ACTIVE)
+                .forEach(GroupInvite::revoke);
+    }
+
+    private void leaveActiveMembers(GroupRoom room, LocalDateTime leftAt) {
+        groupRoomMemberRepository.findActiveMembersByRoomId(room.getId())
+                .forEach(membership -> membership.leave(leftAt));
     }
 
     private GroupMemberSummaryResult toMemberSummaryResult(GroupRoomMember membership) {

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -150,6 +150,7 @@ public class GroupServiceImpl implements GroupService {
     }
 
     @Override
+    @Transactional
     public DeleteGroupResult deleteGroup(DeleteGroupCommand command) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
         GroupRoom room = groupRoomRepository.findByIdAndStatusNot(command.groupId(), GroupRoomStatus.DELETED)

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -2,6 +2,7 @@ package matchuri.backend.api.group;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -15,6 +16,7 @@ import java.time.LocalDateTime;
 import java.util.Date;
 import javax.crypto.SecretKey;
 import matchuri.backend.domain.group.entity.GroupInvite;
+import matchuri.backend.domain.group.entity.GroupInviteStatus;
 import matchuri.backend.domain.group.entity.GroupMemberRole;
 import matchuri.backend.domain.group.entity.GroupMemberStatus;
 import matchuri.backend.domain.group.entity.GroupRoom;
@@ -618,6 +620,112 @@ class GroupIntegrationTest {
 
         mockMvc.perform(post("/api/v1/groups/{groupId}/leave", groupRoom.getId())
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("GROUP_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("그룹 삭제는 방을 DELETED로 전환하고 활성 초대와 활성 멤버를 정리한다")
+    void deleteGroupSoftDeletesRoomAndCleansActiveRelations() throws Exception {
+        Member owner = saveMember("delete-owner", "삭제방장");
+        Member activeMember = saveMember("delete-member", "삭제멤버");
+        Member leftMember = saveMember("delete-left-member", "삭제전나간멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "삭제 그룹");
+        GroupRoomMember activeMembership = groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                activeMember,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        GroupRoomMember leftMembership = groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                leftMember,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        leftMembership.leave(LocalDateTime.now().minusHours(1));
+        groupRoomMemberRepository.save(leftMembership);
+        GroupInvite activeInvite = saveInvite(groupRoom, owner, "DELETE01", LocalDateTime.now().plusHours(1));
+        GroupInvite revokedInvite = saveInvite(groupRoom, owner, "DELETE02", LocalDateTime.now().plusHours(1));
+        revokedInvite.revoke();
+        groupInviteRepository.save(revokedInvite);
+
+        mockMvc.perform(delete("/api/v1/groups/{groupId}", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.groupId").value(groupRoom.getId()))
+                .andExpect(jsonPath("$.data.status").value(GroupRoomStatus.DELETED.name()))
+                .andExpect(jsonPath("$.data.deletedAt").isNotEmpty());
+
+        GroupRoom deletedGroup = groupRoomRepository.findById(groupRoom.getId()).orElseThrow();
+        GroupRoomMember ownerMembership = groupRoomMemberRepository
+                .findByRoomIdAndMemberId(groupRoom.getId(), owner.getId())
+                .orElseThrow();
+        GroupRoomMember savedActiveMembership = groupRoomMemberRepository
+                .findById(activeMembership.getId())
+                .orElseThrow();
+        GroupRoomMember savedLeftMembership = groupRoomMemberRepository
+                .findById(leftMembership.getId())
+                .orElseThrow();
+        GroupInvite savedActiveInvite = groupInviteRepository.findById(activeInvite.getId()).orElseThrow();
+        GroupInvite savedRevokedInvite = groupInviteRepository.findById(revokedInvite.getId()).orElseThrow();
+
+        assertThat(deletedGroup.getStatus()).isEqualTo(GroupRoomStatus.DELETED);
+        assertThat(ownerMembership.getStatus()).isEqualTo(GroupMemberStatus.LEFT);
+        assertThat(savedActiveMembership.getStatus()).isEqualTo(GroupMemberStatus.LEFT);
+        assertThat(ownerMembership.getLeftAt()).isNotNull();
+        assertThat(savedActiveMembership.getLeftAt()).isNotNull();
+        assertThat(savedLeftMembership.getStatus()).isEqualTo(GroupMemberStatus.LEFT);
+        assertThat(savedActiveInvite.getStatus()).isEqualTo(GroupInviteStatus.REVOKED);
+        assertThat(savedRevokedInvite.getStatus()).isEqualTo(GroupInviteStatus.REVOKED);
+    }
+
+    @Test
+    @DisplayName("그룹 삭제는 OWNER가 아닌 활성 멤버이면 거절한다")
+    void deleteGroupFailsForNonOwnerMember() throws Exception {
+        Member owner = saveMember("delete-non-owner-host", "삭제권한방장");
+        Member member = saveMember("delete-non-owner-member", "삭제권한멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "삭제 권한 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                member,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+
+        mockMvc.perform(delete("/api/v1/groups/{groupId}", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("GROUP_DELETE_FORBIDDEN"));
+
+        assertThat(groupRoomRepository.findById(groupRoom.getId()).orElseThrow().getStatus())
+                .isEqualTo(GroupRoomStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("그룹 삭제는 활성 멤버가 아니면 거절한다")
+    void deleteGroupFailsForNonMember() throws Exception {
+        Member owner = saveMember("delete-access-owner", "삭제접근방장");
+        Member other = saveMember("delete-access-other", "삭제접근없음");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "삭제 접근 그룹");
+
+        mockMvc.perform(delete("/api/v1/groups/{groupId}", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(other))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("GROUP_ACCESS_DENIED"));
+    }
+
+    @Test
+    @DisplayName("그룹 삭제는 삭제된 그룹이면 찾을 수 없음으로 처리한다")
+    void deleteGroupFailsForDeletedGroup() throws Exception {
+        Member owner = saveMember("already-deleted-owner", "이미삭제방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "이미 삭제 그룹");
+        groupRoom.delete();
+        groupRoomRepository.save(groupRoom);
+
+        mockMvc.perform(delete("/api/v1/groups/{groupId}", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.error.code").value("GROUP_NOT_FOUND"));
     }

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -643,7 +643,8 @@ class GroupIntegrationTest {
                 GroupMemberRole.MEMBER,
                 LocalDateTime.now()
         ));
-        leftMembership.leave(LocalDateTime.now().minusHours(1));
+        LocalDateTime alreadyLeftAt = LocalDateTime.of(2026, 5, 18, 9, 0);
+        leftMembership.leave(alreadyLeftAt);
         groupRoomMemberRepository.save(leftMembership);
         GroupInvite activeInvite = saveInvite(groupRoom, owner, "DELETE01", LocalDateTime.now().plusHours(1));
         GroupInvite revokedInvite = saveInvite(groupRoom, owner, "DELETE02", LocalDateTime.now().plusHours(1));
@@ -677,6 +678,7 @@ class GroupIntegrationTest {
         assertThat(ownerMembership.getLeftAt()).isNotNull();
         assertThat(savedActiveMembership.getLeftAt()).isNotNull();
         assertThat(savedLeftMembership.getStatus()).isEqualTo(GroupMemberStatus.LEFT);
+        assertThat(savedLeftMembership.getLeftAt()).isEqualTo(alreadyLeftAt);
         assertThat(savedActiveInvite.getStatus()).isEqualTo(GroupInviteStatus.REVOKED);
         assertThat(savedRevokedInvite.getStatus()).isEqualTo(GroupInviteStatus.REVOKED);
     }

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -320,6 +320,9 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/groups/{groupId}/leave'].post.responses['200'].content['application/json'].examples.success.value.data.memberStatus")
                         .value("LEFT"))
                 .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}'].delete.responses['200'].content['application/json'].examples.success.value.data.status")
+                        .value("DELETED"))
+                .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}/recommendations'].post.responses['200'].content['application/json'].examples.success.value.data.candidates[0].candidateId")
                         .value(8001))
                 .andExpect(jsonPath(


### PR DESCRIPTION
## 관련 이슈
Closes #194 

## 📝 작업 내용
- `DELETE /api/v1/groups/{groupId}` 추가

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항

- soft delete 방식 `group_rooms.status.DELETED`로 처리
- 일반 멤버 삭제 거절
- 비멤버 삭제 거절
- 이미 삭제된 그룹 삭제 실패
