### PR TITLE
[Refactor] 그룹 초대 DB 스키마 변경

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -179,7 +179,7 @@ public interface GroupApi {
                     초대 코드로 그룹에 참여합니다.
 
                     구현 기준:
-                    - 초대 코드 존재 여부, 취소 여부, 만료 여부를 검증합니다.
+                    - 그룹의 고정 초대 코드 존재 여부를 검증합니다.
                     - 연결된 그룹이 `ACTIVE` 상태일 때만 참여할 수 있습니다.
                     - 이미 `ACTIVE` 멤버이면 중복 참여로 실패합니다.
                     - 과거 `LEFT` 멤버는 기존 membership을 재활성화합니다.
@@ -237,7 +237,7 @@ public interface GroupApi {
                     구현 기준:
                     - 현재 회원이 해당 그룹의 `ACTIVE` OWNER 멤버일 때만 삭제할 수 있습니다.
                     - 그룹은 `DELETED` 상태로 전환됩니다.
-                    - 해당 그룹의 `ACTIVE` 초대 코드는 `REVOKED`로 전환됩니다.
+                    - 해당 그룹의 `PENDING` 초대 요청은 `REVOKED`로 전환됩니다.
                     - 해당 그룹의 `ACTIVE` 멤버는 후속 조회에서 노출되지 않도록 `LEFT`로 전환됩니다.
                     """
     )

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupInvite.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupInvite.java
@@ -37,8 +37,8 @@ public class GroupInvite extends BaseEntity {
     private GroupRoom room;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "created_by_member_id", nullable = false, comment = "초대 생성 회원 ID")
-    private Member createdByMember;
+    @JoinColumn(name = "request_member_id", nullable = false, comment = "초대 생성 회원 ID")
+    private Member requestMember;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "target_member_id", nullable = false, comment = "초대 대상 회원 ID")
@@ -54,9 +54,9 @@ public class GroupInvite extends BaseEntity {
     @Column(name = "responded_at", comment = "응답 시각")
     private LocalDateTime respondedAt;
 
-    public GroupInvite(GroupRoom room, Member createdByMember, Member targetMember, LocalDateTime expiresAt) {
+    public GroupInvite(GroupRoom room, Member requestMember, Member targetMember, LocalDateTime expiresAt) {
         this.room = room;
-        this.createdByMember = createdByMember;
+        this.requestMember = requestMember;
         this.targetMember = targetMember;
         this.expiresAt = expiresAt;
         this.status = GroupInviteStatus.PENDING;

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupInvite.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupInvite.java
@@ -11,7 +11,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -23,15 +22,10 @@ import matchuri.backend.domain.member.entity.Member;
 @Entity
 @Table(
         name = "group_invites",
-        comment = "그룹 초대",
-        uniqueConstraints = {
-                @UniqueConstraint(name = "uk_group_invites_invite_code", columnNames = "invite_code")
-        }
+        comment = "그룹 초대"
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GroupInvite extends BaseEntity {
-
-    public static final int INVITE_CODE_MAX_LENGTH = 64;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -46,8 +40,9 @@ public class GroupInvite extends BaseEntity {
     @JoinColumn(name = "created_by_member_id", nullable = false, comment = "초대 생성 회원 ID")
     private Member createdByMember;
 
-    @Column(name = "invite_code", nullable = false, length = INVITE_CODE_MAX_LENGTH, comment = "초대 코드")
-    private String inviteCode;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "target_member_id", nullable = false, comment = "초대 대상 회원 ID")
+    private Member targetMember;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20, comment = "초대 상태")
@@ -56,12 +51,25 @@ public class GroupInvite extends BaseEntity {
     @Column(name = "expires_at", comment = "만료 시각")
     private LocalDateTime expiresAt;
 
-    public GroupInvite(GroupRoom room, Member createdByMember, String inviteCode, LocalDateTime expiresAt) {
+    @Column(name = "responded_at", comment = "응답 시각")
+    private LocalDateTime respondedAt;
+
+    public GroupInvite(GroupRoom room, Member createdByMember, Member targetMember, LocalDateTime expiresAt) {
         this.room = room;
         this.createdByMember = createdByMember;
-        this.inviteCode = inviteCode;
+        this.targetMember = targetMember;
         this.expiresAt = expiresAt;
-        this.status = GroupInviteStatus.ACTIVE;
+        this.status = GroupInviteStatus.PENDING;
+    }
+
+    public void accept(LocalDateTime respondedAt) {
+        this.status = GroupInviteStatus.ACCEPTED;
+        this.respondedAt = respondedAt;
+    }
+
+    public void decline(LocalDateTime respondedAt) {
+        this.status = GroupInviteStatus.DECLINED;
+        this.respondedAt = respondedAt;
     }
 
     public void expire() {

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupInviteStatus.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupInviteStatus.java
@@ -1,7 +1,9 @@
 package matchuri.backend.domain.group.entity;
 
 public enum GroupInviteStatus {
-    ACTIVE,
+    PENDING,
+    ACCEPTED,
+    DECLINED,
     EXPIRED,
     REVOKED
 }

--- a/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
@@ -21,8 +21,8 @@ public enum GroupErrorCode implements ErrorCode {
     OWNER_LEAVE_NOT_ALLOWED(HttpStatus.CONFLICT, "그룹 방장은 나가기 대신 그룹 삭제를 사용해야 합니다. groupId : {0}"),
     ALREADY_JOINED(HttpStatus.CONFLICT, "이미 참여 중인 그룹입니다. groupId : {0}, memberId : {1}"),
     INVITE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 그룹 초대 코드를 찾을 수 없습니다. inviteCode : {0}"),
-    INVITE_EXPIRED(HttpStatus.CONFLICT, "만료된 그룹 초대 코드입니다. inviteCode : {0}"),
-    INVITE_REVOKED(HttpStatus.CONFLICT, "취소된 그룹 초대 코드입니다. inviteCode : {0}"),
+    INVITE_EXPIRED(HttpStatus.CONFLICT, "만료된 그룹 초대입니다. inviteIdOrCode : {0}"),
+    INVITE_REVOKED(HttpStatus.CONFLICT, "취소된 그룹 초대입니다. inviteIdOrCode : {0}"),
     INVITE_CODE_GENERATION_FAILED(HttpStatus.CONFLICT, "그룹 고정 초대 코드 생성에 실패했습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupInviteRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupInviteRepository.java
@@ -1,24 +1,13 @@
 package matchuri.backend.domain.group.repository;
 
 import java.util.List;
-import java.util.Optional;
 import matchuri.backend.domain.group.entity.GroupInvite;
 import matchuri.backend.domain.group.entity.GroupInviteStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface GroupInviteRepository extends JpaRepository<GroupInvite, Long> {
 
-    boolean existsByInviteCode(String inviteCode);
-
     List<GroupInvite> findAllByRoomIdAndStatus(Long roomId, GroupInviteStatus status);
 
-    @Query("""
-            select groupInvite
-            from GroupInvite groupInvite
-            join fetch groupInvite.room room
-            where groupInvite.inviteCode = :inviteCode
-            """)
-    Optional<GroupInvite> findByInviteCodeWithRoom(@Param("inviteCode") String inviteCode);
+    boolean existsByRoomIdAndTargetMemberIdAndStatus(Long roomId, Long targetMemberId, GroupInviteStatus status);
 }

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRoomRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRoomRepository.java
@@ -10,4 +10,6 @@ public interface GroupRoomRepository extends JpaRepository<GroupRoom, Long> {
     Optional<GroupRoom> findByIdAndStatusNot(Long id, GroupRoomStatus status);
 
     boolean existsByInviteCode(String inviteCode);
+
+    Optional<GroupRoom> findByInviteCode(String inviteCode);
 }

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -11,7 +11,6 @@ import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.command.JoinGroupCommand;
 import matchuri.backend.domain.group.command.LeaveGroupCommand;
 import matchuri.backend.domain.group.command.UpdateGroupCommand;
-import matchuri.backend.domain.group.entity.GroupInvite;
 import matchuri.backend.domain.group.entity.GroupInviteStatus;
 import matchuri.backend.domain.group.entity.GroupMemberRole;
 import matchuri.backend.domain.group.entity.GroupMemberStatus;
@@ -78,12 +77,9 @@ public class GroupServiceImpl implements GroupService {
     @Override
     public JoinGroupResult joinGroup(JoinGroupCommand command) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
-        GroupInvite groupInvite = groupInviteRepository.findByInviteCodeWithRoom(command.inviteCode())
+        GroupRoom room = groupRoomRepository.findByInviteCode(command.inviteCode())
                 .orElseThrow(() -> new BusinessException(GroupErrorCode.INVITE_NOT_FOUND, command.inviteCode()));
 
-        validateJoinableInvite(groupInvite, command.inviteCode());
-
-        GroupRoom room = groupInvite.getRoom();
         if (!room.isActive()) {
             throw new BusinessException(GroupErrorCode.NOT_ACTIVE, room.getId());
         }
@@ -271,21 +267,6 @@ public class GroupServiceImpl implements GroupService {
         throw new BusinessException(GroupErrorCode.INVITE_CODE_GENERATION_FAILED);
     }
 
-    private void validateJoinableInvite(GroupInvite groupInvite, String inviteCode) {
-        if (groupInvite.getStatus() == GroupInviteStatus.REVOKED) {
-            throw new BusinessException(GroupErrorCode.INVITE_REVOKED, inviteCode);
-        }
-
-        if (groupInvite.getStatus() == GroupInviteStatus.EXPIRED) {
-            throw new BusinessException(GroupErrorCode.INVITE_EXPIRED, inviteCode);
-        }
-
-        if (groupInvite.getExpiresAt() != null && !groupInvite.getExpiresAt().isAfter(LocalDateTime.now())) {
-            groupInvite.expire();
-            throw new BusinessException(GroupErrorCode.INVITE_EXPIRED, inviteCode);
-        }
-    }
-
     private GroupRoomMember joinOrRejoinMember(GroupRoom room, Member member) {
         return groupRoomMemberRepository.findByRoomIdAndMemberId(room.getId(), member.getId())
                 .map(membership -> rejoinExistingMembership(room, member, membership))
@@ -312,8 +293,8 @@ public class GroupServiceImpl implements GroupService {
     }
 
     private void revokeActiveInvites(GroupRoom room) {
-        groupInviteRepository.findAllByRoomIdAndStatus(room.getId(), GroupInviteStatus.ACTIVE)
-                .forEach(GroupInvite::revoke);
+        groupInviteRepository.findAllByRoomIdAndStatus(room.getId(), GroupInviteStatus.PENDING)
+                .forEach(groupInvite -> groupInvite.revoke());
     }
 
     private void leaveActiveMembers(GroupRoom room, LocalDateTime leftAt) {

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -469,7 +469,6 @@ class GroupIntegrationTest {
         Member owner = saveMember("join-owner", "입장방장");
         Member newMember = saveMember("join-new-member", "입장멤버");
         GroupRoom groupRoom = saveGroupOwnedBy(owner, "입장 그룹");
-        GroupInvite invite = saveInvite(groupRoom, owner, "JOIN2026", LocalDateTime.now().plusHours(1));
 
         mockMvc.perform(post("/api/v1/groups/join")
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(newMember)))
@@ -478,7 +477,7 @@ class GroupIntegrationTest {
                                 {
                                   "inviteCode": "%s"
                                 }
-                                """.formatted(invite.getInviteCode())))
+                                """.formatted(groupRoom.getInviteCode())))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.groupId").value(groupRoom.getId()))
@@ -509,7 +508,6 @@ class GroupIntegrationTest {
         membership.leave(LocalDateTime.now().minusDays(1));
         groupRoomMemberRepository.save(membership);
         LocalDateTime previousJoinedAt = membership.getJoinedAt();
-        GroupInvite invite = saveInvite(groupRoom, owner, "REJOIN26", LocalDateTime.now().plusHours(1));
 
         mockMvc.perform(post("/api/v1/groups/join")
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(leftMember)))
@@ -518,7 +516,7 @@ class GroupIntegrationTest {
                                 {
                                   "inviteCode": "%s"
                                 }
-                                """.formatted(invite.getInviteCode())))
+                                """.formatted(groupRoom.getInviteCode())))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.groupId").value(groupRoom.getId()))
                 .andExpect(jsonPath("$.data.memberStatus").value(GroupMemberStatus.ACTIVE.name()));
@@ -545,7 +543,6 @@ class GroupIntegrationTest {
                 GroupMemberRole.MEMBER,
                 LocalDateTime.now()
         ));
-        GroupInvite invite = saveInvite(groupRoom, owner, "ACTIVE26", LocalDateTime.now().plusHours(1));
 
         mockMvc.perform(post("/api/v1/groups/join")
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(activeMember)))
@@ -554,7 +551,7 @@ class GroupIntegrationTest {
                                 {
                                   "inviteCode": "%s"
                                 }
-                                """.formatted(invite.getInviteCode())))
+                                """.formatted(groupRoom.getInviteCode())))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error.code").value("GROUP_ALREADY_JOINED"));
     }
@@ -577,48 +574,6 @@ class GroupIntegrationTest {
     }
 
     @Test
-    @DisplayName("초대 코드 입장은 만료된 코드이면 실패한다")
-    void joinGroupFailsForExpiredInvite() throws Exception {
-        Member owner = saveMember("expired-invite-owner", "만료초대방장");
-        Member member = saveMember("expired-invite-member", "만료초대멤버");
-        GroupRoom groupRoom = saveGroupOwnedBy(owner, "만료 입장 그룹");
-        GroupInvite invite = saveInvite(groupRoom, owner, "EXPIRED1", LocalDateTime.now().minusMinutes(1));
-
-        mockMvc.perform(post("/api/v1/groups/join")
-                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member)))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "inviteCode": "%s"
-                                }
-                                """.formatted(invite.getInviteCode())))
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.error.code").value("GROUP_INVITE_EXPIRED"));
-    }
-
-    @Test
-    @DisplayName("초대 코드 입장은 취소된 코드이면 실패한다")
-    void joinGroupFailsForRevokedInvite() throws Exception {
-        Member owner = saveMember("revoked-invite-owner", "취소초대방장");
-        Member member = saveMember("revoked-invite-member", "취소초대멤버");
-        GroupRoom groupRoom = saveGroupOwnedBy(owner, "취소 입장 그룹");
-        GroupInvite invite = saveInvite(groupRoom, owner, "REVOKED1", LocalDateTime.now().plusHours(1));
-        invite.revoke();
-        groupInviteRepository.save(invite);
-
-        mockMvc.perform(post("/api/v1/groups/join")
-                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member)))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "inviteCode": "%s"
-                                }
-                                """.formatted(invite.getInviteCode())))
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.error.code").value("GROUP_INVITE_REVOKED"));
-    }
-
-    @Test
     @DisplayName("초대 코드 입장은 연결된 그룹이 ACTIVE가 아니면 실패한다")
     void joinGroupFailsForNotActiveGroup() throws Exception {
         Member owner = saveMember("not-active-join-owner", "닫힌입장방장");
@@ -626,7 +581,6 @@ class GroupIntegrationTest {
         GroupRoom groupRoom = saveGroupOwnedBy(owner, "닫힌 입장 그룹");
         groupRoom.close();
         groupRoomRepository.save(groupRoom);
-        GroupInvite invite = saveInvite(groupRoom, owner, "CLOSED26", LocalDateTime.now().plusHours(1));
 
         mockMvc.perform(post("/api/v1/groups/join")
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member)))
@@ -635,7 +589,7 @@ class GroupIntegrationTest {
                                 {
                                   "inviteCode": "%s"
                                 }
-                                """.formatted(invite.getInviteCode())))
+                                """.formatted(groupRoom.getInviteCode())))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error.code").value("GROUP_NOT_ACTIVE"));
     }
@@ -764,10 +718,10 @@ class GroupIntegrationTest {
         LocalDateTime alreadyLeftAt = LocalDateTime.of(2026, 5, 18, 9, 0);
         leftMembership.leave(alreadyLeftAt);
         groupRoomMemberRepository.save(leftMembership);
-        GroupInvite activeInvite = saveInvite(groupRoom, owner, "DELETE01", LocalDateTime.now().plusHours(1));
-        GroupInvite revokedInvite = saveInvite(groupRoom, owner, "DELETE02", LocalDateTime.now().plusHours(1));
-        revokedInvite.revoke();
-        groupInviteRepository.save(revokedInvite);
+        GroupInvite pendingInvite = saveInvite(groupRoom, owner, activeMember, LocalDateTime.now().plusHours(1));
+        GroupInvite declinedInvite = saveInvite(groupRoom, owner, leftMember, LocalDateTime.now().plusHours(1));
+        declinedInvite.decline(LocalDateTime.now());
+        groupInviteRepository.save(declinedInvite);
 
         mockMvc.perform(delete("/api/v1/groups/{groupId}", groupRoom.getId())
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
@@ -787,8 +741,8 @@ class GroupIntegrationTest {
         GroupRoomMember savedLeftMembership = groupRoomMemberRepository
                 .findById(leftMembership.getId())
                 .orElseThrow();
-        GroupInvite savedActiveInvite = groupInviteRepository.findById(activeInvite.getId()).orElseThrow();
-        GroupInvite savedRevokedInvite = groupInviteRepository.findById(revokedInvite.getId()).orElseThrow();
+        GroupInvite savedPendingInvite = groupInviteRepository.findById(pendingInvite.getId()).orElseThrow();
+        GroupInvite savedDeclinedInvite = groupInviteRepository.findById(declinedInvite.getId()).orElseThrow();
 
         assertThat(deletedGroup.getStatus()).isEqualTo(GroupRoomStatus.DELETED);
         assertThat(ownerMembership.getStatus()).isEqualTo(GroupMemberStatus.LEFT);
@@ -797,8 +751,8 @@ class GroupIntegrationTest {
         assertThat(savedActiveMembership.getLeftAt()).isNotNull();
         assertThat(savedLeftMembership.getStatus()).isEqualTo(GroupMemberStatus.LEFT);
         assertThat(savedLeftMembership.getLeftAt()).isEqualTo(alreadyLeftAt);
-        assertThat(savedActiveInvite.getStatus()).isEqualTo(GroupInviteStatus.REVOKED);
-        assertThat(savedRevokedInvite.getStatus()).isEqualTo(GroupInviteStatus.REVOKED);
+        assertThat(savedPendingInvite.getStatus()).isEqualTo(GroupInviteStatus.REVOKED);
+        assertThat(savedDeclinedInvite.getStatus()).isEqualTo(GroupInviteStatus.DECLINED);
     }
 
     @Test
@@ -874,10 +828,10 @@ class GroupIntegrationTest {
     private GroupInvite saveInvite(
             GroupRoom groupRoom,
             Member createdByMember,
-            String inviteCode,
+            Member targetMember,
             LocalDateTime expiresAt
     ) {
-        return groupInviteRepository.save(new GroupInvite(groupRoom, createdByMember, inviteCode, expiresAt));
+        return groupInviteRepository.save(new GroupInvite(groupRoom, createdByMember, targetMember, expiresAt));
     }
 
     private void leaveOwnerMembership(GroupRoom groupRoom, Member member) {


### PR DESCRIPTION
## 관련 이슈
Closes #213 

## 📝 작업 내용
- `group_invites`에 `request_member_id`, `target_member_id`, `responded_at `추가

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [x] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- `docker-compose down -v` 실행하여 DB 초기화 바랍니다.
