### PR TITLE
[Feat] 그룹 사용자 초대 API 

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import matchuri.backend.api.group.dto.docs.CreateGroupApiResponse;
+import matchuri.backend.api.group.dto.docs.CreateNicknameGroupInviteApiResponse;
 import matchuri.backend.api.group.dto.docs.CreateGroupRecommendationApiResponse;
 import matchuri.backend.api.group.dto.docs.DeleteGroupApiResponse;
 import matchuri.backend.api.group.dto.docs.FinalizeGroupRecommendationApiResponse;
@@ -25,11 +26,13 @@ import matchuri.backend.api.group.dto.docs.LeaveGroupApiResponse;
 import matchuri.backend.api.group.dto.docs.UpdateGroupApiResponse;
 import matchuri.backend.api.group.dto.request.CreateGroupRecommendationRequest;
 import matchuri.backend.api.group.dto.request.CreateGroupRequest;
+import matchuri.backend.api.group.dto.request.CreateNicknameGroupInviteRequest;
 import matchuri.backend.api.group.dto.request.JoinGroupRequest;
 import matchuri.backend.api.group.dto.request.UpdateGroupRequest;
 import matchuri.backend.api.group.dto.request.VoteGroupRecommendationRequest;
 import matchuri.backend.api.group.dto.response.CreateGroupRecommendationResponse;
 import matchuri.backend.api.group.dto.response.CreateGroupResponse;
+import matchuri.backend.api.group.dto.response.CreateNicknameGroupInviteResponse;
 import matchuri.backend.api.group.dto.response.DeleteGroupResponse;
 import matchuri.backend.api.group.dto.response.FinalizeGroupRecommendationResponse;
 import matchuri.backend.api.group.dto.response.GroupDetailResponse;
@@ -140,6 +143,37 @@ public interface GroupApi {
             )
     })
     ApiResponse<GroupDetailResponse> getGroup(Long groupId);
+
+    @Operation(
+            summary = "닉네임 기반 그룹 초대 생성",
+            description = """
+                    닉네임으로 특정 회원에게 그룹 초대 요청을 보냅니다.
+
+                    구현 기준:
+                    - 로그인한 활성 회원만 사용할 수 있습니다.
+                    - 현재 회원이 해당 그룹의 `ACTIVE` OWNER 멤버일 때만 초대할 수 있습니다.
+                    - 초대 대상은 활성 회원의 nickname으로 찾습니다.
+                    - 자기 자신, 이미 그룹에 참여 중인 회원, 동일 그룹/대상의 `PENDING` 초대는 거절합니다.
+                    - 초대 요청은 생성 시점부터 24시간 뒤 만료됩니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "초대 생성 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CreateNicknameGroupInviteApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = GroupApiExamples.CREATE_NICKNAME_INVITE_SUCCESS
+                            )
+                    )
+            )
+    })
+    ApiResponse<CreateNicknameGroupInviteResponse> createNicknameInvite(
+            @Valid CreateNicknameGroupInviteRequest request
+    );
 
     @Operation(
             summary = "그룹 수정",

--- a/src/main/java/matchuri/backend/api/group/GroupController.java
+++ b/src/main/java/matchuri/backend/api/group/GroupController.java
@@ -7,11 +7,13 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.api.group.dto.request.CreateGroupRecommendationRequest;
 import matchuri.backend.api.group.dto.request.CreateGroupRequest;
+import matchuri.backend.api.group.dto.request.CreateNicknameGroupInviteRequest;
 import matchuri.backend.api.group.dto.request.JoinGroupRequest;
 import matchuri.backend.api.group.dto.request.UpdateGroupRequest;
 import matchuri.backend.api.group.dto.request.VoteGroupRecommendationRequest;
 import matchuri.backend.api.group.dto.response.CreateGroupRecommendationResponse;
 import matchuri.backend.api.group.dto.response.CreateGroupResponse;
+import matchuri.backend.api.group.dto.response.CreateNicknameGroupInviteResponse;
 import matchuri.backend.api.group.dto.response.DeleteGroupResponse;
 import matchuri.backend.api.group.dto.response.FinalizeGroupRecommendationResponse;
 import matchuri.backend.api.group.dto.response.GroupDetailResponse;
@@ -23,6 +25,7 @@ import matchuri.backend.api.group.dto.response.JoinGroupResponse;
 import matchuri.backend.api.group.dto.response.LeaveGroupResponse;
 import matchuri.backend.api.group.dto.response.UpdateGroupResponse;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
+import matchuri.backend.domain.group.command.CreateNicknameGroupInviteCommand;
 import matchuri.backend.domain.group.command.DeleteGroupCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.command.JoinGroupCommand;
@@ -30,6 +33,7 @@ import matchuri.backend.domain.group.command.LeaveGroupCommand;
 import matchuri.backend.domain.group.command.UpdateGroupCommand;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.result.CreateGroupResult;
+import matchuri.backend.domain.group.result.CreateNicknameGroupInviteResult;
 import matchuri.backend.domain.group.result.DeleteGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
@@ -92,6 +96,17 @@ public class GroupController implements GroupApi {
         GroupDetailResult result = groupService.getGroup(groupId);
 
         return ApiResponse.success(groupMapper.toGroupDetailResponse(result));
+    }
+
+    @Override
+    @PostMapping("/invites/nickname")
+    public ApiResponse<CreateNicknameGroupInviteResponse> createNicknameInvite(
+            @Valid @RequestBody CreateNicknameGroupInviteRequest request
+    ) {
+        CreateNicknameGroupInviteCommand command = groupMapper.toCreateNicknameGroupInviteCommand(request);
+        CreateNicknameGroupInviteResult result = groupService.createNicknameInvite(command);
+
+        return ApiResponse.success(groupMapper.toCreateNicknameGroupInviteResponse(result));
     }
 
     @Override

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -1,8 +1,10 @@
 package matchuri.backend.api.group;
 
 import matchuri.backend.api.group.dto.request.CreateGroupRequest;
+import matchuri.backend.api.group.dto.request.CreateNicknameGroupInviteRequest;
 import matchuri.backend.api.group.dto.request.JoinGroupRequest;
 import matchuri.backend.api.group.dto.request.UpdateGroupRequest;
+import matchuri.backend.api.group.dto.response.CreateNicknameGroupInviteResponse;
 import matchuri.backend.api.group.dto.response.CreateGroupResponse;
 import matchuri.backend.api.group.dto.response.DeleteGroupResponse;
 import matchuri.backend.api.group.dto.response.GroupDetailResponse;
@@ -12,6 +14,7 @@ import matchuri.backend.api.group.dto.response.JoinGroupResponse;
 import matchuri.backend.api.group.dto.response.LeaveGroupResponse;
 import matchuri.backend.api.group.dto.response.UpdateGroupResponse;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
+import matchuri.backend.domain.group.command.CreateNicknameGroupInviteCommand;
 import matchuri.backend.domain.group.command.DeleteGroupCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.command.JoinGroupCommand;
@@ -19,6 +22,7 @@ import matchuri.backend.domain.group.command.LeaveGroupCommand;
 import matchuri.backend.domain.group.command.UpdateGroupCommand;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.result.CreateGroupResult;
+import matchuri.backend.domain.group.result.CreateNicknameGroupInviteResult;
 import matchuri.backend.domain.group.result.DeleteGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
@@ -43,6 +47,29 @@ public class GroupMapper {
         return new CreateGroupResponse(
                 result.groupId(),
                 result.inviteCode(),
+                result.status()
+        );
+    }
+
+    public CreateNicknameGroupInviteCommand toCreateNicknameGroupInviteCommand(
+            CreateNicknameGroupInviteRequest request
+    ) {
+        return new CreateNicknameGroupInviteCommand(
+                request.groupId(),
+                request.nickname()
+        );
+    }
+
+    public CreateNicknameGroupInviteResponse toCreateNicknameGroupInviteResponse(
+            CreateNicknameGroupInviteResult result
+    ) {
+        return new CreateNicknameGroupInviteResponse(
+                result.inviteId(),
+                result.groupId(),
+                result.groupName(),
+                result.targetMemberId(),
+                result.targetNickname(),
+                result.expiresAt(),
                 result.status()
         );
     }

--- a/src/main/java/matchuri/backend/api/group/dto/docs/CreateNicknameGroupInviteApiResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/CreateNicknameGroupInviteApiResponse.java
@@ -1,0 +1,11 @@
+package matchuri.backend.api.group.dto.docs;
+
+import matchuri.backend.api.group.dto.response.CreateNicknameGroupInviteResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+public record CreateNicknameGroupInviteApiResponse(
+        boolean success,
+        CreateNicknameGroupInviteResponse data,
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -107,6 +107,22 @@ public final class GroupApiExamples {
             }
             """;
 
+    public static final String CREATE_NICKNAME_INVITE_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "inviteId": 501,
+                "groupId": 3001,
+                "groupName": "오늘 점심 메뉴 회의",
+                "targetMemberId": 42,
+                "targetNickname": "점심탐험가",
+                "expiresAt": "2026-05-20T12:00:00",
+                "status": "PENDING"
+              },
+              "error": null
+            }
+            """;
+
     public static final String JOIN_GROUP_SUCCESS = """
             {
               "success": true,

--- a/src/main/java/matchuri/backend/api/group/dto/request/CreateNicknameGroupInviteRequest.java
+++ b/src/main/java/matchuri/backend/api/group/dto/request/CreateNicknameGroupInviteRequest.java
@@ -1,0 +1,19 @@
+package matchuri.backend.api.group.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import matchuri.backend.domain.member.entity.Member;
+
+public record CreateNicknameGroupInviteRequest(
+        @Schema(description = "초대를 보낼 그룹 ID입니다.", example = "3001")
+        @NotNull(message = "groupId는 필수입니다.")
+        Long groupId,
+
+        @Schema(description = "초대할 회원의 닉네임입니다.", example = "점심탐험가")
+        @NotBlank(message = "nickname은 비어 있을 수 없습니다.")
+        @Size(max = Member.NICKNAME_MAX_SIZE, message = "nickname은 " + Member.NICKNAME_MAX_SIZE + "자를 초과할 수 없습니다.")
+        String nickname
+) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/response/CreateNicknameGroupInviteResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/CreateNicknameGroupInviteResponse.java
@@ -1,0 +1,29 @@
+package matchuri.backend.api.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import matchuri.backend.domain.group.entity.GroupInviteStatus;
+
+public record CreateNicknameGroupInviteResponse(
+        @Schema(description = "생성된 초대 ID입니다.", example = "501")
+        Long inviteId,
+
+        @Schema(description = "초대 대상 그룹 ID입니다.", example = "3001")
+        Long groupId,
+
+        @Schema(description = "초대 대상 그룹 이름입니다.", example = "오늘 점심 메뉴 회의")
+        String groupName,
+
+        @Schema(description = "초대 대상 회원 ID입니다.", example = "42")
+        Long targetMemberId,
+
+        @Schema(description = "초대 대상 회원 닉네임입니다.", example = "점심탐험가")
+        String targetNickname,
+
+        @Schema(description = "초대 만료 시각입니다.", example = "2026-05-20T12:00:00")
+        LocalDateTime expiresAt,
+
+        @Schema(description = "초대 상태입니다.", example = "PENDING")
+        GroupInviteStatus status
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/command/CreateNicknameGroupInviteCommand.java
+++ b/src/main/java/matchuri/backend/domain/group/command/CreateNicknameGroupInviteCommand.java
@@ -1,0 +1,7 @@
+package matchuri.backend.domain.group.command;
+
+public record CreateNicknameGroupInviteCommand(
+        Long groupId,
+        String nickname
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
@@ -23,6 +23,11 @@ public enum GroupErrorCode implements ErrorCode {
     INVITE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 그룹 초대 코드를 찾을 수 없습니다. inviteCode : {0}"),
     INVITE_EXPIRED(HttpStatus.CONFLICT, "만료된 그룹 초대입니다. inviteIdOrCode : {0}"),
     INVITE_REVOKED(HttpStatus.CONFLICT, "취소된 그룹 초대입니다. inviteIdOrCode : {0}"),
+    INVITE_FORBIDDEN(HttpStatus.FORBIDDEN, "그룹 초대 권한이 없습니다. groupId : {0}"),
+    INVITE_TARGET_NOT_FOUND(HttpStatus.NOT_FOUND, "초대 대상 회원을 찾을 수 없습니다. nickname : {0}"),
+    INVITE_SELF_NOT_ALLOWED(HttpStatus.CONFLICT, "자기 자신은 그룹에 초대할 수 없습니다. memberId : {0}"),
+    INVITE_TARGET_ALREADY_MEMBER(HttpStatus.CONFLICT, "이미 그룹에 참여 중인 회원입니다. groupId : {0}, memberId : {1}"),
+    INVITE_ALREADY_PENDING(HttpStatus.CONFLICT, "이미 대기 중인 그룹 초대가 있습니다. groupId : {0}, memberId : {1}"),
     INVITE_CODE_GENERATION_FAILED(HttpStatus.CONFLICT, "그룹 고정 초대 코드 생성에 실패했습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/matchuri/backend/domain/group/result/CreateNicknameGroupInviteResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/CreateNicknameGroupInviteResult.java
@@ -1,0 +1,15 @@
+package matchuri.backend.domain.group.result;
+
+import java.time.LocalDateTime;
+import matchuri.backend.domain.group.entity.GroupInviteStatus;
+
+public record CreateNicknameGroupInviteResult(
+        Long inviteId,
+        Long groupId,
+        String groupName,
+        Long targetMemberId,
+        String targetNickname,
+        LocalDateTime expiresAt,
+        GroupInviteStatus status
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/service/GroupService.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupService.java
@@ -2,12 +2,14 @@ package matchuri.backend.domain.group.service;
 
 import lombok.NonNull;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
+import matchuri.backend.domain.group.command.CreateNicknameGroupInviteCommand;
 import matchuri.backend.domain.group.command.DeleteGroupCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.command.JoinGroupCommand;
 import matchuri.backend.domain.group.command.LeaveGroupCommand;
 import matchuri.backend.domain.group.command.UpdateGroupCommand;
 import matchuri.backend.domain.group.result.CreateGroupResult;
+import matchuri.backend.domain.group.result.CreateNicknameGroupInviteResult;
 import matchuri.backend.domain.group.result.DeleteGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
@@ -19,6 +21,8 @@ import org.springframework.data.domain.Page;
 public interface GroupService {
 
     CreateGroupResult createGroup(CreateGroupCommand command);
+
+    CreateNicknameGroupInviteResult createNicknameInvite(CreateNicknameGroupInviteCommand command);
 
     JoinGroupResult joinGroup(JoinGroupCommand command);
 

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -6,11 +6,13 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
+import matchuri.backend.domain.group.command.CreateNicknameGroupInviteCommand;
 import matchuri.backend.domain.group.command.DeleteGroupCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.command.JoinGroupCommand;
 import matchuri.backend.domain.group.command.LeaveGroupCommand;
 import matchuri.backend.domain.group.command.UpdateGroupCommand;
+import matchuri.backend.domain.group.entity.GroupInvite;
 import matchuri.backend.domain.group.entity.GroupInviteStatus;
 import matchuri.backend.domain.group.entity.GroupMemberRole;
 import matchuri.backend.domain.group.entity.GroupMemberStatus;
@@ -23,6 +25,7 @@ import matchuri.backend.domain.group.repository.GroupRoomMemberCountProjection;
 import matchuri.backend.domain.group.repository.GroupRoomMemberRepository;
 import matchuri.backend.domain.group.repository.GroupRoomRepository;
 import matchuri.backend.domain.group.result.CreateGroupResult;
+import matchuri.backend.domain.group.result.CreateNicknameGroupInviteResult;
 import matchuri.backend.domain.group.result.DeleteGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
@@ -32,6 +35,8 @@ import matchuri.backend.domain.group.result.LeaveGroupResult;
 import matchuri.backend.domain.group.result.UpdateGroupResult;
 import matchuri.backend.domain.group.support.GroupInviteCodeGenerator;
 import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.entity.MemberStatus;
+import matchuri.backend.domain.member.repository.MemberRepository;
 import matchuri.backend.domain.member.support.member.ActiveMemberReader;
 import matchuri.backend.global.exception.BusinessException;
 import org.jspecify.annotations.NonNull;
@@ -46,8 +51,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class GroupServiceImpl implements GroupService {
 
     private static final int MAX_INVITE_CODE_GENERATION_ATTEMPTS = 5;
+    private static final int NICKNAME_INVITE_EXPIRATION_HOURS = 24;
 
     private final ActiveMemberReader activeMemberReader;
+    private final MemberRepository memberRepository;
     private final GroupRoomRepository groupRoomRepository;
     private final GroupRoomMemberRepository groupRoomMemberRepository;
     private final GroupInviteRepository groupInviteRepository;
@@ -71,6 +78,61 @@ public class GroupServiceImpl implements GroupService {
                 savedGroupRoom.getId(),
                 savedGroupRoom.getInviteCode(),
                 savedGroupRoom.getStatus()
+        );
+    }
+
+    @Override
+    public CreateNicknameGroupInviteResult createNicknameInvite(CreateNicknameGroupInviteCommand command) {
+        Member requestMember = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        GroupRoom room = groupRoomRepository.findByIdAndStatusNot(command.groupId(), GroupRoomStatus.DELETED)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.NOT_FOUND, command.groupId()));
+
+        if (!room.isActive()) {
+            throw new BusinessException(GroupErrorCode.NOT_ACTIVE, command.groupId());
+        }
+
+        GroupRoomMember requestMembership = groupRoomMemberRepository
+                .findActiveMembershipInNotDeletedRoom(room.getId(), requestMember.getId())
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.INVITE_FORBIDDEN, room.getId()));
+
+        if (!requestMembership.isOwner()) {
+            throw new BusinessException(GroupErrorCode.INVITE_FORBIDDEN, room.getId());
+        }
+
+        Member targetMember = memberRepository.findByNicknameAndStatus(command.nickname(), MemberStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.INVITE_TARGET_NOT_FOUND, command.nickname()));
+
+        if (requestMember.getId().equals(targetMember.getId())) {
+            throw new BusinessException(GroupErrorCode.INVITE_SELF_NOT_ALLOWED, requestMember.getId());
+        }
+
+        if (groupRoomMemberRepository.existsActiveMembershipInNotDeletedRoom(room.getId(), targetMember.getId())) {
+            throw new BusinessException(
+                    GroupErrorCode.INVITE_TARGET_ALREADY_MEMBER,
+                    room.getId(),
+                    targetMember.getId()
+            );
+        }
+
+        if (groupInviteRepository.existsByRoomIdAndTargetMemberIdAndStatus(
+                room.getId(),
+                targetMember.getId(),
+                GroupInviteStatus.PENDING
+        )) {
+            throw new BusinessException(GroupErrorCode.INVITE_ALREADY_PENDING, room.getId(), targetMember.getId());
+        }
+
+        LocalDateTime expiresAt = LocalDateTime.now().plusHours(NICKNAME_INVITE_EXPIRATION_HOURS);
+        GroupInvite invite = groupInviteRepository.save(new GroupInvite(room, requestMember, targetMember, expiresAt));
+
+        return new CreateNicknameGroupInviteResult(
+                invite.getId(),
+                room.getId(),
+                room.getName(),
+                targetMember.getId(),
+                targetMember.getNickname(),
+                invite.getExpiresAt(),
+                invite.getStatus()
         );
     }
 

--- a/src/main/java/matchuri/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/matchuri/backend/domain/member/repository/MemberRepository.java
@@ -22,6 +22,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByLoginId(String loginId);
 
+    Optional<Member> findByNicknameAndStatus(String nickname, MemberStatus status);
+
     Optional<Member> findByEmailAndSocialFalseAndStatus(String email, MemberStatus status);
 
     Optional<Member> findByLoginIdAndEmailAndSocialFalseAndStatus(String loginId, String email, MemberStatus status);

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -464,6 +464,166 @@ class GroupIntegrationTest {
     }
 
     @Test
+    @DisplayName("닉네임 그룹 초대 생성은 OWNER가 대상 회원에게 PENDING 초대를 저장한다")
+    void createNicknameInviteCreatesPendingInviteForOwner() throws Exception {
+        Member owner = saveMember("nickname-invite-owner", "닉초대방장");
+        Member target = saveMember("nickname-invite-target", "닉초대대상");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "닉네임 초대 그룹");
+        LocalDateTime beforeExpectedExpiry = LocalDateTime.now().plusHours(24);
+
+        mockMvc.perform(post("/api/v1/groups/invites/nickname")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "groupId": %d,
+                                  "nickname": "%s"
+                                }
+                                """.formatted(groupRoom.getId(), target.getNickname())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.inviteId").isNumber())
+                .andExpect(jsonPath("$.data.groupId").value(groupRoom.getId()))
+                .andExpect(jsonPath("$.data.groupName").value("닉네임 초대 그룹"))
+                .andExpect(jsonPath("$.data.targetMemberId").value(target.getId()))
+                .andExpect(jsonPath("$.data.targetNickname").value(target.getNickname()))
+                .andExpect(jsonPath("$.data.expiresAt").isNotEmpty())
+                .andExpect(jsonPath("$.data.status").value(GroupInviteStatus.PENDING.name()));
+
+        LocalDateTime afterExpectedExpiry = LocalDateTime.now().plusHours(24);
+        GroupInvite savedInvite = groupInviteRepository.findAll().getFirst();
+
+        assertThat(savedInvite.getRoom().getId()).isEqualTo(groupRoom.getId());
+        assertThat(savedInvite.getRequestMember().getId()).isEqualTo(owner.getId());
+        assertThat(savedInvite.getTargetMember().getId()).isEqualTo(target.getId());
+        assertThat(savedInvite.getStatus()).isEqualTo(GroupInviteStatus.PENDING);
+        assertThat(savedInvite.getExpiresAt()).isBetween(beforeExpectedExpiry, afterExpectedExpiry);
+        assertThat(savedInvite.getRespondedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("닉네임 그룹 초대 생성은 OWNER가 아니면 거절한다")
+    void createNicknameInviteFailsForNonOwner() throws Exception {
+        Member owner = saveMember("nickname-non-owner-host", "닉초대방장2");
+        Member requester = saveMember("nickname-non-owner-requester", "닉초대멤버");
+        Member target = saveMember("nickname-non-owner-target", "닉초대대상2");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "멤버 닉네임 초대 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                requester,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+
+        mockMvc.perform(post("/api/v1/groups/invites/nickname")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(requester)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "groupId": %d,
+                                  "nickname": "%s"
+                                }
+                                """.formatted(groupRoom.getId(), target.getNickname())))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("GROUP_INVITE_FORBIDDEN"));
+
+        assertThat(groupInviteRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("닉네임 그룹 초대 생성은 대상 닉네임이 없으면 실패한다")
+    void createNicknameInviteFailsForMissingTargetNickname() throws Exception {
+        Member owner = saveMember("nickname-missing-owner", "닉없는대상방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "없는 대상 초대 그룹");
+
+        mockMvc.perform(post("/api/v1/groups/invites/nickname")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "groupId": %d,
+                                  "nickname": "없는닉네임"
+                                }
+                                """.formatted(groupRoom.getId())))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("GROUP_INVITE_TARGET_NOT_FOUND"));
+
+        assertThat(groupInviteRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("닉네임 그룹 초대 생성은 자기 자신 초대를 거절한다")
+    void createNicknameInviteFailsForSelfInvite() throws Exception {
+        Member owner = saveMember("nickname-self-owner", "닉자기초대방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "자기 초대 그룹");
+
+        mockMvc.perform(post("/api/v1/groups/invites/nickname")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "groupId": %d,
+                                  "nickname": "%s"
+                                }
+                                """.formatted(groupRoom.getId(), owner.getNickname())))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("GROUP_INVITE_SELF_NOT_ALLOWED"));
+
+        assertThat(groupInviteRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("닉네임 그룹 초대 생성은 이미 활성 멤버인 대상이면 거절한다")
+    void createNicknameInviteFailsForAlreadyActiveTargetMember() throws Exception {
+        Member owner = saveMember("nickname-active-owner", "닉활성방장");
+        Member target = saveMember("nickname-active-target", "닉활성대상");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "활성 대상 초대 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                target,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+
+        mockMvc.perform(post("/api/v1/groups/invites/nickname")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "groupId": %d,
+                                  "nickname": "%s"
+                                }
+                                """.formatted(groupRoom.getId(), target.getNickname())))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("GROUP_INVITE_TARGET_ALREADY_MEMBER"));
+
+        assertThat(groupInviteRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("닉네임 그룹 초대 생성은 같은 그룹과 대상의 PENDING 초대가 있으면 거절한다")
+    void createNicknameInviteFailsForDuplicatePendingInvite() throws Exception {
+        Member owner = saveMember("nickname-duplicate-owner", "닉중복방장");
+        Member target = saveMember("nickname-duplicate-target", "닉중복대상");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "중복 초대 그룹");
+        saveInvite(groupRoom, owner, target, LocalDateTime.now().plusHours(1));
+
+        mockMvc.perform(post("/api/v1/groups/invites/nickname")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "groupId": %d,
+                                  "nickname": "%s"
+                                }
+                                """.formatted(groupRoom.getId(), target.getNickname())))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("GROUP_INVITE_ALREADY_PENDING"));
+
+        assertThat(groupInviteRepository.count()).isEqualTo(1);
+    }
+
+    @Test
     @DisplayName("초대 코드 입장은 신규 멤버를 ACTIVE 멤버로 저장한다")
     void joinGroupCreatesActiveMember() throws Exception {
         Member owner = saveMember("join-owner", "입장방장");

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -322,6 +322,14 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}'].patch.responses['200'].content['application/json'].examples.success.value.data.latitude")
                         .value(37.498095))
+                .andExpect(jsonPath("$.paths['/api/v1/groups/invites/nickname'].post.summary")
+                        .value("닉네임 기반 그룹 초대 생성"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/invites/nickname'].post.responses['200'].content['application/json'].examples.success.value.data.status")
+                        .value("PENDING"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/invites/nickname'].post.responses['200'].content['application/json'].examples.success.value.data.targetNickname")
+                        .value("점심탐험가"))
                 .andExpect(jsonPath("$.paths['/api/v1/groups/{groupId}/invites']").doesNotExist())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/join'].post.responses['200'].content['application/json'].examples.success.value.data.memberStatus")


### PR DESCRIPTION
## 관련 이슈
Closes #209 

## 📝 작업 내용
- `POST /api/v1/groups/invites/nickname`
- 요청 DTO: groupId, nickname
- 응답 DTO: inviteId, groupId, groupName, targetMemberId, targetNickname, expiresAt, status
- OWNER만 초대 가능
- 대상 nickname 활성 회원 조회
- 자기 초대 차단
- 이미 ACTIVE 멤버인 대상 차단
- 같은 그룹/대상 PENDING 초대 중복 생성 차단
- 초대 만료 시각 now + 24h
- request_member_id 기준으로 GroupInvite 저장
- OpenAPI 예시와 API 문서 갱신

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항

- 자기 자신 초대시 exception
- 이미 초대했던 사용자에게는 초대 불가
- 초대 만료는 24시간

```json
{
  "groupId": 1,
  "nickname": "테스터일"
}
```

```json
{
  "success": true,
  "data": {
    "inviteId": 1,
    "groupId": 1,
    "groupName": "오늘 점심 메뉴 회의",
    "targetMemberId": 1,
    "targetNickname": "테스터일",
    "expiresAt": "2026-05-20T04:55:39.2719393",
    "status": "PENDING"
  },
  "error": null
}
```