### PR TITLE
[Feat] 내 초대 목록 API

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -17,6 +17,7 @@ import matchuri.backend.api.group.dto.docs.DeleteGroupApiResponse;
 import matchuri.backend.api.group.dto.docs.FinalizeGroupRecommendationApiResponse;
 import matchuri.backend.api.group.dto.docs.GroupApiExamples;
 import matchuri.backend.api.group.dto.docs.GroupDetailApiResponse;
+import matchuri.backend.api.group.dto.docs.GroupInviteSummaryPageApiResponse;
 import matchuri.backend.api.group.dto.docs.GroupRecommendationCandidateListApiResponse;
 import matchuri.backend.api.group.dto.docs.GroupRecommendationSessionApiResponse;
 import matchuri.backend.api.group.dto.docs.GroupSummaryPageApiResponse;
@@ -36,6 +37,7 @@ import matchuri.backend.api.group.dto.response.CreateNicknameGroupInviteResponse
 import matchuri.backend.api.group.dto.response.DeleteGroupResponse;
 import matchuri.backend.api.group.dto.response.FinalizeGroupRecommendationResponse;
 import matchuri.backend.api.group.dto.response.GroupDetailResponse;
+import matchuri.backend.api.group.dto.response.GroupInviteSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateListResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationSessionResponse;
 import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
@@ -43,6 +45,7 @@ import matchuri.backend.api.group.dto.response.GroupVoteResponse;
 import matchuri.backend.api.group.dto.response.JoinGroupResponse;
 import matchuri.backend.api.group.dto.response.LeaveGroupResponse;
 import matchuri.backend.api.group.dto.response.UpdateGroupResponse;
+import matchuri.backend.domain.group.entity.GroupInviteStatus;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.global.api.ApiResponse;
 import matchuri.backend.global.api.PageResponse;
@@ -173,6 +176,45 @@ public interface GroupApi {
     })
     ApiResponse<CreateNicknameGroupInviteResponse> createNicknameInvite(
             @Valid CreateNicknameGroupInviteRequest request
+    );
+
+    @Operation(
+            summary = "내 그룹 초대 목록 조회",
+            description = """
+                    현재 회원이 받은 그룹 초대 목록을 조회합니다.
+
+                    - 로그인한 활성 회원만 사용할 수 있습니다.
+                    - 현재 회원이 초대 대상인 초대 요청만 반환합니다.
+                    - `status`를 생략하면 `PENDING` 초대만 조회합니다.
+                    - 생성 시각 최신순으로 정렬합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = GroupInviteSummaryPageApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = GroupApiExamples.MY_INVITES_SUCCESS
+                            )
+                    )
+            )
+    })
+    ApiResponse<PageResponse<GroupInviteSummaryResponse>> getMyInvites(
+            @Parameter(description = "초대 상태 필터입니다. 생략하면 PENDING 초대만 조회합니다.", example = "PENDING")
+            GroupInviteStatus status,
+
+            @Parameter(description = "0부터 시작하는 페이지 번호입니다.", example = "0")
+            @Min(0)
+            Integer page,
+
+            @Parameter(description = "페이지 크기입니다. 기본값은 20입니다.", example = "20")
+            @Min(1)
+            @Max(100)
+            Integer size
     );
 
     @Operation(

--- a/src/main/java/matchuri/backend/api/group/GroupController.java
+++ b/src/main/java/matchuri/backend/api/group/GroupController.java
@@ -17,6 +17,7 @@ import matchuri.backend.api.group.dto.response.CreateNicknameGroupInviteResponse
 import matchuri.backend.api.group.dto.response.DeleteGroupResponse;
 import matchuri.backend.api.group.dto.response.FinalizeGroupRecommendationResponse;
 import matchuri.backend.api.group.dto.response.GroupDetailResponse;
+import matchuri.backend.api.group.dto.response.GroupInviteSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateListResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationSessionResponse;
 import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
@@ -27,15 +28,18 @@ import matchuri.backend.api.group.dto.response.UpdateGroupResponse;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.CreateNicknameGroupInviteCommand;
 import matchuri.backend.domain.group.command.DeleteGroupCommand;
+import matchuri.backend.domain.group.command.GetMyGroupInvitesCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.command.JoinGroupCommand;
 import matchuri.backend.domain.group.command.LeaveGroupCommand;
 import matchuri.backend.domain.group.command.UpdateGroupCommand;
+import matchuri.backend.domain.group.entity.GroupInviteStatus;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.result.CreateGroupResult;
 import matchuri.backend.domain.group.result.CreateNicknameGroupInviteResult;
 import matchuri.backend.domain.group.result.DeleteGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
+import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
 import matchuri.backend.domain.group.result.LeaveGroupResult;
@@ -107,6 +111,24 @@ public class GroupController implements GroupApi {
         CreateNicknameGroupInviteResult result = groupService.createNicknameInvite(command);
 
         return ApiResponse.success(groupMapper.toCreateNicknameGroupInviteResponse(result));
+    }
+
+    @Override
+    @GetMapping("/invites/me")
+    public ApiResponse<PageResponse<GroupInviteSummaryResponse>> getMyInvites(
+            @RequestParam(required = false) GroupInviteStatus status,
+            @Min(0) @RequestParam(defaultValue = "0")
+            Integer page,
+
+            @Min(1) @Max(100) @RequestParam(defaultValue = "20")
+            Integer size
+    ) {
+        GetMyGroupInvitesCommand command = groupMapper.toGetMyGroupInvitesCommand(status, page, size);
+        Page<@NonNull GroupInviteSummaryResult> results = groupService.getMyInvites(command);
+        PageResponse<GroupInviteSummaryResponse> response =
+                PageResponse.of(results, groupMapper::toGroupInviteSummaryResponse);
+
+        return ApiResponse.success(response);
     }
 
     @Override

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -8,6 +8,7 @@ import matchuri.backend.api.group.dto.response.CreateNicknameGroupInviteResponse
 import matchuri.backend.api.group.dto.response.CreateGroupResponse;
 import matchuri.backend.api.group.dto.response.DeleteGroupResponse;
 import matchuri.backend.api.group.dto.response.GroupDetailResponse;
+import matchuri.backend.api.group.dto.response.GroupInviteSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupMemberSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
 import matchuri.backend.api.group.dto.response.JoinGroupResponse;
@@ -16,15 +17,18 @@ import matchuri.backend.api.group.dto.response.UpdateGroupResponse;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.CreateNicknameGroupInviteCommand;
 import matchuri.backend.domain.group.command.DeleteGroupCommand;
+import matchuri.backend.domain.group.command.GetMyGroupInvitesCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.command.JoinGroupCommand;
 import matchuri.backend.domain.group.command.LeaveGroupCommand;
 import matchuri.backend.domain.group.command.UpdateGroupCommand;
+import matchuri.backend.domain.group.entity.GroupInviteStatus;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.result.CreateGroupResult;
 import matchuri.backend.domain.group.result.CreateNicknameGroupInviteResult;
 import matchuri.backend.domain.group.result.DeleteGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
+import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
 import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
@@ -133,6 +137,10 @@ public class GroupMapper {
         return new GetMyGroupsCommand(status, page, size);
     }
 
+    public GetMyGroupInvitesCommand toGetMyGroupInvitesCommand(GroupInviteStatus status, int page, int size) {
+        return new GetMyGroupInvitesCommand(status, page, size);
+    }
+
     public GroupSummaryResponse toGroupSummaryResponse(GroupSummaryResult result) {
         return new GroupSummaryResponse(
                 result.id(),
@@ -156,6 +164,19 @@ public class GroupMapper {
                         .map(this::toGroupMemberSummaryResponse)
                         .toList(),
                 null
+        );
+    }
+
+    public GroupInviteSummaryResponse toGroupInviteSummaryResponse(GroupInviteSummaryResult result) {
+        return new GroupInviteSummaryResponse(
+                result.inviteId(),
+                result.groupId(),
+                result.groupName(),
+                result.requestMemberId(),
+                result.requestMemberNickname(),
+                result.status(),
+                result.expiresAt(),
+                result.createdAt()
         );
     }
 

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -123,6 +123,37 @@ public final class GroupApiExamples {
             }
             """;
 
+    public static final String MY_INVITES_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "content": [
+                  {
+                    "inviteId": 501,
+                    "groupId": 3001,
+                    "groupName": "맛집 탐방 모임",
+                    "requestMemberId": 11,
+                    "requestMemberNickname": "나는야 임영웅",
+                    "status": "PENDING",
+                    "expiresAt": "2026-05-20T12:00:00",
+                    "createdAt": "2026-05-19T12:00:00"
+                  }
+                ],
+                "pageInfo": {
+                  "page": 0,
+                  "size": 20,
+                  "totalElements": 1,
+                  "totalPages": 1,
+                  "first": true,
+                  "last": true,
+                  "hasNext": false,
+                  "hasPrevious": false
+                }
+              },
+              "error": null
+            }
+            """;
+
     public static final String JOIN_GROUP_SUCCESS = """
             {
               "success": true,

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupInviteSummaryPageApiResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupInviteSummaryPageApiResponse.java
@@ -1,0 +1,14 @@
+package matchuri.backend.api.group.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.group.dto.response.GroupInviteSummaryResponse;
+import matchuri.backend.global.api.ErrorResponse;
+import matchuri.backend.global.api.PageResponse;
+
+@Schema(description = "내 그룹 초대 목록 API의 공통 응답 envelope입니다.")
+public record GroupInviteSummaryPageApiResponse(
+        boolean success,
+        PageResponse<GroupInviteSummaryResponse> data,
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupInviteSummaryResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupInviteSummaryResponse.java
@@ -1,0 +1,32 @@
+package matchuri.backend.api.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import matchuri.backend.domain.group.entity.GroupInviteStatus;
+
+public record GroupInviteSummaryResponse(
+        @Schema(description = "초대 ID입니다.", example = "501")
+        Long inviteId,
+
+        @Schema(description = "초대 대상 그룹 ID입니다.", example = "3001")
+        Long groupId,
+
+        @Schema(description = "초대 대상 그룹 이름입니다.", example = "맛집 탐방 모임")
+        String groupName,
+
+        @Schema(description = "초대한 회원 ID입니다.", example = "11")
+        Long requestMemberId,
+
+        @Schema(description = "초대한 회원 닉네임입니다.", example = "나는야 임영웅")
+        String requestMemberNickname,
+
+        @Schema(description = "초대 상태입니다.", example = "PENDING")
+        GroupInviteStatus status,
+
+        @Schema(description = "초대 만료 시각입니다.", example = "2026-05-20T12:00:00")
+        LocalDateTime expiresAt,
+
+        @Schema(description = "초대 생성 시각입니다.", example = "2026-05-19T12:00:00")
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/command/GetMyGroupInvitesCommand.java
+++ b/src/main/java/matchuri/backend/domain/group/command/GetMyGroupInvitesCommand.java
@@ -1,0 +1,10 @@
+package matchuri.backend.domain.group.command;
+
+import matchuri.backend.domain.group.entity.GroupInviteStatus;
+
+public record GetMyGroupInvitesCommand(
+        GroupInviteStatus status,
+        int page,
+        int size
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupInviteRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupInviteRepository.java
@@ -3,11 +3,38 @@ package matchuri.backend.domain.group.repository;
 import java.util.List;
 import matchuri.backend.domain.group.entity.GroupInvite;
 import matchuri.backend.domain.group.entity.GroupInviteStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface GroupInviteRepository extends JpaRepository<GroupInvite, Long> {
 
     List<GroupInvite> findAllByRoomIdAndStatus(Long roomId, GroupInviteStatus status);
 
     boolean existsByRoomIdAndTargetMemberIdAndStatus(Long roomId, Long targetMemberId, GroupInviteStatus status);
+
+    @Query(
+            value = """
+                    select invite
+                    from GroupInvite invite
+                    join fetch invite.room room
+                    join fetch invite.requestMember requestMember
+                    where invite.targetMember.id = :targetMemberId
+                      and (:status is null or invite.status = :status)
+                    order by invite.createdAt desc, invite.id desc
+                    """,
+            countQuery = """
+                    select count(invite)
+                    from GroupInvite invite
+                    where invite.targetMember.id = :targetMemberId
+                      and (:status is null or invite.status = :status)
+                    """
+    )
+    Page<GroupInvite> findMyInvites(
+            @Param("targetMemberId") Long targetMemberId,
+            @Param("status") GroupInviteStatus status,
+            Pageable pageable
+    );
 }

--- a/src/main/java/matchuri/backend/domain/group/result/GroupInviteSummaryResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupInviteSummaryResult.java
@@ -1,0 +1,16 @@
+package matchuri.backend.domain.group.result;
+
+import java.time.LocalDateTime;
+import matchuri.backend.domain.group.entity.GroupInviteStatus;
+
+public record GroupInviteSummaryResult(
+        Long inviteId,
+        Long groupId,
+        String groupName,
+        Long requestMemberId,
+        String requestMemberNickname,
+        GroupInviteStatus status,
+        LocalDateTime expiresAt,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/service/GroupService.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupService.java
@@ -4,6 +4,7 @@ import lombok.NonNull;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.CreateNicknameGroupInviteCommand;
 import matchuri.backend.domain.group.command.DeleteGroupCommand;
+import matchuri.backend.domain.group.command.GetMyGroupInvitesCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.command.JoinGroupCommand;
 import matchuri.backend.domain.group.command.LeaveGroupCommand;
@@ -12,6 +13,7 @@ import matchuri.backend.domain.group.result.CreateGroupResult;
 import matchuri.backend.domain.group.result.CreateNicknameGroupInviteResult;
 import matchuri.backend.domain.group.result.DeleteGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
+import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
 import matchuri.backend.domain.group.result.LeaveGroupResult;
@@ -33,6 +35,8 @@ public interface GroupService {
     UpdateGroupResult updateGroup(UpdateGroupCommand command);
 
     Page<@NonNull GroupSummaryResult> getMyGroups(GetMyGroupsCommand command);
+
+    Page<@NonNull GroupInviteSummaryResult> getMyInvites(GetMyGroupInvitesCommand command);
 
     GroupDetailResult getGroup(Long groupId);
 }

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.CreateNicknameGroupInviteCommand;
 import matchuri.backend.domain.group.command.DeleteGroupCommand;
+import matchuri.backend.domain.group.command.GetMyGroupInvitesCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.command.JoinGroupCommand;
 import matchuri.backend.domain.group.command.LeaveGroupCommand;
@@ -28,6 +29,7 @@ import matchuri.backend.domain.group.result.CreateGroupResult;
 import matchuri.backend.domain.group.result.CreateNicknameGroupInviteResult;
 import matchuri.backend.domain.group.result.DeleteGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
+import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
 import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
@@ -259,6 +261,18 @@ public class GroupServiceImpl implements GroupService {
 
     @Override
     @Transactional(readOnly = true)
+    public Page<@NonNull GroupInviteSummaryResult> getMyInvites(GetMyGroupInvitesCommand command) {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        GroupInviteStatus status = command.status() == null ? GroupInviteStatus.PENDING : command.status();
+
+        return groupInviteRepository.findMyInvites(
+                member.getId(),
+                status,
+                PageRequest.of(command.page(), command.size())).map(this::toInviteSummaryResult);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public GroupDetailResult getGroup(Long groupId) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
         GroupRoom room = groupRoomRepository.findByIdAndStatusNot(groupId, GroupRoomStatus.DELETED)
@@ -314,6 +328,22 @@ public class GroupServiceImpl implements GroupService {
                 activeMemberCounts.getOrDefault(room.getId(), 0L).intValue(),
                 null,
                 room.getCreatedAt()
+        );
+    }
+
+    private GroupInviteSummaryResult toInviteSummaryResult(GroupInvite invite) {
+        GroupRoom room = invite.getRoom();
+        Member requestMember = invite.getRequestMember();
+
+        return new GroupInviteSummaryResult(
+                invite.getId(),
+                room.getId(),
+                room.getName(),
+                requestMember.getId(),
+                requestMember.getNickname(),
+                invite.getStatus(),
+                invite.getExpiresAt(),
+                invite.getCreatedAt()
         );
     }
 

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -624,6 +624,65 @@ class GroupIntegrationTest {
     }
 
     @Test
+    @DisplayName("내 그룹 초대 목록은 현재 회원이 받은 PENDING 초대를 기본 조회한다")
+    void getMyInvitesReturnsPendingInvitesForCurrentTargetMember() throws Exception {
+        Member owner = saveMember("my-invite-owner", "내초대방장");
+        Member target = saveMember("my-invite-target", "내초대대상");
+        Member otherTarget = saveMember("my-invite-other-target", "다른초대대상");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "받은 초대 그룹");
+        GroupRoom otherGroupRoom = saveGroupOwnedBy(owner, "다른 대상 초대 그룹");
+        GroupInvite pendingInvite = saveInvite(groupRoom, owner, target, LocalDateTime.now().plusHours(3));
+        GroupInvite declinedInvite = saveInvite(groupRoom, owner, target, LocalDateTime.now().plusHours(4));
+        declinedInvite.decline(LocalDateTime.now());
+        groupInviteRepository.save(declinedInvite);
+        saveInvite(otherGroupRoom, owner, otherTarget, LocalDateTime.now().plusHours(5));
+
+        mockMvc.perform(get("/api/v1/groups/invites/me")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(target)))
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.content.length()").value(1))
+                .andExpect(jsonPath("$.data.content[0].inviteId").value(pendingInvite.getId()))
+                .andExpect(jsonPath("$.data.content[0].groupId").value(groupRoom.getId()))
+                .andExpect(jsonPath("$.data.content[0].groupName").value("받은 초대 그룹"))
+                .andExpect(jsonPath("$.data.content[0].requestMemberId").value(owner.getId()))
+                .andExpect(jsonPath("$.data.content[0].requestMemberNickname").value(owner.getNickname()))
+                .andExpect(jsonPath("$.data.content[0].status").value(GroupInviteStatus.PENDING.name()))
+                .andExpect(jsonPath("$.data.content[0].expiresAt").isNotEmpty())
+                .andExpect(jsonPath("$.data.content[0].createdAt").isNotEmpty())
+                .andExpect(jsonPath("$.data.pageInfo.totalElements").value(1));
+    }
+
+    @Test
+    @DisplayName("내 그룹 초대 목록은 상태 필터와 페이지네이션을 적용한다")
+    void getMyInvitesAppliesStatusFilterAndPagination() throws Exception {
+        Member owner = saveMember("my-invite-filter-owner", "초대필터방장");
+        Member target = saveMember("my-invite-filter-target", "초대필터대상");
+        GroupRoom firstGroup = saveGroupOwnedBy(owner, "거절 초대 1");
+        GroupRoom secondGroup = saveGroupOwnedBy(owner, "거절 초대 2");
+        GroupInvite firstDeclinedInvite = saveInvite(firstGroup, owner, target, LocalDateTime.now().plusHours(1));
+        firstDeclinedInvite.decline(LocalDateTime.now().minusMinutes(1));
+        groupInviteRepository.save(firstDeclinedInvite);
+        GroupInvite secondDeclinedInvite = saveInvite(secondGroup, owner, target, LocalDateTime.now().plusHours(2));
+        secondDeclinedInvite.decline(LocalDateTime.now());
+        groupInviteRepository.save(secondDeclinedInvite);
+
+        mockMvc.perform(get("/api/v1/groups/invites/me")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(target)))
+                        .param("status", GroupInviteStatus.DECLINED.name())
+                        .param("page", "0")
+                        .param("size", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content.length()").value(1))
+                .andExpect(jsonPath("$.data.content[0].inviteId").value(secondDeclinedInvite.getId()))
+                .andExpect(jsonPath("$.data.content[0].status").value(GroupInviteStatus.DECLINED.name()))
+                .andExpect(jsonPath("$.data.pageInfo.size").value(1))
+                .andExpect(jsonPath("$.data.pageInfo.totalElements").value(2));
+    }
+
+    @Test
     @DisplayName("초대 코드 입장은 신규 멤버를 ACTIVE 멤버로 저장한다")
     void joinGroupCreatesActiveMember() throws Exception {
         Member owner = saveMember("join-owner", "입장방장");

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -330,6 +330,11 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/invites/nickname'].post.responses['200'].content['application/json'].examples.success.value.data.targetNickname")
                         .value("점심탐험가"))
+                .andExpect(jsonPath("$.paths['/api/v1/groups/invites/me'].get.summary")
+                        .value("내 그룹 초대 목록 조회"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/invites/me'].get.responses['200'].content['application/json'].examples.success.value.data.content[0].status")
+                        .value("PENDING"))
                 .andExpect(jsonPath("$.paths['/api/v1/groups/{groupId}/invites']").doesNotExist())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/join'].post.responses['200'].content['application/json'].examples.success.value.data.memberStatus")


### PR DESCRIPTION
## 관련 이슈
Closes #210 

## 📝 작업 내용
- `GET /api/v1/groups/invites/me` 추가
- 현재 로그인 회원이 `targetMember`인 초대만 조회
- status query 지원, 생략 시 PENDING 기본 조회
- `page`, `size` 페이지네이션 지원
- 생성 최신순 정렬
- 응답 DTO: `inviteId`, `groupId`, `groupName`, `requestMemberId`, `requestMemberNickname`, `status`, `expiresAt`, `createdAt`
- OpenAPI 예시와 `docs/api/group.md`, `api-status.md`, 실행 계획 문서 갱신
- 통합 테스트로 기본 `PENDING` 조회, 상태 필터, 페이지네이션, 타겟 회원 기준 필터링 검증

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
```json
{
  "success": true,
  "data": {
    "content": [
      {
        "inviteId": 1,
        "groupId": 1,
        "groupName": "오늘 점심 메뉴 회의",
        "requestMemberId": 3,
        "requestMemberNickname": "matchuri-admin",
        "status": "PENDING",
        "expiresAt": "2026-05-20T04:55:39.271939",
        "createdAt": "2026-05-19T04:55:39.273559"
      }
    ],
    "pageInfo": {
      "page": 0,
      "size": 20,
      "totalElements": 1,
      "totalPages": 1,
      "first": true,
      "last": true,
      "hasNext": false,
      "hasPrevious": false
    }
  },
  "error": null
}
```
