### PR TITLE
[Refactor] 개인 추천 종료 상태 모델 추가

### DIFF
--- a/init/sql/01-schema.sql
+++ b/init/sql/01-schema.sql
@@ -193,6 +193,8 @@ CREATE TABLE personal_recommendations (
     id BIGINT NOT NULL AUTO_INCREMENT,
     member_id BIGINT NOT NULL,
     status VARCHAR(20) NOT NULL,
+    closed_at DATETIME(6),
+    close_reason VARCHAR(30),
     requested_at DATETIME(6) NOT NULL,
     context_json JSON,
     selected_candidate_id BIGINT,

--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
@@ -243,6 +243,7 @@ public interface RecommendationApi {
                     개인 추천 후보 중 하나를 최종 선택으로 반영합니다.
 
                     선택된 후보는 개인 추천에 저장되며 `member_menu_actions`에 `CHOOSE` 로그가 함께 기록됩니다.
+                    선택 성공 시 개인 추천은 `closeReason=SELECTED`, `closedAt=선택 시각`으로 종료됩니다.
                     """
     )
     @ApiResponses({
@@ -277,12 +278,12 @@ public interface RecommendationApi {
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "409",
-                    description = "이미 후보가 선택된 개인 추천",
+                    description = "이미 종료된 개인 추천",
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(
-                                    name = "alreadySelected",
-                                    value = RecommendationApiExamples.PERSONAL_RECOMMENDATION_ALREADY_SELECTED
+                                    name = "alreadyClosed",
+                                    value = RecommendationApiExamples.PERSONAL_RECOMMENDATION_ALREADY_CLOSED
                             )
                     )
             )

--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationMapper.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationMapper.java
@@ -68,6 +68,8 @@ public class RecommendationMapper {
                 result.id(),
                 result.status(),
                 result.requestedAt(),
+                result.closedAt(),
+                result.closeReason(),
                 toCandidateResponses(result.candidates())
         );
     }
@@ -76,6 +78,8 @@ public class RecommendationMapper {
         return new PersonalRecommendationDetailResponse(
                 result.id(),
                 result.status(),
+                result.closedAt(),
+                result.closeReason(),
                 toContextMap(result.contextJson()),
                 toCandidateResponses(result.candidates()),
                 result.selectedCandidateId()
@@ -96,7 +100,9 @@ public class RecommendationMapper {
         return new PersonalRecommendationResponse(
                 result.id(),
                 result.status(),
-                result.requestedAt()
+                result.requestedAt(),
+                result.closedAt(),
+                result.closeReason()
         );
     }
 
@@ -104,6 +110,8 @@ public class RecommendationMapper {
         return new SelectPersonalRecommendationResponse(
                 result.id(),
                 result.selectedCandidateId(),
+                result.closedAt(),
+                result.closeReason(),
                 result.updatedAt()
         );
     }
@@ -144,9 +152,8 @@ public class RecommendationMapper {
 
         try {
             JsonNode contextNode = objectMapper.readTree(contextJson);
-            if (contextNode.isTextual()) {
-                return objectMapper.readValue(contextNode.asText(), new TypeReference<>() {
-                });
+            while (contextNode.isTextual()) {
+                contextNode = objectMapper.readTree(contextNode.asText());
             }
 
             return objectMapper.convertValue(contextNode, new TypeReference<>() {

--- a/src/main/java/matchuri/backend/api/recommendation/dto/docs/RecommendationApiExamples.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/docs/RecommendationApiExamples.java
@@ -120,7 +120,9 @@ public final class RecommendationApiExamples {
                   {
                     "id": 9001,
                     "status": "COMPLETED",
-                    "requestedAt": "2026-05-06T12:10:00"
+                    "requestedAt": "2026-05-06T12:10:00",
+                    "closedAt": null,
+                    "closeReason": null
                   }
                 ],
                 "pageInfo": {
@@ -145,6 +147,8 @@ public final class RecommendationApiExamples {
                 "requestId": 9001,
                 "status": "COMPLETED",
                 "requestedAt": "2026-05-06T12:10:00",
+                "closedAt": null,
+                "closeReason": null,
                 "candidates": [
                   {
                     "id": 10001,
@@ -179,6 +183,8 @@ public final class RecommendationApiExamples {
               "data": {
                 "id": 9001,
                 "status": "COMPLETED",
+                "closedAt": "2026-05-06T12:15:00",
+                "closeReason": "SELECTED",
                 "contextJson": {
                   "mealTime": "LUNCH",
                   "budgetLevel": 2,
@@ -265,6 +271,19 @@ public final class RecommendationApiExamples {
             }
             """;
 
+    public static final String PERSONAL_RECOMMENDATION_ALREADY_CLOSED = """
+            {
+              "success": false,
+              "data": null,
+              "error": {
+                "status": 409,
+                "code": "PERSONAL_RECOMMENDATION_ALREADY_CLOSED",
+                "message": "이미 종료된 개인 추천입니다. personalRecommendationId : 9001",
+                "details": []
+              }
+            }
+            """;
+
     public static final String PERSONAL_RECOMMENDATION_CANDIDATES_SUCCESS = """
             {
               "success": true,
@@ -304,6 +323,8 @@ public final class RecommendationApiExamples {
               "data": {
                 "id": 9001,
                 "selectedCandidateId": 10001,
+                "closedAt": "2026-05-06T12:15:00",
+                "closeReason": "SELECTED",
                 "updatedAt": "2026-05-06T12:15:00"
               },
               "error": null

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationDetailResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationDetailResponse.java
@@ -1,8 +1,10 @@
 package matchuri.backend.api.recommendation.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCloseReason;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 
 public record PersonalRecommendationDetailResponse(
@@ -11,6 +13,12 @@ public record PersonalRecommendationDetailResponse(
 
         @Schema(description = "개인 추천 처리 상태입니다.", example = "COMPLETED")
         PersonalRecommendationStatus status,
+
+        @Schema(description = "추천 종료 시각입니다. 아직 선택/재요청/만료로 종료되지 않았다면 null입니다.", example = "2026-05-06T12:15:00")
+        LocalDateTime closedAt,
+
+        @Schema(description = "추천 종료 사유입니다. 아직 종료되지 않았다면 null입니다.", example = "SELECTED")
+        PersonalRecommendationCloseReason closeReason,
 
         @Schema(description = "요청 컨텍스트 JSON입니다.")
         Map<String, Object> contextJson,
@@ -25,6 +33,8 @@ public record PersonalRecommendationDetailResponse(
         return new PersonalRecommendationDetailResponse(
                 9001L,
                 PersonalRecommendationStatus.COMPLETED,
+                LocalDateTime.of(2026, 5, 6, 12, 15),
+                PersonalRecommendationCloseReason.SELECTED,
                 PersonalRecommendationMocks.contextJson(),
                 PersonalRecommendationMocks.candidates(),
                 10001L

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationRequestResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationRequestResponse.java
@@ -3,6 +3,7 @@ package matchuri.backend.api.recommendation.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCloseReason;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 
 public record PersonalRecommendationRequestResponse(
@@ -15,6 +16,12 @@ public record PersonalRecommendationRequestResponse(
         @Schema(description = "추천 요청 시각입니다.", example = "2026-05-06T12:10:00")
         LocalDateTime requestedAt,
 
+        @Schema(description = "추천 종료 시각입니다. 아직 선택/재요청/만료로 종료되지 않았다면 null입니다.", example = "2026-05-06T12:15:00")
+        LocalDateTime closedAt,
+
+        @Schema(description = "추천 종료 사유입니다. 아직 종료되지 않았다면 null입니다.", example = "SELECTED")
+        PersonalRecommendationCloseReason closeReason,
+
         @Schema(description = "추천 후보 목록입니다.")
         List<PersonalRecommendationCandidateResponse> candidates
 ) {
@@ -23,6 +30,8 @@ public record PersonalRecommendationRequestResponse(
                 9001L,
                 PersonalRecommendationStatus.COMPLETED,
                 LocalDateTime.of(2026, 5, 6, 12, 10),
+                null,
+                null,
                 PersonalRecommendationMocks.candidates()
         );
     }

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationResponse.java
@@ -1,18 +1,23 @@
 package matchuri.backend.api.recommendation.dto.response;
 
 import java.time.LocalDateTime;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCloseReason;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 
 public record PersonalRecommendationResponse(
         long id,
         PersonalRecommendationStatus status,
-        LocalDateTime requestedAt
+        LocalDateTime requestedAt,
+        LocalDateTime closedAt,
+        PersonalRecommendationCloseReason closeReason
 ) {
     public static PersonalRecommendationResponse mock() {
         return new PersonalRecommendationResponse(
                 9001L,
                 PersonalRecommendationStatus.COMPLETED,
-                LocalDateTime.of(2026, 5, 6, 12, 10)
+                LocalDateTime.of(2026, 5, 6, 12, 10),
+                null,
+                null
         );
     }
 }

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/SelectPersonalRecommendationResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/SelectPersonalRecommendationResponse.java
@@ -2,6 +2,7 @@ package matchuri.backend.api.recommendation.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCloseReason;
 
 public record SelectPersonalRecommendationResponse(
         @Schema(description = "개인 추천 요청 ID입니다.", example = "9001")
@@ -10,6 +11,12 @@ public record SelectPersonalRecommendationResponse(
         @Schema(description = "최종 선택 후보 ID입니다.", example = "10001")
         Long selectedCandidateId,
 
+        @Schema(description = "추천 종료 시각입니다.", example = "2026-05-06T12:15:00")
+        LocalDateTime closedAt,
+
+        @Schema(description = "추천 종료 사유입니다.", example = "SELECTED")
+        PersonalRecommendationCloseReason closeReason,
+
         @Schema(description = "선택 반영 시각입니다.", example = "2026-05-06T12:15:00")
         LocalDateTime updatedAt
 ) {
@@ -17,6 +24,8 @@ public record SelectPersonalRecommendationResponse(
         return new SelectPersonalRecommendationResponse(
                 9001L,
                 selectedCandidateId,
+                LocalDateTime.of(2026, 5, 6, 12, 15),
+                PersonalRecommendationCloseReason.SELECTED,
                 LocalDateTime.of(2026, 5, 6, 12, 15)
         );
     }

--- a/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendation.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendation.java
@@ -44,6 +44,13 @@ public class PersonalRecommendation extends BaseEntity {
     @Column(nullable = false, length = 20, comment = "개인 추천 상태")
     private PersonalRecommendationStatus status;
 
+    @Column(name = "closed_at", comment = "추천 종료 시각")
+    private LocalDateTime closedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "close_reason", length = 30, comment = "추천 종료 사유")
+    private PersonalRecommendationCloseReason closeReason;
+
     @Column(name = "requested_at", nullable = false, comment = "추천 실행 시각")
     private LocalDateTime requestedAt;
 
@@ -87,8 +94,30 @@ public class PersonalRecommendation extends BaseEntity {
         this.status = PersonalRecommendationStatus.FAILED;
     }
 
-    public void select(PersonalRecommendationCandidate selectedCandidate) {
+    public void select(PersonalRecommendationCandidate selectedCandidate, LocalDateTime closedAt) {
         this.selectedCandidate = selectedCandidate;
+        close(PersonalRecommendationCloseReason.SELECTED, closedAt);
+    }
+
+    public void closeAsRerolledWithSkip(LocalDateTime closedAt) {
+        close(PersonalRecommendationCloseReason.REROLLED_WITH_SKIP, closedAt);
+    }
+
+    public void closeAsRerolledWithoutSkip(LocalDateTime closedAt) {
+        close(PersonalRecommendationCloseReason.REROLLED_WITHOUT_SKIP, closedAt);
+    }
+
+    public void expire(LocalDateTime closedAt) {
+        close(PersonalRecommendationCloseReason.EXPIRED, closedAt);
+    }
+
+    public boolean isClosed() {
+        return this.closedAt != null;
+    }
+
+    private void close(PersonalRecommendationCloseReason closeReason, LocalDateTime closedAt) {
+        this.closeReason = closeReason;
+        this.closedAt = closedAt;
     }
 
     public MenuItem getSelectedMenu() {

--- a/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendationCloseReason.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendationCloseReason.java
@@ -1,0 +1,8 @@
+package matchuri.backend.domain.recommendation.entity;
+
+public enum PersonalRecommendationCloseReason {
+    SELECTED,
+    REROLLED_WITH_SKIP,
+    REROLLED_WITHOUT_SKIP,
+    EXPIRED
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/exception/RecommendationErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/exception/RecommendationErrorCode.java
@@ -13,7 +13,8 @@ public enum RecommendationErrorCode implements ErrorCode {
     TASTE_PROFILE_REQUIRED(HttpStatus.FORBIDDEN, "개인 추천을 만들려면 취향 프로필이 필요합니다. memberId : {0}"),
     NOT_FOUND(HttpStatus.NOT_FOUND, "해당 개인 추천을 찾을 수 없습니다. personalRecommendationId : {0}"),
     CANDIDATE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 개인 추천 후보를 찾을 수 없습니다. candidateId : {0}"),
-    ALREADY_SELECTED(HttpStatus.CONFLICT, "이미 최종 후보가 선택된 개인 추천입니다. personalRecommendationId : {0}");
+    ALREADY_SELECTED(HttpStatus.CONFLICT, "이미 최종 후보가 선택된 개인 추천입니다. personalRecommendationId : {0}"),
+    ALREADY_CLOSED(HttpStatus.CONFLICT, "이미 종료된 개인 추천입니다. personalRecommendationId : {0}");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/matchuri/backend/domain/recommendation/result/PersonalRecommendationResult.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/result/PersonalRecommendationResult.java
@@ -4,12 +4,15 @@ import java.time.LocalDateTime;
 import java.util.List;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCandidate;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCloseReason;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 
 public record PersonalRecommendationResult(
         Long id,
         PersonalRecommendationStatus status,
         LocalDateTime requestedAt,
+        LocalDateTime closedAt,
+        PersonalRecommendationCloseReason closeReason,
         String contextJson,
         Long selectedCandidateId,
         List<PersonalRecommendationCandidateResult> candidates
@@ -26,6 +29,8 @@ public record PersonalRecommendationResult(
                 personalRecommendation.getId(),
                 personalRecommendation.getStatus(),
                 personalRecommendation.getRequestedAt(),
+                personalRecommendation.getClosedAt(),
+                personalRecommendation.getCloseReason(),
                 personalRecommendation.getContextJson(),
                 selectedCandidateId,
                 candidates.stream()

--- a/src/main/java/matchuri/backend/domain/recommendation/result/PersonalRecommendationSummaryResult.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/result/PersonalRecommendationSummaryResult.java
@@ -2,18 +2,23 @@ package matchuri.backend.domain.recommendation.result;
 
 import java.time.LocalDateTime;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCloseReason;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 
 public record PersonalRecommendationSummaryResult(
         Long id,
         PersonalRecommendationStatus status,
-        LocalDateTime requestedAt
+        LocalDateTime requestedAt,
+        LocalDateTime closedAt,
+        PersonalRecommendationCloseReason closeReason
 ) {
     public static PersonalRecommendationSummaryResult from(PersonalRecommendation personalRecommendation) {
         return new PersonalRecommendationSummaryResult(
                 personalRecommendation.getId(),
                 personalRecommendation.getStatus(),
-                personalRecommendation.getRequestedAt()
+                personalRecommendation.getRequestedAt(),
+                personalRecommendation.getClosedAt(),
+                personalRecommendation.getCloseReason()
         );
     }
 }

--- a/src/main/java/matchuri/backend/domain/recommendation/result/SelectPersonalRecommendationResult.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/result/SelectPersonalRecommendationResult.java
@@ -3,10 +3,13 @@ package matchuri.backend.domain.recommendation.result;
 import java.time.LocalDateTime;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCandidate;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCloseReason;
 
 public record SelectPersonalRecommendationResult(
         Long id,
         Long selectedCandidateId,
+        LocalDateTime closedAt,
+        PersonalRecommendationCloseReason closeReason,
         LocalDateTime updatedAt
 ) {
     public static SelectPersonalRecommendationResult of(
@@ -16,6 +19,8 @@ public record SelectPersonalRecommendationResult(
         return new SelectPersonalRecommendationResult(
                 personalRecommendation.getId(),
                 selectedCandidate.getId(),
+                personalRecommendation.getClosedAt(),
+                personalRecommendation.getCloseReason(),
                 personalRecommendation.getUpdatedAt()
         );
     }

--- a/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
@@ -2,6 +2,7 @@ package matchuri.backend.domain.recommendation.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -20,7 +21,6 @@ import matchuri.backend.domain.member.support.member.ActiveMemberReader;
 import matchuri.backend.domain.menu.entity.AttributeCategory;
 import matchuri.backend.domain.menu.entity.Ingredient;
 import matchuri.backend.domain.menu.entity.MenuAttributeCategory;
-import matchuri.backend.domain.menu.entity.MenuIngredient;
 import matchuri.backend.domain.menu.entity.MenuItem;
 import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
 import matchuri.backend.domain.menu.repository.IngredientRepository;
@@ -215,6 +215,7 @@ public class RecommendationServiceImpl implements RecommendationService {
     }
 
     @Override
+    @Transactional
     public SelectPersonalRecommendationResult selectPersonalRecommendationCandidate(
             Long personalRecommendationId,
             Long selectedCandidateId
@@ -223,8 +224,8 @@ public class RecommendationServiceImpl implements RecommendationService {
         PersonalRecommendation personalRecommendation = getOwnedPersonalRecommendation(personalRecommendationId,
                 member.getId());
 
-        if (personalRecommendation.getSelectedCandidate() != null) {
-            throw new BusinessException(RecommendationErrorCode.ALREADY_SELECTED, personalRecommendationId);
+        if (personalRecommendation.isClosed()) {
+            throw new BusinessException(RecommendationErrorCode.ALREADY_CLOSED, personalRecommendationId);
         }
 
         PersonalRecommendationCandidate selectedCandidate = personalRecommendationCandidateRepository
@@ -234,7 +235,7 @@ public class RecommendationServiceImpl implements RecommendationService {
                         selectedCandidateId
                 ));
 
-        personalRecommendation.select(selectedCandidate);
+        personalRecommendation.select(selectedCandidate, LocalDateTime.now());
         memberMenuActionRepository.save(new MemberMenuAction(
                 member,
                 selectedCandidate.getMenuItem(),

--- a/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
@@ -41,6 +41,8 @@ import matchuri.backend.domain.menu.repository.IngredientRepository;
 import matchuri.backend.domain.menu.repository.MenuAttributeCategoryRepository;
 import matchuri.backend.domain.menu.repository.MenuIngredientRepository;
 import matchuri.backend.domain.menu.repository.MenuItemRepository;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCloseReason;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 import matchuri.backend.domain.recommendation.repository.PersonalRecommendationCandidateRepository;
 import matchuri.backend.domain.recommendation.repository.PersonalRecommendationRepository;
@@ -163,6 +165,8 @@ class PersonalRecommendationIntegrationTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.error").value(nullValue()))
                 .andExpect(jsonPath("$.data.status").value(PersonalRecommendationStatus.COMPLETED.name()))
+                .andExpect(jsonPath("$.data.closedAt").value(nullValue()))
+                .andExpect(jsonPath("$.data.closeReason").value(nullValue()))
                 .andExpect(jsonPath("$.data.candidates.length()").value(2))
                 .andExpect(jsonPath("$.data.candidates[0].menuId").value(bibimbap.getId()))
                 .andExpect(jsonPath("$.data.candidates[0].rankNo").value(1))
@@ -181,6 +185,8 @@ class PersonalRecommendationIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.id").value(requestId))
                 .andExpect(jsonPath("$.data.contextJson.mealTime").value("LUNCH"))
+                .andExpect(jsonPath("$.data.closedAt").value(nullValue()))
+                .andExpect(jsonPath("$.data.closeReason").value(nullValue()))
                 .andExpect(jsonPath("$.data.candidates.length()").value(2))
                 .andExpect(jsonPath("$.data.selectedCandidateId").value(nullValue()));
 
@@ -196,6 +202,8 @@ class PersonalRecommendationIntegrationTest {
                         .param("size", "10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.content[0].id").value(requestId))
+                .andExpect(jsonPath("$.data.content[0].closedAt").value(nullValue()))
+                .andExpect(jsonPath("$.data.content[0].closeReason").value(nullValue()))
                 .andExpect(jsonPath("$.data.pageInfo.totalElements").value(1));
 
         mockMvc.perform(patch("/api/v1/personal/recommendations/{requestId}", requestId)
@@ -208,10 +216,23 @@ class PersonalRecommendationIntegrationTest {
                                 """.formatted(firstCandidateId)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.id").value(requestId))
-                .andExpect(jsonPath("$.data.selectedCandidateId").value(firstCandidateId));
+                .andExpect(jsonPath("$.data.selectedCandidateId").value(firstCandidateId))
+                .andExpect(jsonPath("$.data.closedAt").exists())
+                .andExpect(jsonPath("$.data.closeReason").value(PersonalRecommendationCloseReason.SELECTED.name()));
 
         assertThat(memberMenuActionRepository.count()).isEqualTo(1);
         assertThat(memberMenuActionRepository.findAll().getFirst().getActionType()).isEqualTo(ActionType.CHOOSE);
+
+        PersonalRecommendation selectedRecommendation = personalRecommendationRepository.findById(requestId)
+                .orElseThrow();
+        assertThat(selectedRecommendation.getClosedAt()).isNotNull();
+        assertThat(selectedRecommendation.getCloseReason()).isEqualTo(PersonalRecommendationCloseReason.SELECTED);
+
+        mockMvc.perform(get("/api/v1/personal/recommendations/{requestId}", requestId)
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.closedAt").exists())
+                .andExpect(jsonPath("$.data.closeReason").value(PersonalRecommendationCloseReason.SELECTED.name()));
     }
 
     @Test
@@ -293,7 +314,7 @@ class PersonalRecommendationIntegrationTest {
     }
 
     @Test
-    @DisplayName("개인 추천 선택은 다른 추천의 후보와 이미 선택된 추천을 거절한다")
+    @DisplayName("개인 추천 선택은 다른 추천의 후보와 이미 종료된 추천을 거절한다")
     void selectPersonalRecommendationRejectsInvalidCandidateAndAlreadySelectedRecommendation() throws Exception {
         Member member = saveMember("select-user", "선택검증");
         String accessToken = accessToken(member);
@@ -339,7 +360,7 @@ class PersonalRecommendationIntegrationTest {
                                 }
                                 """.formatted(firstCandidateId)))
                 .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.error.code").value("PERSONAL_RECOMMENDATION_ALREADY_SELECTED"));
+                .andExpect(jsonPath("$.error.code").value("PERSONAL_RECOMMENDATION_ALREADY_CLOSED"));
     }
 
     private JsonNode createRecommendation(String accessToken) throws Exception {

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -259,11 +259,17 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/personal/recommendations'].get.responses['200'].content['application/json'].examples.success.value.data.content[0].id")
                         .value(9001))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/personal/recommendations'].get.responses['200'].content['application/json'].examples.success.value.data.content[0].closedAt")
+                        .value(nullValue()))
                 .andExpect(jsonPath("$.paths['/api/v1/personal/recommendations'].post.summary")
                         .value("개인 추천 요청 생성"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/personal/recommendations'].post.responses['200'].content['application/json'].examples.success.value.data.candidates[0].menuName")
                         .value("비빔밥"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/personal/recommendations'].post.responses['200'].content['application/json'].examples.success.value.data.closeReason")
+                        .value(nullValue()))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/personal/recommendations'].post.responses['200'].content['application/json'].examples.success.value.data.resultJson")
                         .doesNotExist())
@@ -273,6 +279,9 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/personal/recommendations/{requestId}'].get.responses['200'].content['application/json'].examples.success.value.data.contextJson.mealTime")
                         .value("LUNCH"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/personal/recommendations/{requestId}'].get.responses['200'].content['application/json'].examples.success.value.data.closeReason")
+                        .value("SELECTED"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/personal/recommendations/{requestId}'].get.responses['200'].content['application/json'].examples.success.value.data.resultJson")
                         .doesNotExist())
@@ -289,14 +298,17 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/personal/recommendations/{requestId}'].patch.responses['200'].content['application/json'].examples.success.value.data.selectedCandidateId")
                         .value(10001))
                 .andExpect(jsonPath(
+                        "$.paths['/api/v1/personal/recommendations/{requestId}'].patch.responses['200'].content['application/json'].examples.success.value.data.closeReason")
+                        .value("SELECTED"))
+                .andExpect(jsonPath(
                         "$.paths['/api/v1/personal/recommendations/{requestId}'].patch.responses['404'].content['application/json'].examples.notFound.value.error.code")
                         .value("PERSONAL_RECOMMENDATION_NOT_FOUND"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/personal/recommendations/{requestId}'].patch.responses['404'].content['application/json'].examples.candidateNotFound.value.error.code")
                         .value("PERSONAL_RECOMMENDATION_CANDIDATE_NOT_FOUND"))
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/personal/recommendations/{requestId}'].patch.responses['409'].content['application/json'].examples.alreadySelected.value.error.code")
-                        .value("PERSONAL_RECOMMENDATION_ALREADY_SELECTED"))
+                        "$.paths['/api/v1/personal/recommendations/{requestId}'].patch.responses['409'].content['application/json'].examples.alreadyClosed.value.error.code")
+                        .value("PERSONAL_RECOMMENDATION_ALREADY_CLOSED"))
                 .andExpect(jsonPath("$.paths['/api/v1/groups'].post.summary")
                         .value("그룹 생성"))
                 .andExpect(jsonPath(


### PR DESCRIPTION
## 관련 이슈
Closes #221 

## 📝 작업 내용
- `personal_recommendation`에 `closeAt`, `closeReason`을 추가

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [x] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- `docker-compose down -v`로 DB 초기화
- 현재 sql 파일로 데이터를 이니셜라이징을 하는 과정에서 한글이 깨지는 현상이 발생했습니다. 바로 수정하겠습니다.