### PR TITLE
[Fix] 한글 문자열 인코딩 오류 방지를 위한 sql 명시

### DIFF
--- a/init/sql/02-reference-seed.sql
+++ b/init/sql/02-reference-seed.sql
@@ -1,3 +1,6 @@
+SET NAMES utf8mb4;
+SET time_zone = '+09:00';
+
 -- Reference seed data
 
 INSERT INTO attribute_categories (category_type, code, name, sort_order, is_active, created_at, updated_at) VALUES

--- a/init/sql/03-local-sample-seed.sql
+++ b/init/sql/03-local-sample-seed.sql
@@ -1,3 +1,6 @@
+SET NAMES utf8mb4;
+SET time_zone = '+09:00';
+
 -- Local sample members
 INSERT INTO members (login_id, password_hash, nickname, nickname_completed, email, is_social, social_provider_type, social_provider_user_id, member_role, status, created_at, updated_at) VALUES
     ('tester01', '$2a$10$VVuO/Z4eCysA.tIaAEnjkOwHhT42Kx1ci84jB5yNR8td9fkO7wNGq', '테스터일', b'1', 'tester01@example.com', b'0', NULL, NULL, 'MEMBER', 'ACTIVE', NOW(6), NOW(6)),

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -8,4 +8,4 @@ spring:
 
 logging:
   level:
-    org.hibernate.SQL: info
+    org.hibernate.SQL: debug


### PR DESCRIPTION
## 관련 이슈
Closes #228 

## 📝 작업 내용
- 한글 깨짐 현상이 확인되어 수정
- .sql 파일에 명시 (`SET NAMES utf8mb4;`) 

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- `docker-compose down -v` 실행
