### PR TITLE
[Refactor] 열린 개인 추천 단일성 보장

### DIFF
--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
@@ -135,6 +135,7 @@ public interface RecommendationApi {
                     특정 회원에게 취향 프로필(`MemberTasteProfile`) 정보가 없다면 403에러가 발생합니다.
 
                     `restriction ingredient`, `disliked menu item`, 최근 선택 메뉴를 제외한 뒤 후보를 저장하고 반환합니다.
+                    24시간 이내 열린 개인 추천이 이미 있으면 새 추천을 만들지 않고 409를 반환합니다.
                     """
     )
     @ApiResponses({
@@ -158,6 +159,17 @@ public interface RecommendationApi {
                             examples = @ExampleObject(
                                     name = "tasteProfileRequired",
                                     value = RecommendationApiExamples.PERSONAL_RECOMMENDATION_TASTE_PROFILE_REQUIRED
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "열린 개인 추천이 이미 있음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "openExists",
+                                    value = RecommendationApiExamples.PERSONAL_RECOMMENDATION_OPEN_EXISTS
                             )
                     )
             )

--- a/src/main/java/matchuri/backend/api/recommendation/dto/docs/RecommendationApiExamples.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/docs/RecommendationApiExamples.java
@@ -232,6 +232,19 @@ public final class RecommendationApiExamples {
             }
             """;
 
+    public static final String PERSONAL_RECOMMENDATION_OPEN_EXISTS = """
+            {
+              "success": false,
+              "data": null,
+              "error": {
+                "status": 409,
+                "code": "PERSONAL_RECOMMENDATION_OPEN_EXISTS",
+                "message": "이미 열린 개인 추천이 있습니다. personalRecommendationId : 9001",
+                "details": []
+              }
+            }
+            """;
+
     public static final String PERSONAL_RECOMMENDATION_NOT_FOUND = """
             {
               "success": false,

--- a/src/main/java/matchuri/backend/domain/recommendation/exception/RecommendationErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/exception/RecommendationErrorCode.java
@@ -14,7 +14,8 @@ public enum RecommendationErrorCode implements ErrorCode {
     NOT_FOUND(HttpStatus.NOT_FOUND, "해당 개인 추천을 찾을 수 없습니다. personalRecommendationId : {0}"),
     CANDIDATE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 개인 추천 후보를 찾을 수 없습니다. candidateId : {0}"),
     ALREADY_SELECTED(HttpStatus.CONFLICT, "이미 최종 후보가 선택된 개인 추천입니다. personalRecommendationId : {0}"),
-    ALREADY_CLOSED(HttpStatus.CONFLICT, "이미 종료된 개인 추천입니다. personalRecommendationId : {0}");
+    ALREADY_CLOSED(HttpStatus.CONFLICT, "이미 종료된 개인 추천입니다. personalRecommendationId : {0}"),
+    OPEN_EXISTS(HttpStatus.CONFLICT, "이미 열린 개인 추천이 있습니다. personalRecommendationId : {0}");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
@@ -39,6 +39,7 @@ import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendatio
 import matchuri.backend.domain.recommendation.command.GuestPersonalRecommendationCommand;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCandidate;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 import matchuri.backend.domain.recommendation.exception.GuestRecommendationErrorCode;
 import matchuri.backend.domain.recommendation.exception.RecommendationErrorCode;
 import matchuri.backend.domain.recommendation.repository.PersonalRecommendationCandidateRepository;
@@ -62,6 +63,7 @@ public class RecommendationServiceImpl implements RecommendationService {
 
     private static final int RECENT_SELECTED_MENU_EXCLUSION_COUNT = 3;
     private static final int RECOMMENDATION_CANDIDATE_LIMIT = 3;
+    private static final long PERSONAL_RECOMMENDATION_OPEN_HOURS = 24;
     private static final String GUEST_PARTICIPANT_KEY = "guest";
 
     private final ActiveMemberReader activeMemberReader;
@@ -92,6 +94,7 @@ public class RecommendationServiceImpl implements RecommendationService {
 
         List<PersonalRecommendation> recommendations =
                 personalRecommendationRepository.findByMemberIdOrderByRequestedAtDescIdDesc(member.getId());
+        closeExpiredOrRejectOpenRecommendation(recommendations);
 
         MenuRecommendationAlgorithm algorithm =
                 menuRecommendationAlgorithmResolver.resolve(RecommendationAlgorithmType.PERSONAL);
@@ -250,6 +253,28 @@ public class RecommendationServiceImpl implements RecommendationService {
     private PersonalRecommendation getOwnedPersonalRecommendation(Long personalRecommendationId, Long memberId) {
         return personalRecommendationRepository.findByIdAndMemberId(personalRecommendationId, memberId)
                 .orElseThrow(() -> new BusinessException(RecommendationErrorCode.NOT_FOUND, personalRecommendationId));
+    }
+
+    private void closeExpiredOrRejectOpenRecommendation(List<PersonalRecommendation> recommendations) {
+        LocalDateTime now = LocalDateTime.now();
+
+        for (PersonalRecommendation recommendation : recommendations) {
+            if (!isUnclosedCompletedRecommendation(recommendation)) {
+                continue;
+            }
+
+            if (recommendation.getRequestedAt().plusHours(PERSONAL_RECOMMENDATION_OPEN_HOURS).isAfter(now)) {
+                throw new BusinessException(RecommendationErrorCode.OPEN_EXISTS, recommendation.getId());
+            }
+
+            recommendation.expire(now);
+        }
+    }
+
+    private boolean isUnclosedCompletedRecommendation(PersonalRecommendation recommendation) {
+        return recommendation.getStatus() == PersonalRecommendationStatus.COMPLETED
+                && recommendation.getSelectedCandidate() == null
+                && !recommendation.isClosed();
     }
 
     private TasteProfileSnapshot toTasteProfileSnapshot(Member member, MemberTasteProfile tasteProfile) {

--- a/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
@@ -14,6 +14,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Date;
 import javax.crypto.SecretKey;
 import matchuri.backend.domain.behavior.entity.ActionType;
@@ -282,6 +283,73 @@ class PersonalRecommendationIntegrationTest {
     }
 
     @Test
+    @DisplayName("개인 추천 생성은 24시간 이내 열린 추천이 있으면 거절한다")
+    void createPersonalRecommendationRejectsWhenOpenRecommendationExists() throws Exception {
+        Member member = saveMember("open-exists-user", "열린추천");
+        String accessToken = accessToken(member);
+        AttributeCategory spicy = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 10));
+        MenuItem bibimbap = menuItemRepository.save(new MenuItem("BIBIMBAP", "비빔밥", "채소와 밥"));
+        saveMenuAttribute(bibimbap, spicy);
+        saveTasteProfile(member, spicy, null);
+
+        JsonNode first = createRecommendation(accessToken);
+        long firstRequestId = first.path("requestId").asLong();
+
+        mockMvc.perform(post("/api/v1/personal/recommendations")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "contextJson": {}
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("PERSONAL_RECOMMENDATION_OPEN_EXISTS"));
+
+        assertThat(personalRecommendationRepository.count()).isEqualTo(1);
+        PersonalRecommendation openRecommendation = personalRecommendationRepository.findById(firstRequestId)
+                .orElseThrow();
+        assertThat(openRecommendation.getClosedAt()).isNull();
+        assertThat(openRecommendation.getCloseReason()).isNull();
+    }
+
+    @Test
+    @DisplayName("개인 추천 생성은 만료 대상 열린 추천을 즉시 종료하고 새 추천을 생성한다")
+    void createPersonalRecommendationExpiresOldOpenRecommendationAndCreatesNewOne() throws Exception {
+        Member member = saveMember("expired-open-user", "만료추천");
+        String accessToken = accessToken(member);
+        AttributeCategory spicy = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 10));
+        MenuItem bibimbap = menuItemRepository.save(new MenuItem("BIBIMBAP", "비빔밥", "채소와 밥"));
+        saveMenuAttribute(bibimbap, spicy);
+        saveTasteProfile(member, spicy, null);
+
+        JsonNode first = createRecommendation(accessToken);
+        long firstRequestId = first.path("requestId").asLong();
+        jdbcTemplate.update(
+                "update personal_recommendations set requested_at = ? where id = ?",
+                LocalDateTime.now().minusHours(25),
+                firstRequestId
+        );
+
+        JsonNode second = createRecommendation(accessToken);
+        long secondRequestId = second.path("requestId").asLong();
+
+        assertThat(secondRequestId).isNotEqualTo(firstRequestId);
+        assertThat(personalRecommendationRepository.count()).isEqualTo(2);
+
+        PersonalRecommendation expiredRecommendation = personalRecommendationRepository.findById(firstRequestId)
+                .orElseThrow();
+        PersonalRecommendation newRecommendation = personalRecommendationRepository.findById(secondRequestId)
+                .orElseThrow();
+        assertThat(expiredRecommendation.getClosedAt()).isNotNull();
+        assertThat(expiredRecommendation.getCloseReason()).isEqualTo(PersonalRecommendationCloseReason.EXPIRED);
+        assertThat(newRecommendation.getClosedAt()).isNull();
+        assertThat(newRecommendation.getCloseReason()).isNull();
+    }
+
+    @Test
     @DisplayName("개인 추천 조회는 타인 추천 접근을 찾을 수 없음으로 거절한다")
     void getPersonalRecommendationRejectsOtherMemberRecommendation() throws Exception {
         Member owner = saveMember("owner-user", "추천주인");
@@ -324,41 +392,39 @@ class PersonalRecommendationIntegrationTest {
         saveMenuAttribute(bibimbap, spicy);
         saveTasteProfile(member, spicy, null);
 
-        JsonNode first = createRecommendation(accessToken);
-        JsonNode second = createRecommendation(accessToken);
-        long firstRequestId = first.path("requestId").asLong();
-        long firstCandidateId = first.path("candidates").get(0).path("id").asLong();
-        long secondCandidateId = second.path("candidates").get(0).path("id").asLong();
+        JsonNode recommendation = createRecommendation(accessToken);
+        long requestId = recommendation.path("requestId").asLong();
+        long candidateId = recommendation.path("candidates").get(0).path("id").asLong();
 
-        mockMvc.perform(patch("/api/v1/personal/recommendations/{requestId}", firstRequestId)
+        mockMvc.perform(patch("/api/v1/personal/recommendations/{requestId}", requestId)
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
                                   "selectedCandidateId": %d
                                 }
-                                """.formatted(secondCandidateId)))
+                                """.formatted(candidateId + 10_000)))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.error.code").value("PERSONAL_RECOMMENDATION_CANDIDATE_NOT_FOUND"));
 
-        mockMvc.perform(patch("/api/v1/personal/recommendations/{requestId}", firstRequestId)
+        mockMvc.perform(patch("/api/v1/personal/recommendations/{requestId}", requestId)
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
                                   "selectedCandidateId": %d
                                 }
-                                """.formatted(firstCandidateId)))
+                                """.formatted(candidateId)))
                 .andExpect(status().isOk());
 
-        mockMvc.perform(patch("/api/v1/personal/recommendations/{requestId}", firstRequestId)
+        mockMvc.perform(patch("/api/v1/personal/recommendations/{requestId}", requestId)
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
                                   "selectedCandidateId": %d
                                 }
-                                """.formatted(firstCandidateId)))
+                                """.formatted(candidateId)))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error.code").value("PERSONAL_RECOMMENDATION_ALREADY_CLOSED"));
     }

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -277,6 +277,9 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/personal/recommendations'].post.responses['403'].content['application/json'].examples.tasteProfileRequired.value.error.code")
                         .value("PERSONAL_RECOMMENDATION_TASTE_PROFILE_REQUIRED"))
                 .andExpect(jsonPath(
+                        "$.paths['/api/v1/personal/recommendations'].post.responses['409'].content['application/json'].examples.openExists.value.error.code")
+                        .value("PERSONAL_RECOMMENDATION_OPEN_EXISTS"))
+                .andExpect(jsonPath(
                         "$.paths['/api/v1/personal/recommendations/{requestId}'].get.responses['200'].content['application/json'].examples.success.value.data.contextJson.mealTime")
                         .value("LUNCH"))
                 .andExpect(jsonPath(


### PR DESCRIPTION
## 관련 이슈
Closes #223 

## 📝 작업 내용

- 일반 개인 추천 생성 시 24시간 이내 열린 추천이 있으면 409 PERSONAL_RECOMMENDATION_OPEN_EXISTS 반환
- 열린 추천 정의 적용: COMPLETED, selectedCandidate == null, closedAt == null, requestedAt + 24h > now
- 24시간이 지난 미선택 추천은 생성 시점에 즉시 EXPIRED로 닫고 새 추천 생성 허용
- Swagger/OpenAPI 예시에 openExists 409 케이스 추가
- 통합 테스트에 열린 추천 409, 만료 대상 즉시 종료 후 생성 성공 케이스 추가
- 기존 선택 테스트는 “연속 열린 추천 생성 불가” 정책에 맞게 조정

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 이미 열린 요청이 있으면 아래와 같은 값을 응답합니다.

```json
{
  "success": false,
  "data": null,
  "error": {
    "status": 409,
    "code": "PERSONAL_RECOMMENDATION_OPEN_EXISTS",
    "message": "이미 열린 개인 추천이 있습니다. personalRecommendationId : 1",
    "details": []
  }
}
```
