### PR TITLE
[Feat] 개인 메뉴 추천 재요청 API

### DIFF
--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
@@ -20,6 +20,7 @@ import matchuri.backend.api.recommendation.dto.docs.RecommendationApiExamples;
 import matchuri.backend.api.recommendation.dto.docs.SelectPersonalRecommendationApiResponse;
 import matchuri.backend.api.recommendation.dto.request.CreateGuestPersonalRecommendationRequest;
 import matchuri.backend.api.recommendation.dto.request.CreatePersonalRecommendationRequest;
+import matchuri.backend.api.recommendation.dto.request.RerollPersonalRecommendationRequest;
 import matchuri.backend.api.recommendation.dto.request.SelectPersonalRecommendationRequest;
 import matchuri.backend.api.recommendation.dto.response.GuestPersonalRecommendationResponse;
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationCandidateListResponse;
@@ -177,6 +178,58 @@ public interface RecommendationApi {
     ApiResponse<PersonalRecommendationRequestResponse> createPersonalRecommendation(
             @Valid
             CreatePersonalRecommendationRequest request
+    );
+
+    @Operation(
+            summary = "개인 추천 재요청",
+            description = """
+                    이전 개인 추천을 종료하고 새 개인 추천을 실행합니다.
+
+                    `NOT_SATISFIED`는 이전 추천 후보 전체를 `SKIP` 행동 로그로 저장하고
+                    source 추천을 `REROLLED_WITH_SKIP`으로 종료합니다.
+                    `INPUT_CHANGED`는 `SKIP` 로그 없이 source 추천을 `REROLLED_WITHOUT_SKIP`으로 종료합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "개인 추천 재요청 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = PersonalRecommendationRequestApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = RecommendationApiExamples.PERSONAL_RECOMMENDATION_REROLL_SUCCESS
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "개인 추천을 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "notFound",
+                                    value = RecommendationApiExamples.PERSONAL_RECOMMENDATION_NOT_FOUND
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "이미 종료된 개인 추천",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "alreadyClosed",
+                                    value = RecommendationApiExamples.PERSONAL_RECOMMENDATION_ALREADY_CLOSED
+                            )
+                    )
+            )
+    })
+    ApiResponse<PersonalRecommendationRequestResponse> rerollPersonalRecommendation(
+            Long requestId,
+            @Valid
+            RerollPersonalRecommendationRequest request
     );
 
     @Operation(

--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationController.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationController.java
@@ -7,6 +7,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.api.recommendation.dto.request.CreateGuestPersonalRecommendationRequest;
 import matchuri.backend.api.recommendation.dto.request.CreatePersonalRecommendationRequest;
+import matchuri.backend.api.recommendation.dto.request.RerollPersonalRecommendationRequest;
 import matchuri.backend.api.recommendation.dto.request.SelectPersonalRecommendationRequest;
 import matchuri.backend.api.recommendation.dto.response.GuestPersonalRecommendationResponse;
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationCandidateListResponse;
@@ -76,6 +77,22 @@ public class RecommendationController implements RecommendationApi {
     ) {
         String contextJson = recommendationMapper.toContextJson(request);
         PersonalRecommendationResult result = recommendationService.createPersonalRecommendation(contextJson);
+
+        return ApiResponse.success(recommendationMapper.toCreateResponse(result));
+    }
+
+    @Override
+    @PostMapping("/personal/recommendations/{requestId}/reroll")
+    public ApiResponse<PersonalRecommendationRequestResponse> rerollPersonalRecommendation(
+            @PathVariable Long requestId,
+            @Valid @RequestBody RerollPersonalRecommendationRequest request
+    ) {
+        String contextJson = recommendationMapper.toContextJson(request);
+        PersonalRecommendationResult result = recommendationService.rerollPersonalRecommendation(
+                requestId,
+                request.rerollType(),
+                contextJson
+        );
 
         return ApiResponse.success(recommendationMapper.toCreateResponse(result));
     }

--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationMapper.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationMapper.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.api.recommendation.dto.request.CreateGuestPersonalRecommendationRequest;
 import matchuri.backend.api.recommendation.dto.request.CreatePersonalRecommendationRequest;
+import matchuri.backend.api.recommendation.dto.request.RerollPersonalRecommendationRequest;
 import matchuri.backend.api.recommendation.dto.response.GuestPersonalRecommendationCandidateResponse;
 import matchuri.backend.api.recommendation.dto.response.GuestPersonalRecommendationResponse;
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationCandidateListResponse;
@@ -33,6 +34,10 @@ public class RecommendationMapper {
     private final ObjectMapper objectMapper;
 
     public String toContextJson(CreatePersonalRecommendationRequest request) {
+        return toContextJson(request.contextJson());
+    }
+
+    public String toContextJson(RerollPersonalRecommendationRequest request) {
         return toContextJson(request.contextJson());
     }
 

--- a/src/main/java/matchuri/backend/api/recommendation/dto/docs/RecommendationApiExamples.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/docs/RecommendationApiExamples.java
@@ -177,6 +177,36 @@ public final class RecommendationApiExamples {
             }
             """;
 
+    public static final String PERSONAL_RECOMMENDATION_REROLL_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "requestId": 9002,
+                "status": "COMPLETED",
+                "requestedAt": "2026-05-06T12:20:00",
+                "closedAt": null,
+                "closeReason": null,
+                "candidates": [
+                  {
+                    "id": 10004,
+                    "menuId": 1004,
+                    "menuName": "김치찌개",
+                    "rankNo": 1,
+                    "score": 91.0
+                  },
+                  {
+                    "id": 10005,
+                    "menuId": 1005,
+                    "menuName": "샐러드볼",
+                    "rankNo": 2,
+                    "score": 84.0
+                  }
+                ]
+              },
+              "error": null
+            }
+            """;
+
     public static final String PERSONAL_RECOMMENDATION_DETAIL_SUCCESS = """
             {
               "success": true,

--- a/src/main/java/matchuri/backend/api/recommendation/dto/request/RerollPersonalRecommendationRequest.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/request/RerollPersonalRecommendationRequest.java
@@ -1,0 +1,16 @@
+package matchuri.backend.api.recommendation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationRerollType;
+
+public record RerollPersonalRecommendationRequest(
+        @Schema(description = "재요청 타입입니다.", example = "NOT_SATISFIED")
+        @NotNull(message = "재요청 타입은 필수입니다.")
+        PersonalRecommendationRerollType rerollType,
+
+        @Schema(description = "새 추천 요청 컨텍스트 JSON입니다.")
+        Map<String, Object> contextJson
+) {
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendationRerollType.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendationRerollType.java
@@ -1,0 +1,6 @@
+package matchuri.backend.domain.recommendation.entity;
+
+public enum PersonalRecommendationRerollType {
+    NOT_SATISFIED,
+    INPUT_CHANGED
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationService.java
@@ -2,6 +2,7 @@ package matchuri.backend.domain.recommendation.service;
 
 import java.util.List;
 import matchuri.backend.domain.recommendation.command.GuestPersonalRecommendationCommand;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationRerollType;
 import matchuri.backend.domain.recommendation.result.GuestPersonalRecommendationResult;
 import matchuri.backend.domain.recommendation.result.PersonalRecommendationCandidateResult;
 import matchuri.backend.domain.recommendation.result.PersonalRecommendationResult;
@@ -12,6 +13,12 @@ import org.springframework.data.domain.Page;
 
 public interface RecommendationService {
     PersonalRecommendationResult createPersonalRecommendation(String contextJson);
+
+    PersonalRecommendationResult rerollPersonalRecommendation(
+            Long sourcePersonalRecommendationId,
+            PersonalRecommendationRerollType rerollType,
+            String contextJson
+    );
 
     GuestPersonalRecommendationResult createGuestPersonalRecommendation(GuestPersonalRecommendationCommand command);
 

--- a/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
@@ -39,6 +39,7 @@ import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendatio
 import matchuri.backend.domain.recommendation.command.GuestPersonalRecommendationCommand;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCandidate;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationRerollType;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 import matchuri.backend.domain.recommendation.exception.GuestRecommendationErrorCode;
 import matchuri.backend.domain.recommendation.exception.RecommendationErrorCode;
@@ -84,17 +85,74 @@ public class RecommendationServiceImpl implements RecommendationService {
      * @return 생성된 개인 추천과 추천 후보 목록
      */
     @Override
+    @Transactional
     public PersonalRecommendationResult createPersonalRecommendation(String contextJson) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+
+        List<PersonalRecommendation> recommendations =
+                personalRecommendationRepository.findByMemberIdOrderByRequestedAtDescIdDesc(member.getId());
+        closeExpiredOrRejectOpenRecommendation(recommendations);
+
+        return createPersonalRecommendation(member, contextJson, recommendations);
+    }
+
+    @Override
+    @Transactional
+    public PersonalRecommendationResult rerollPersonalRecommendation(
+            Long sourcePersonalRecommendationId,
+            PersonalRecommendationRerollType rerollType,
+            String contextJson
+    ) {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        PersonalRecommendation sourceRecommendation = getOwnedPersonalRecommendation(sourcePersonalRecommendationId,
+                member.getId());
+
+        if (sourceRecommendation.isClosed()) {
+            throw new BusinessException(RecommendationErrorCode.ALREADY_CLOSED, sourcePersonalRecommendationId);
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        if (isExpiredOpenRecommendation(sourceRecommendation, now)) {
+            sourceRecommendation.expire(now);
+            throw new BusinessException(RecommendationErrorCode.ALREADY_CLOSED, sourcePersonalRecommendationId);
+        }
+
+        if (rerollType == PersonalRecommendationRerollType.NOT_SATISFIED) {
+            List<PersonalRecommendationCandidate> candidates =
+                    personalRecommendationCandidateRepository.findByPersonalRecommendationIdOrderByRankNoAsc(
+                            sourcePersonalRecommendationId);
+            List<MemberMenuAction> skipActions = candidates.stream()
+                    .map(candidate -> new MemberMenuAction(
+                            member,
+                            candidate.getMenuItem(),
+                            sourceRecommendation,
+                            ActionType.SKIP
+                    ))
+                    .toList();
+            memberMenuActionRepository.saveAll(skipActions);
+            sourceRecommendation.closeAsRerolledWithSkip(now);
+        } else if (rerollType == PersonalRecommendationRerollType.INPUT_CHANGED) {
+            sourceRecommendation.closeAsRerolledWithoutSkip(now);
+        } else {
+            throw new IllegalArgumentException("지원하지 않는 개인 추천 재요청 타입입니다. rerollType=" + rerollType);
+        }
+
+        List<PersonalRecommendation> recommendations =
+                personalRecommendationRepository.findByMemberIdOrderByRequestedAtDescIdDesc(member.getId());
+
+        return createPersonalRecommendation(member, contextJson, recommendations);
+    }
+
+    private PersonalRecommendationResult createPersonalRecommendation(
+            Member member,
+            String contextJson,
+            List<PersonalRecommendation> recommendations
+    ) {
         MemberTasteProfile tasteProfile = member.getTasteProfile();
 
         if (tasteProfile == null) {
             throw new BusinessException(RecommendationErrorCode.TASTE_PROFILE_REQUIRED, member.getId());
         }
-
-        List<PersonalRecommendation> recommendations =
-                personalRecommendationRepository.findByMemberIdOrderByRequestedAtDescIdDesc(member.getId());
-        closeExpiredOrRejectOpenRecommendation(recommendations);
 
         MenuRecommendationAlgorithm algorithm =
                 menuRecommendationAlgorithmResolver.resolve(RecommendationAlgorithmType.PERSONAL);
@@ -263,7 +321,7 @@ public class RecommendationServiceImpl implements RecommendationService {
                 continue;
             }
 
-            if (recommendation.getRequestedAt().plusHours(PERSONAL_RECOMMENDATION_OPEN_HOURS).isAfter(now)) {
+            if (!isExpiredOpenRecommendation(recommendation, now)) {
                 throw new BusinessException(RecommendationErrorCode.OPEN_EXISTS, recommendation.getId());
             }
 
@@ -275,6 +333,11 @@ public class RecommendationServiceImpl implements RecommendationService {
         return recommendation.getStatus() == PersonalRecommendationStatus.COMPLETED
                 && recommendation.getSelectedCandidate() == null
                 && !recommendation.isClosed();
+    }
+
+    private boolean isExpiredOpenRecommendation(PersonalRecommendation recommendation, LocalDateTime now) {
+        return isUnclosedCompletedRecommendation(recommendation)
+                && !recommendation.getRequestedAt().plusHours(PERSONAL_RECOMMENDATION_OPEN_HOURS).isAfter(now);
     }
 
     private TasteProfileSnapshot toTasteProfileSnapshot(Member member, MemberTasteProfile tasteProfile) {

--- a/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
@@ -350,6 +350,147 @@ class PersonalRecommendationIntegrationTest {
     }
 
     @Test
+    @DisplayName("불만족 개인 추천 재요청은 이전 후보를 SKIP 로그로 저장하고 새 추천을 생성한다")
+    void rerollPersonalRecommendationWithNotSatisfiedClosesWithSkipAndCreatesNewRecommendation() throws Exception {
+        Member member = saveMember("reroll-skip-user", "불만족재요청");
+        String accessToken = accessToken(member);
+        AttributeCategory spicy = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 10));
+        MenuItem bibimbap = menuItemRepository.save(new MenuItem("BIBIMBAP", "비빔밥", "채소와 밥"));
+        MenuItem riceNoodle = menuItemRepository.save(new MenuItem("RICE_NOODLE", "쌀국수", "가벼운 국물 메뉴"));
+        saveMenuAttribute(bibimbap, spicy);
+        saveMenuAttribute(riceNoodle, spicy);
+        saveTasteProfile(member, spicy, null);
+
+        JsonNode source = createRecommendation(accessToken);
+        long sourceRequestId = source.path("requestId").asLong();
+        int sourceCandidateCount = source.path("candidates").size();
+
+        MvcResult rerollResult = mockMvc.perform(post(
+                                "/api/v1/personal/recommendations/{requestId}/reroll",
+                                sourceRequestId
+                        )
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "rerollType": "NOT_SATISFIED",
+                                  "contextJson": {
+                                    "mealTime": "LUNCH",
+                                    "mood": "다른 메뉴"
+                                  }
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.requestId").isNumber())
+                .andExpect(jsonPath("$.data.closedAt").value(nullValue()))
+                .andExpect(jsonPath("$.data.closeReason").value(nullValue()))
+                .andReturn();
+
+        long rerolledRequestId = objectMapper.readTree(rerollResult.getResponse().getContentAsString())
+                .path("data")
+                .path("requestId")
+                .asLong();
+
+        assertThat(rerolledRequestId).isNotEqualTo(sourceRequestId);
+        assertThat(personalRecommendationRepository.count()).isEqualTo(2);
+        assertThat(memberMenuActionRepository.findAll())
+                .hasSize(sourceCandidateCount)
+                .allSatisfy(action -> assertThat(action.getActionType()).isEqualTo(ActionType.SKIP));
+
+        PersonalRecommendation sourceRecommendation = personalRecommendationRepository.findById(sourceRequestId)
+                .orElseThrow();
+        assertThat(sourceRecommendation.getClosedAt()).isNotNull();
+        assertThat(sourceRecommendation.getCloseReason()).isEqualTo(
+                PersonalRecommendationCloseReason.REROLLED_WITH_SKIP);
+    }
+
+    @Test
+    @DisplayName("입력 변경 개인 추천 재요청은 SKIP 로그 없이 이전 추천을 종료하고 새 추천을 생성한다")
+    void rerollPersonalRecommendationWithInputChangedClosesWithoutSkipAndCreatesNewRecommendation() throws Exception {
+        Member member = saveMember("reroll-input-user", "입력변경재요청");
+        String accessToken = accessToken(member);
+        AttributeCategory spicy = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 10));
+        MenuItem bibimbap = menuItemRepository.save(new MenuItem("BIBIMBAP", "비빔밥", "채소와 밥"));
+        saveMenuAttribute(bibimbap, spicy);
+        saveTasteProfile(member, spicy, null);
+
+        JsonNode source = createRecommendation(accessToken);
+        long sourceRequestId = source.path("requestId").asLong();
+
+        MvcResult rerollResult = mockMvc.perform(post(
+                                "/api/v1/personal/recommendations/{requestId}/reroll",
+                                sourceRequestId
+                        )
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "rerollType": "INPUT_CHANGED",
+                                  "contextJson": {
+                                    "mealTime": "DINNER"
+                                  }
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.requestId").isNumber())
+                .andReturn();
+
+        long rerolledRequestId = objectMapper.readTree(rerollResult.getResponse().getContentAsString())
+                .path("data")
+                .path("requestId")
+                .asLong();
+
+        assertThat(rerolledRequestId).isNotEqualTo(sourceRequestId);
+        assertThat(memberMenuActionRepository.count()).isZero();
+
+        PersonalRecommendation sourceRecommendation = personalRecommendationRepository.findById(sourceRequestId)
+                .orElseThrow();
+        assertThat(sourceRecommendation.getClosedAt()).isNotNull();
+        assertThat(sourceRecommendation.getCloseReason()).isEqualTo(
+                PersonalRecommendationCloseReason.REROLLED_WITHOUT_SKIP);
+    }
+
+    @Test
+    @DisplayName("종료된 개인 추천은 재요청할 수 없다")
+    void rerollPersonalRecommendationRejectsClosedRecommendation() throws Exception {
+        Member member = saveMember("reroll-closed-user", "종료재요청");
+        String accessToken = accessToken(member);
+        AttributeCategory spicy = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 10));
+        MenuItem bibimbap = menuItemRepository.save(new MenuItem("BIBIMBAP", "비빔밥", "채소와 밥"));
+        saveMenuAttribute(bibimbap, spicy);
+        saveTasteProfile(member, spicy, null);
+
+        JsonNode source = createRecommendation(accessToken);
+        long sourceRequestId = source.path("requestId").asLong();
+
+        mockMvc.perform(post("/api/v1/personal/recommendations/{requestId}/reroll", sourceRequestId)
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "rerollType": "INPUT_CHANGED",
+                                  "contextJson": {}
+                                }
+                                """))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/personal/recommendations/{requestId}/reroll", sourceRequestId)
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "rerollType": "INPUT_CHANGED",
+                                  "contextJson": {}
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("PERSONAL_RECOMMENDATION_ALREADY_CLOSED"));
+    }
+
+    @Test
     @DisplayName("개인 추천 조회는 타인 추천 접근을 찾을 수 없음으로 거절한다")
     void getPersonalRecommendationRejectsOtherMemberRecommendation() throws Exception {
         Member owner = saveMember("owner-user", "추천주인");

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -279,6 +279,17 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/personal/recommendations'].post.responses['409'].content['application/json'].examples.openExists.value.error.code")
                         .value("PERSONAL_RECOMMENDATION_OPEN_EXISTS"))
+                .andExpect(jsonPath("$.paths['/api/v1/personal/recommendations/{requestId}/reroll'].post.summary")
+                        .value("개인 추천 재요청"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/personal/recommendations/{requestId}/reroll'].post.responses['200'].content['application/json'].examples.success.value.data.candidates[0].menuName")
+                        .value("김치찌개"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/personal/recommendations/{requestId}/reroll'].post.responses['404'].content['application/json'].examples.notFound.value.error.code")
+                        .value("PERSONAL_RECOMMENDATION_NOT_FOUND"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/personal/recommendations/{requestId}/reroll'].post.responses['409'].content['application/json'].examples.alreadyClosed.value.error.code")
+                        .value("PERSONAL_RECOMMENDATION_ALREADY_CLOSED"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/personal/recommendations/{requestId}'].get.responses['200'].content['application/json'].examples.success.value.data.contextJson.mealTime")
                         .value("LUNCH"))


### PR DESCRIPTION
## 관련 이슈
Closes #224

## 📝 작업 내용
- `POST /api/v1/personal/recommendations/{requestId}/reroll` 추가
- `RerollPersonalRecommendationRequest` 추가: `rerollType`, `contextJson`
- `PersonalRecommendationRerollType` 추가: `NOT_SATISFIED`, `INPUT_CHANGED`
- `NOT_SATISFIED: source` 추천 후보 전체를 `SKIP` 로그로 저장하고 `REROLLED_WITH_SKIP` 종료
- `INPUT_CHANGED`: `SKIP` 로그 없이 `REROLLED_WITHOUT_SKIP` 종료
- 종료된 추천 재요청은 409 `PERSONAL_RECOMMENDATION_ALREADY_CLOSED`
- reroll 성공 후 새 개인 추천 생성 응답 반환
- Swagger/OpenAPI 예시와 docs/api 문서 갱신
- 통합 테스트/문서 테스트 보강

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 재요청 API를 실행시킬 곳은 다음과 같습니다. (아직 이에 대한 내용은 미구현)
  - 요청 결과 화면 내부의 "재요청" 버튼 클릭시
  - 열려 있는 요청이 있을 때 "메뉴 추천 받기" 버튼 클릭시
  - 사용자 취향 프로필 수정 후 재요청 제안 모달 내부 "재요청" 버튼 클릭시
  - 그룹의 위치 변경시 재요청 제안 모달 내부 "재요청" 버튼 클릭시
