### PR TITLE
[Refactor] 스킵된 메뉴는 24시간 동안 추천하지 않음

### DIFF
--- a/src/main/java/matchuri/backend/api/recommendation/dto/request/RerollPersonalRecommendationRequest.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/request/RerollPersonalRecommendationRequest.java
@@ -10,7 +10,7 @@ public record RerollPersonalRecommendationRequest(
         @NotNull(message = "재요청 타입은 필수입니다.")
         PersonalRecommendationRerollType rerollType,
 
-        @Schema(description = "새 추천 요청 컨텍스트 JSON입니다.")
+        @Schema(description = "새 추천 요청 컨텍스트 JSON입니다.", example = "{\"mealTime\":\"LUNCH\"}")
         Map<String, Object> contextJson
 ) {
 }

--- a/src/main/java/matchuri/backend/domain/behavior/repository/MemberMenuActionRepository.java
+++ b/src/main/java/matchuri/backend/domain/behavior/repository/MemberMenuActionRepository.java
@@ -1,9 +1,17 @@
 package matchuri.backend.domain.behavior.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import matchuri.backend.domain.behavior.entity.ActionType;
 import matchuri.backend.domain.behavior.entity.MemberMenuAction;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 @NullMarked
 public interface MemberMenuActionRepository extends JpaRepository<MemberMenuAction, Long> {
+    List<MemberMenuAction> findByMemberIdAndActionTypeAndCreatedAtAfter(
+            Long memberId,
+            ActionType actionType,
+            LocalDateTime createdAt
+    );
 }

--- a/src/main/java/matchuri/backend/domain/recommendation/algorithm/input/MenuRecommendationInput.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/algorithm/input/MenuRecommendationInput.java
@@ -11,6 +11,7 @@ public record MenuRecommendationInput(
         RecommendationContextSnapshot context,
         int candidateLimit,
         List<Long> recentSelectedMenuIds,
+        List<Long> recentlySkippedMenuIds,
         Map<Long, Long> selectedAttributeCategoryFrequency
 ) {
     public MenuRecommendationInput {
@@ -18,6 +19,7 @@ public record MenuRecommendationInput(
         menus = menus == null ? List.of() : List.copyOf(menus);
         context = context == null ? RecommendationContextSnapshot.of(null) : context;
         recentSelectedMenuIds = recentSelectedMenuIds == null ? List.of() : List.copyOf(recentSelectedMenuIds);
+        recentlySkippedMenuIds = recentlySkippedMenuIds == null ? List.of() : List.copyOf(recentlySkippedMenuIds);
         selectedAttributeCategoryFrequency = selectedAttributeCategoryFrequency == null
                 ? Map.of()
                 : Map.copyOf(selectedAttributeCategoryFrequency);

--- a/src/main/java/matchuri/backend/domain/recommendation/algorithm/support/SingleParticipantMenuRecommendationAlgorithm.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/algorithm/support/SingleParticipantMenuRecommendationAlgorithm.java
@@ -29,6 +29,7 @@ public abstract class SingleParticipantMenuRecommendationAlgorithm implements Me
                 .filter(menu -> !containsAny(menu.ingredientIds(), participant.restrictionIngredientIds()))
                 .filter(menu -> !participant.dislikedMenuItemIds().contains(menu.menuId()))
                 .filter(menu -> !input.recentSelectedMenuIds().contains(menu.menuId()))
+                .filter(menu -> !input.recentlySkippedMenuIds().contains(menu.menuId()))
                 .map(menu -> score(menu, participant, input.selectedAttributeCategoryFrequency()))
                 .sorted(Comparator.comparing(ScoredMenu::totalScore).reversed()
                         .thenComparing(scoredMenu -> scoredMenu.menu().menuId()))

--- a/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
@@ -65,6 +65,7 @@ public class RecommendationServiceImpl implements RecommendationService {
     private static final int RECENT_SELECTED_MENU_EXCLUSION_COUNT = 3;
     private static final int RECOMMENDATION_CANDIDATE_LIMIT = 3;
     private static final long PERSONAL_RECOMMENDATION_OPEN_HOURS = 24;
+    private static final long RECENT_SKIPPED_MENU_EXCLUSION_HOURS = 24;
     private static final String GUEST_PARTICIPANT_KEY = "guest";
 
     private final ActiveMemberReader activeMemberReader;
@@ -168,6 +169,7 @@ public class RecommendationServiceImpl implements RecommendationService {
                 RecommendationContextSnapshot.of(contextJson),
                 RECOMMENDATION_CANDIDATE_LIMIT,
                 findRecentlySelectedMenuIds(recommendations),
+                findRecentlySkippedMenuIds(member.getId()),
                 countSelectedAttributeCategoryFrequency(recommendations)
         );
         MenuRecommendationResult recommendationResult = algorithm.recommend(input);
@@ -215,6 +217,7 @@ public class RecommendationServiceImpl implements RecommendationService {
                 toMenuRecommendationProfiles(menuItems),
                 RecommendationContextSnapshot.of(command.contextJson()),
                 RECOMMENDATION_CANDIDATE_LIMIT,
+                List.of(),
                 List.of(),
                 Map.of()
         );
@@ -461,6 +464,18 @@ public class RecommendationServiceImpl implements RecommendationService {
                 .map(PersonalRecommendation::getSelectedMenu)
                 .map(MenuItem::getId)
                 .limit(RECENT_SELECTED_MENU_EXCLUSION_COUNT)
+                .toList();
+    }
+
+    private List<Long> findRecentlySkippedMenuIds(Long memberId) {
+        LocalDateTime threshold = LocalDateTime.now().minusHours(RECENT_SKIPPED_MENU_EXCLUSION_HOURS);
+
+        return memberMenuActionRepository
+                .findByMemberIdAndActionTypeAndCreatedAtAfter(memberId, ActionType.SKIP, threshold)
+                .stream()
+                .map(MemberMenuAction::getMenuItem)
+                .map(MenuItem::getId)
+                .distinct()
                 .toList();
     }
 

--- a/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
@@ -15,7 +15,9 @@ import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import javax.crypto.SecretKey;
 import matchuri.backend.domain.behavior.entity.ActionType;
 import matchuri.backend.domain.behavior.repository.MemberMenuActionRepository;
@@ -364,6 +366,7 @@ class PersonalRecommendationIntegrationTest {
 
         JsonNode source = createRecommendation(accessToken);
         long sourceRequestId = source.path("requestId").asLong();
+        List<Long> sourceCandidateMenuIds = candidateMenuIds(source);
         int sourceCandidateCount = source.path("candidates").size();
 
         MvcResult rerollResult = mockMvc.perform(post(
@@ -391,8 +394,10 @@ class PersonalRecommendationIntegrationTest {
                 .path("data")
                 .path("requestId")
                 .asLong();
+        JsonNode rerolledData = objectMapper.readTree(rerollResult.getResponse().getContentAsString()).path("data");
 
         assertThat(rerolledRequestId).isNotEqualTo(sourceRequestId);
+        assertThat(candidateMenuIds(rerolledData)).doesNotContainAnyElementsOf(sourceCandidateMenuIds);
         assertThat(personalRecommendationRepository.count()).isEqualTo(2);
         assertThat(memberMenuActionRepository.findAll())
                 .hasSize(sourceCandidateCount)
@@ -403,6 +408,34 @@ class PersonalRecommendationIntegrationTest {
         assertThat(sourceRecommendation.getClosedAt()).isNotNull();
         assertThat(sourceRecommendation.getCloseReason()).isEqualTo(
                 PersonalRecommendationCloseReason.REROLLED_WITH_SKIP);
+
+        jdbcTemplate.update(
+                "update member_menu_actions set created_at = ? where personal_recommendation_id = ?",
+                LocalDateTime.now().minusHours(25),
+                sourceRequestId
+        );
+
+        MvcResult afterSkipWindowResult = mockMvc.perform(post(
+                                "/api/v1/personal/recommendations/{requestId}/reroll",
+                                rerolledRequestId
+                        )
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "rerollType": "INPUT_CHANGED",
+                                  "contextJson": {
+                                    "mealTime": "LUNCH",
+                                    "mood": "다시 후보 허용"
+                                  }
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode afterSkipWindowData = objectMapper.readTree(afterSkipWindowResult.getResponse().getContentAsString())
+                .path("data");
+        assertThat(candidateMenuIds(afterSkipWindowData)).containsAnyElementsOf(sourceCandidateMenuIds);
     }
 
     @Test
@@ -418,6 +451,7 @@ class PersonalRecommendationIntegrationTest {
 
         JsonNode source = createRecommendation(accessToken);
         long sourceRequestId = source.path("requestId").asLong();
+        List<Long> sourceCandidateMenuIds = candidateMenuIds(source);
 
         MvcResult rerollResult = mockMvc.perform(post(
                                 "/api/v1/personal/recommendations/{requestId}/reroll",
@@ -441,8 +475,10 @@ class PersonalRecommendationIntegrationTest {
                 .path("data")
                 .path("requestId")
                 .asLong();
+        JsonNode rerolledData = objectMapper.readTree(rerollResult.getResponse().getContentAsString()).path("data");
 
         assertThat(rerolledRequestId).isNotEqualTo(sourceRequestId);
+        assertThat(candidateMenuIds(rerolledData)).containsAnyElementsOf(sourceCandidateMenuIds);
         assertThat(memberMenuActionRepository.count()).isZero();
 
         PersonalRecommendation sourceRecommendation = personalRecommendationRepository.findById(sourceRequestId)
@@ -583,6 +619,14 @@ class PersonalRecommendationIntegrationTest {
                 .andReturn();
 
         return objectMapper.readTree(result.getResponse().getContentAsString()).path("data");
+    }
+
+    private List<Long> candidateMenuIds(JsonNode recommendationData) {
+        List<Long> menuIds = new ArrayList<>();
+        recommendationData.path("candidates")
+                .forEach(candidate -> menuIds.add(candidate.path("menuId").asLong()));
+
+        return menuIds;
     }
 
     private Member saveMember(String loginId, String nickname) {

--- a/src/test/java/matchuri/backend/domain/recommendation/algorithm/guest/GuestPersonalMenuRecommendationAlgorithmV1Test.java
+++ b/src/test/java/matchuri/backend/domain/recommendation/algorithm/guest/GuestPersonalMenuRecommendationAlgorithmV1Test.java
@@ -40,6 +40,7 @@ class GuestPersonalMenuRecommendationAlgorithmV1Test {
                 RecommendationContextSnapshot.of("{}"),
                 3,
                 List.of(),
+                List.of(),
                 Map.of()
         );
 

--- a/src/test/java/matchuri/backend/domain/recommendation/algorithm/personal/PersonalMenuRecommendationAlgorithmV1Test.java
+++ b/src/test/java/matchuri/backend/domain/recommendation/algorithm/personal/PersonalMenuRecommendationAlgorithmV1Test.java
@@ -41,6 +41,7 @@ class PersonalMenuRecommendationAlgorithmV1Test {
                 RecommendationContextSnapshot.of("{}"),
                 3,
                 List.of(5L),
+                List.of(),
                 Map.of(10L, 2L, 30L, 1L)
         );
 
@@ -77,11 +78,44 @@ class PersonalMenuRecommendationAlgorithmV1Test {
                 RecommendationContextSnapshot.of("{}"),
                 2,
                 List.of(),
+                List.of(),
                 Map.of()
         );
 
         MenuRecommendationResult result = algorithm.recommend(input);
 
         assertThat(result.candidates()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("최근 SKIP 메뉴를 제외한다")
+    void recommendFiltersRecentlySkippedMenus() {
+        TasteProfileSnapshot participant = new TasteProfileSnapshot(
+                1L,
+                "1",
+                List.of(10L),
+                List.of(),
+                List.of()
+        );
+        MenuRecommendationInput input = new MenuRecommendationInput(
+                RecommendationTargetType.PERSONAL,
+                List.of(participant),
+                List.of(
+                        new MenuRecommendationProfile(1L, "M1", "메뉴1", List.of(10L), List.of()),
+                        new MenuRecommendationProfile(2L, "M2", "메뉴2", List.of(10L), List.of()),
+                        new MenuRecommendationProfile(3L, "M3", "메뉴3", List.of(10L), List.of())
+                ),
+                RecommendationContextSnapshot.of("{}"),
+                3,
+                List.of(),
+                List.of(1L, 3L),
+                Map.of()
+        );
+
+        MenuRecommendationResult result = algorithm.recommend(input);
+
+        assertThat(result.candidates())
+                .extracting(candidate -> candidate.menuId())
+                .containsExactly(2L);
     }
 }


### PR DESCRIPTION
## 관련 이슈
Closes #225 

## 📝 작업 내용
- 개인 추천에서 더 이상 skip 했던 메뉴들을 추천하지 않습니다.

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 재요청 약 10번 수행하니 아래와 같이 0점 메뉴를 추천하기 시작
- 메뉴 및 식재료에 대한 데이터 필요

```json
{
   "success":true,
   "data":{
      "requestId":11,
      "status":"COMPLETED",
      "requestedAt":"2026-05-21T11:43:32.6975763",
      "closedAt":null,
      "closeReason":null,
      "candidates":[
         {
            "id":31,
            "menuId":8,
            "menuName":"초밥",
            "rankNo":1,
            "score":0
         },
         {
            "id":32,
            "menuId":15,
            "menuName":"김밥",
            "rankNo":2,
            "score":0
         },
         {
            "id":33,
            "menuId":18,
            "menuName":"소바",
            "rankNo":3,
            "score":0
         }
      ]
   },
   "error":null
}

```
