### PR TITLE
[Feat] 미선택 개인 추천 24시간 만료 Scheduler

### DIFF
--- a/src/main/java/matchuri/backend/BackendApplication.java
+++ b/src/main/java/matchuri/backend/BackendApplication.java
@@ -2,7 +2,9 @@ package matchuri.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class BackendApplication {
 

--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
@@ -216,13 +216,19 @@ public interface RecommendationApi {
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "409",
-                    description = "이미 종료된 개인 추천",
+                    description = "이미 종료되었거나 만료된 개인 추천",
                     content = @Content(
                             mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    name = "alreadyClosed",
-                                    value = RecommendationApiExamples.PERSONAL_RECOMMENDATION_ALREADY_CLOSED
-                            )
+                            examples = {
+                                    @ExampleObject(
+                                            name = "alreadyClosed",
+                                            value = RecommendationApiExamples.PERSONAL_RECOMMENDATION_ALREADY_CLOSED
+                                    ),
+                                    @ExampleObject(
+                                            name = "expired",
+                                            value = RecommendationApiExamples.PERSONAL_RECOMMENDATION_EXPIRED
+                                    )
+                            }
                     )
             )
     })
@@ -343,13 +349,19 @@ public interface RecommendationApi {
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "409",
-                    description = "이미 종료된 개인 추천",
+                    description = "이미 종료되었거나 만료된 개인 추천",
                     content = @Content(
                             mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    name = "alreadyClosed",
-                                    value = RecommendationApiExamples.PERSONAL_RECOMMENDATION_ALREADY_CLOSED
-                            )
+                            examples = {
+                                    @ExampleObject(
+                                            name = "alreadyClosed",
+                                            value = RecommendationApiExamples.PERSONAL_RECOMMENDATION_ALREADY_CLOSED
+                                    ),
+                                    @ExampleObject(
+                                            name = "expired",
+                                            value = RecommendationApiExamples.PERSONAL_RECOMMENDATION_EXPIRED
+                                    )
+                            }
                     )
             )
     })

--- a/src/main/java/matchuri/backend/api/recommendation/dto/docs/RecommendationApiExamples.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/docs/RecommendationApiExamples.java
@@ -327,6 +327,19 @@ public final class RecommendationApiExamples {
             }
             """;
 
+    public static final String PERSONAL_RECOMMENDATION_EXPIRED = """
+            {
+              "success": false,
+              "data": null,
+              "error": {
+                "status": 409,
+                "code": "PERSONAL_RECOMMENDATION_EXPIRED",
+                "message": "만료된 개인 추천입니다. personalRecommendationId : 9001",
+                "details": []
+              }
+            }
+            """;
+
     public static final String PERSONAL_RECOMMENDATION_CANDIDATES_SUCCESS = """
             {
               "success": true,

--- a/src/main/java/matchuri/backend/domain/recommendation/exception/RecommendationErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/exception/RecommendationErrorCode.java
@@ -15,6 +15,7 @@ public enum RecommendationErrorCode implements ErrorCode {
     CANDIDATE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 개인 추천 후보를 찾을 수 없습니다. candidateId : {0}"),
     ALREADY_SELECTED(HttpStatus.CONFLICT, "이미 최종 후보가 선택된 개인 추천입니다. personalRecommendationId : {0}"),
     ALREADY_CLOSED(HttpStatus.CONFLICT, "이미 종료된 개인 추천입니다. personalRecommendationId : {0}"),
+    EXPIRED(HttpStatus.CONFLICT, "만료된 개인 추천입니다. personalRecommendationId : {0}"),
     OPEN_EXISTS(HttpStatus.CONFLICT, "이미 열린 개인 추천이 있습니다. personalRecommendationId : {0}");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/matchuri/backend/domain/recommendation/repository/PersonalRecommendationRepository.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/repository/PersonalRecommendationRepository.java
@@ -2,7 +2,9 @@ package matchuri.backend.domain.recommendation.repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.time.LocalDateTime;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,4 +18,9 @@ public interface PersonalRecommendationRepository extends JpaRepository<Personal
     Page<PersonalRecommendation> findByMemberIdOrderByRequestedAtDescIdDesc(Long memberId, Pageable pageable);
 
     Optional<PersonalRecommendation> findByIdAndMemberId(Long id, Long memberId);
+
+    List<PersonalRecommendation> findByStatusAndSelectedCandidateIsNullAndClosedAtIsNullAndRequestedAtLessThanEqual(
+            PersonalRecommendationStatus status,
+            LocalDateTime requestedAt
+    );
 }

--- a/src/main/java/matchuri/backend/domain/recommendation/service/PersonalRecommendationExpirationService.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/PersonalRecommendationExpirationService.java
@@ -1,0 +1,63 @@
+package matchuri.backend.domain.recommendation.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
+import matchuri.backend.domain.recommendation.repository.PersonalRecommendationRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PersonalRecommendationExpirationService {
+
+    static final long EXPIRATION_HOURS = 24;
+
+    private final PersonalRecommendationRepository personalRecommendationRepository;
+
+    @Scheduled(fixedRateString = "PT1H")
+    public void expireOpenPersonalRecommendationsOnSchedule() {
+        int expiredCount = expireOpenPersonalRecommendations();
+        if (expiredCount > 0) {
+            log.info("Expired {} open personal recommendations", expiredCount);
+        }
+    }
+
+    @Transactional
+    public int expireOpenPersonalRecommendations() {
+        LocalDateTime now = LocalDateTime.now();
+        List<PersonalRecommendation> targets = personalRecommendationRepository
+                .findByStatusAndSelectedCandidateIsNullAndClosedAtIsNullAndRequestedAtLessThanEqual(
+                        PersonalRecommendationStatus.COMPLETED,
+                        expirationThreshold(now)
+                );
+
+        targets.forEach(recommendation -> recommendation.expire(now));
+
+        return targets.size();
+    }
+
+    public boolean isExpired(PersonalRecommendation recommendation, LocalDateTime now) {
+        return recommendation.getStatus() == PersonalRecommendationStatus.COMPLETED
+                && recommendation.getSelectedCandidate() == null
+                && !recommendation.isClosed()
+                && !recommendation.getRequestedAt().plusHours(EXPIRATION_HOURS).isAfter(now);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void expirePersonalRecommendationImmediately(Long personalRecommendationId, LocalDateTime expiredAt) {
+        personalRecommendationRepository.findById(personalRecommendationId)
+                .filter(recommendation -> isExpired(recommendation, expiredAt))
+                .ifPresent(recommendation -> recommendation.expire(expiredAt));
+    }
+
+    private LocalDateTime expirationThreshold(LocalDateTime now) {
+        return now.minusHours(EXPIRATION_HOURS);
+    }
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
@@ -39,6 +39,7 @@ import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendatio
 import matchuri.backend.domain.recommendation.command.GuestPersonalRecommendationCommand;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCandidate;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCloseReason;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationRerollType;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 import matchuri.backend.domain.recommendation.exception.GuestRecommendationErrorCode;
@@ -64,7 +65,6 @@ public class RecommendationServiceImpl implements RecommendationService {
 
     private static final int RECENT_SELECTED_MENU_EXCLUSION_COUNT = 3;
     private static final int RECOMMENDATION_CANDIDATE_LIMIT = 3;
-    private static final long PERSONAL_RECOMMENDATION_OPEN_HOURS = 24;
     private static final long RECENT_SKIPPED_MENU_EXCLUSION_HOURS = 24;
     private static final String GUEST_PARTICIPANT_KEY = "guest";
 
@@ -77,6 +77,7 @@ public class RecommendationServiceImpl implements RecommendationService {
     private final PersonalRecommendationCandidateRepository personalRecommendationCandidateRepository;
     private final MemberMenuActionRepository memberMenuActionRepository;
     private final MenuRecommendationAlgorithmResolver menuRecommendationAlgorithmResolver;
+    private final PersonalRecommendationExpirationService personalRecommendationExpirationService;
     private final ObjectMapper objectMapper;
 
     /**
@@ -108,15 +109,8 @@ public class RecommendationServiceImpl implements RecommendationService {
         PersonalRecommendation sourceRecommendation = getOwnedPersonalRecommendation(sourcePersonalRecommendationId,
                 member.getId());
 
-        if (sourceRecommendation.isClosed()) {
-            throw new BusinessException(RecommendationErrorCode.ALREADY_CLOSED, sourcePersonalRecommendationId);
-        }
-
         LocalDateTime now = LocalDateTime.now();
-        if (isExpiredOpenRecommendation(sourceRecommendation, now)) {
-            sourceRecommendation.expire(now);
-            throw new BusinessException(RecommendationErrorCode.ALREADY_CLOSED, sourcePersonalRecommendationId);
-        }
+        validatePersonalRecommendationOpen(sourceRecommendation, now);
 
         if (rerollType == PersonalRecommendationRerollType.NOT_SATISFIED) {
             List<PersonalRecommendationCandidate> candidates =
@@ -288,9 +282,7 @@ public class RecommendationServiceImpl implements RecommendationService {
         PersonalRecommendation personalRecommendation = getOwnedPersonalRecommendation(personalRecommendationId,
                 member.getId());
 
-        if (personalRecommendation.isClosed()) {
-            throw new BusinessException(RecommendationErrorCode.ALREADY_CLOSED, personalRecommendationId);
-        }
+        validatePersonalRecommendationOpen(personalRecommendation, LocalDateTime.now());
 
         PersonalRecommendationCandidate selectedCandidate = personalRecommendationCandidateRepository
                 .findByIdAndPersonalRecommendationId(selectedCandidateId, personalRecommendationId)
@@ -324,7 +316,7 @@ public class RecommendationServiceImpl implements RecommendationService {
                 continue;
             }
 
-            if (!isExpiredOpenRecommendation(recommendation, now)) {
+            if (!personalRecommendationExpirationService.isExpired(recommendation, now)) {
                 throw new BusinessException(RecommendationErrorCode.OPEN_EXISTS, recommendation.getId());
             }
 
@@ -338,9 +330,19 @@ public class RecommendationServiceImpl implements RecommendationService {
                 && !recommendation.isClosed();
     }
 
-    private boolean isExpiredOpenRecommendation(PersonalRecommendation recommendation, LocalDateTime now) {
-        return isUnclosedCompletedRecommendation(recommendation)
-                && !recommendation.getRequestedAt().plusHours(PERSONAL_RECOMMENDATION_OPEN_HOURS).isAfter(now);
+    private void validatePersonalRecommendationOpen(PersonalRecommendation recommendation, LocalDateTime now) {
+        if (recommendation.getCloseReason() == PersonalRecommendationCloseReason.EXPIRED) {
+            throw new BusinessException(RecommendationErrorCode.EXPIRED, recommendation.getId());
+        }
+
+        if (recommendation.isClosed()) {
+            throw new BusinessException(RecommendationErrorCode.ALREADY_CLOSED, recommendation.getId());
+        }
+
+        if (personalRecommendationExpirationService.isExpired(recommendation, now)) {
+            personalRecommendationExpirationService.expirePersonalRecommendationImmediately(recommendation.getId(), now);
+            throw new BusinessException(RecommendationErrorCode.EXPIRED, recommendation.getId());
+        }
     }
 
     private TasteProfileSnapshot toTasteProfileSnapshot(Member member, MemberTasteProfile tasteProfile) {

--- a/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
@@ -49,6 +49,7 @@ import matchuri.backend.domain.recommendation.entity.PersonalRecommendationClose
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 import matchuri.backend.domain.recommendation.repository.PersonalRecommendationCandidateRepository;
 import matchuri.backend.domain.recommendation.repository.PersonalRecommendationRepository;
+import matchuri.backend.domain.recommendation.service.PersonalRecommendationExpirationService;
 import matchuri.backend.global.config.MatchuriProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -118,6 +119,9 @@ class PersonalRecommendationIntegrationTest {
 
     @Autowired
     private MemberMenuActionRepository memberMenuActionRepository;
+
+    @Autowired
+    private PersonalRecommendationExpirationService personalRecommendationExpirationService;
 
     @BeforeEach
     void setUp() {
@@ -349,6 +353,98 @@ class PersonalRecommendationIntegrationTest {
         assertThat(expiredRecommendation.getCloseReason()).isEqualTo(PersonalRecommendationCloseReason.EXPIRED);
         assertThat(newRecommendation.getClosedAt()).isNull();
         assertThat(newRecommendation.getCloseReason()).isNull();
+    }
+
+    @Test
+    @DisplayName("미선택 개인 추천 만료 서비스는 24시간 지난 열린 추천을 종료한다")
+    void expirationServiceClosesOpenRecommendationAfter24Hours() throws Exception {
+        Member member = saveMember("expiration-service-user", "만료서비스");
+        String accessToken = accessToken(member);
+        AttributeCategory spicy = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 10));
+        MenuItem bibimbap = menuItemRepository.save(new MenuItem("BIBIMBAP", "비빔밥", "채소와 밥"));
+        saveMenuAttribute(bibimbap, spicy);
+        saveTasteProfile(member, spicy, null);
+
+        JsonNode recommendation = createRecommendation(accessToken);
+        long requestId = recommendation.path("requestId").asLong();
+        expireRequestedAt(requestId);
+
+        int expiredCount = personalRecommendationExpirationService.expireOpenPersonalRecommendations();
+
+        PersonalRecommendation expiredRecommendation = personalRecommendationRepository.findById(requestId)
+                .orElseThrow();
+        assertThat(expiredCount).isEqualTo(1);
+        assertThat(expiredRecommendation.getClosedAt()).isNotNull();
+        assertThat(expiredRecommendation.getCloseReason()).isEqualTo(PersonalRecommendationCloseReason.EXPIRED);
+    }
+
+    @Test
+    @DisplayName("24시간 지난 미선택 개인 추천은 선택 시점에 즉시 만료되고 거절된다")
+    void selectPersonalRecommendationExpiresOldOpenRecommendationImmediately() throws Exception {
+        Member member = saveMember("select-expired-user", "선택만료");
+        String accessToken = accessToken(member);
+        AttributeCategory spicy = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 10));
+        MenuItem bibimbap = menuItemRepository.save(new MenuItem("BIBIMBAP", "비빔밥", "채소와 밥"));
+        saveMenuAttribute(bibimbap, spicy);
+        saveTasteProfile(member, spicy, null);
+
+        JsonNode recommendation = createRecommendation(accessToken);
+        long requestId = recommendation.path("requestId").asLong();
+        long candidateId = recommendation.path("candidates").get(0).path("id").asLong();
+        expireRequestedAt(requestId);
+
+        mockMvc.perform(patch("/api/v1/personal/recommendations/{requestId}", requestId)
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "selectedCandidateId": %d
+                                }
+                                """.formatted(candidateId)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("PERSONAL_RECOMMENDATION_EXPIRED"));
+
+        PersonalRecommendation expiredRecommendation = personalRecommendationRepository.findById(requestId)
+                .orElseThrow();
+        assertThat(expiredRecommendation.getSelectedCandidate()).isNull();
+        assertThat(expiredRecommendation.getClosedAt()).isNotNull();
+        assertThat(expiredRecommendation.getCloseReason()).isEqualTo(PersonalRecommendationCloseReason.EXPIRED);
+    }
+
+    @Test
+    @DisplayName("24시간 지난 미선택 개인 추천은 재요청 시점에 즉시 만료되고 거절된다")
+    void rerollPersonalRecommendationExpiresOldOpenRecommendationImmediately() throws Exception {
+        Member member = saveMember("reroll-expired-user", "재요청만료");
+        String accessToken = accessToken(member);
+        AttributeCategory spicy = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 10));
+        MenuItem bibimbap = menuItemRepository.save(new MenuItem("BIBIMBAP", "비빔밥", "채소와 밥"));
+        saveMenuAttribute(bibimbap, spicy);
+        saveTasteProfile(member, spicy, null);
+
+        JsonNode recommendation = createRecommendation(accessToken);
+        long requestId = recommendation.path("requestId").asLong();
+        expireRequestedAt(requestId);
+
+        mockMvc.perform(post("/api/v1/personal/recommendations/{requestId}/reroll", requestId)
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "rerollType": "INPUT_CHANGED",
+                                  "contextJson": {}
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("PERSONAL_RECOMMENDATION_EXPIRED"));
+
+        PersonalRecommendation expiredRecommendation = personalRecommendationRepository.findById(requestId)
+                .orElseThrow();
+        assertThat(expiredRecommendation.getClosedAt()).isNotNull();
+        assertThat(expiredRecommendation.getCloseReason()).isEqualTo(PersonalRecommendationCloseReason.EXPIRED);
+        assertThat(personalRecommendationRepository.count()).isEqualTo(1);
     }
 
     @Test
@@ -619,6 +715,14 @@ class PersonalRecommendationIntegrationTest {
                 .andReturn();
 
         return objectMapper.readTree(result.getResponse().getContentAsString()).path("data");
+    }
+
+    private void expireRequestedAt(long requestId) {
+        jdbcTemplate.update(
+                "update personal_recommendations set requested_at = ? where id = ?",
+                LocalDateTime.now().minusHours(25),
+                requestId
+        );
     }
 
     private List<Long> candidateMenuIds(JsonNode recommendationData) {

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -291,6 +291,9 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/personal/recommendations/{requestId}/reroll'].post.responses['409'].content['application/json'].examples.alreadyClosed.value.error.code")
                         .value("PERSONAL_RECOMMENDATION_ALREADY_CLOSED"))
                 .andExpect(jsonPath(
+                        "$.paths['/api/v1/personal/recommendations/{requestId}/reroll'].post.responses['409'].content['application/json'].examples.expired.value.error.code")
+                        .value("PERSONAL_RECOMMENDATION_EXPIRED"))
+                .andExpect(jsonPath(
                         "$.paths['/api/v1/personal/recommendations/{requestId}'].get.responses['200'].content['application/json'].examples.success.value.data.contextJson.mealTime")
                         .value("LUNCH"))
                 .andExpect(jsonPath(
@@ -323,6 +326,9 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/personal/recommendations/{requestId}'].patch.responses['409'].content['application/json'].examples.alreadyClosed.value.error.code")
                         .value("PERSONAL_RECOMMENDATION_ALREADY_CLOSED"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/personal/recommendations/{requestId}'].patch.responses['409'].content['application/json'].examples.expired.value.error.code")
+                        .value("PERSONAL_RECOMMENDATION_EXPIRED"))
                 .andExpect(jsonPath("$.paths['/api/v1/groups'].post.summary")
                         .value("그룹 생성"))
                 .andExpect(jsonPath(


### PR DESCRIPTION
## 관련 이슈
Closes #226 

## 📝 작업 내용
- `PersonalRecommendationExpirationService` 추가
- `@EnableScheduling` 활성화 및 1시간 주기 `@Scheduled(fixedRateString = "PT1H")` 만료 처리 추가
- 만료 대상 조건 적용: `COMPLETED`, 미선택, 미종료, `requestedAt <= now - 24h`
- 만료 시 `closedAt=now`, `closeReason=EXPIRED`
- 선택/재요청 API에서 즉시 만료 검사 추가
- 만료 대상 선택/재요청은 `409 PERSONAL_RECOMMENDATION_EXPIRED`
- 즉시 만료 저장은 실패 응답 트랜잭션 롤백에 말리지 않도록 별도 트랜잭션으로 처리
- Swagger/OpenAPI 예시와 `docs/api`, `docs/generated/db-schema.md` 갱신
- 통합 테스트에 scheduler 서비스 만료, 선택 시 즉시 만료, 재요청 시 즉시 만료 케이스 추가

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 1시간에 한번씩 만료 처리를 검증하는 스케줄러 추가
