### PR TITLE
[Refactor] 개인 추천 요청 API에 스케줄러 호출 로직 제거

### DIFF
--- a/src/main/java/matchuri/backend/domain/recommendation/service/PersonalRecommendationExpirationService.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/PersonalRecommendationExpirationService.java
@@ -9,7 +9,6 @@ import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatu
 import matchuri.backend.domain.recommendation.repository.PersonalRecommendationRepository;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
@@ -48,13 +47,6 @@ public class PersonalRecommendationExpirationService {
                 && recommendation.getSelectedCandidate() == null
                 && !recommendation.isClosed()
                 && !recommendation.getRequestedAt().plusHours(EXPIRATION_HOURS).isAfter(now);
-    }
-
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void expirePersonalRecommendationImmediately(Long personalRecommendationId, LocalDateTime expiredAt) {
-        personalRecommendationRepository.findById(personalRecommendationId)
-                .filter(recommendation -> isExpired(recommendation, expiredAt))
-                .ifPresent(recommendation -> recommendation.expire(expiredAt));
     }
 
     private LocalDateTime expirationThreshold(LocalDateTime now) {

--- a/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
@@ -109,8 +109,7 @@ public class RecommendationServiceImpl implements RecommendationService {
         PersonalRecommendation sourceRecommendation = getOwnedPersonalRecommendation(sourcePersonalRecommendationId,
                 member.getId());
 
-        LocalDateTime now = LocalDateTime.now();
-        validatePersonalRecommendationOpen(sourceRecommendation, now);
+        validatePersonalRecommendationOpen(sourceRecommendation);
 
         if (rerollType == PersonalRecommendationRerollType.NOT_SATISFIED) {
             List<PersonalRecommendationCandidate> candidates =
@@ -125,9 +124,9 @@ public class RecommendationServiceImpl implements RecommendationService {
                     ))
                     .toList();
             memberMenuActionRepository.saveAll(skipActions);
-            sourceRecommendation.closeAsRerolledWithSkip(now);
+            sourceRecommendation.closeAsRerolledWithSkip(LocalDateTime.now());
         } else if (rerollType == PersonalRecommendationRerollType.INPUT_CHANGED) {
-            sourceRecommendation.closeAsRerolledWithoutSkip(now);
+            sourceRecommendation.closeAsRerolledWithoutSkip(LocalDateTime.now());
         } else {
             throw new IllegalArgumentException("지원하지 않는 개인 추천 재요청 타입입니다. rerollType=" + rerollType);
         }
@@ -282,7 +281,7 @@ public class RecommendationServiceImpl implements RecommendationService {
         PersonalRecommendation personalRecommendation = getOwnedPersonalRecommendation(personalRecommendationId,
                 member.getId());
 
-        validatePersonalRecommendationOpen(personalRecommendation, LocalDateTime.now());
+        validatePersonalRecommendationOpen(personalRecommendation);
 
         PersonalRecommendationCandidate selectedCandidate = personalRecommendationCandidateRepository
                 .findByIdAndPersonalRecommendationId(selectedCandidateId, personalRecommendationId)
@@ -330,18 +329,13 @@ public class RecommendationServiceImpl implements RecommendationService {
                 && !recommendation.isClosed();
     }
 
-    private void validatePersonalRecommendationOpen(PersonalRecommendation recommendation, LocalDateTime now) {
+    private void validatePersonalRecommendationOpen(PersonalRecommendation recommendation) {
         if (recommendation.getCloseReason() == PersonalRecommendationCloseReason.EXPIRED) {
             throw new BusinessException(RecommendationErrorCode.EXPIRED, recommendation.getId());
         }
 
         if (recommendation.isClosed()) {
             throw new BusinessException(RecommendationErrorCode.ALREADY_CLOSED, recommendation.getId());
-        }
-
-        if (personalRecommendationExpirationService.isExpired(recommendation, now)) {
-            personalRecommendationExpirationService.expirePersonalRecommendationImmediately(recommendation.getId(), now);
-            throw new BusinessException(RecommendationErrorCode.EXPIRED, recommendation.getId());
         }
     }
 

--- a/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
@@ -380,8 +380,8 @@ class PersonalRecommendationIntegrationTest {
     }
 
     @Test
-    @DisplayName("24시간 지난 미선택 개인 추천은 선택 시점에 즉시 만료되고 거절된다")
-    void selectPersonalRecommendationExpiresOldOpenRecommendationImmediately() throws Exception {
+    @DisplayName("24시간이 지났어도 scheduler가 닫기 전이면 개인 추천을 선택할 수 있다")
+    void selectPersonalRecommendationAllowsExpiredByTimeUntilSchedulerClosesIt() throws Exception {
         Member member = saveMember("select-expired-user", "선택만료");
         String accessToken = accessToken(member);
         AttributeCategory spicy = attributeCategoryRepository.save(
@@ -403,19 +403,19 @@ class PersonalRecommendationIntegrationTest {
                                   "selectedCandidateId": %d
                                 }
                                 """.formatted(candidateId)))
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.error.code").value("PERSONAL_RECOMMENDATION_EXPIRED"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.closeReason").value(PersonalRecommendationCloseReason.SELECTED.name()));
 
-        PersonalRecommendation expiredRecommendation = personalRecommendationRepository.findById(requestId)
+        PersonalRecommendation selectedRecommendation = personalRecommendationRepository.findById(requestId)
                 .orElseThrow();
-        assertThat(expiredRecommendation.getSelectedCandidate()).isNull();
-        assertThat(expiredRecommendation.getClosedAt()).isNotNull();
-        assertThat(expiredRecommendation.getCloseReason()).isEqualTo(PersonalRecommendationCloseReason.EXPIRED);
+        assertThat(selectedRecommendation.getSelectedCandidate()).isNotNull();
+        assertThat(selectedRecommendation.getClosedAt()).isNotNull();
+        assertThat(selectedRecommendation.getCloseReason()).isEqualTo(PersonalRecommendationCloseReason.SELECTED);
     }
 
     @Test
-    @DisplayName("24시간 지난 미선택 개인 추천은 재요청 시점에 즉시 만료되고 거절된다")
-    void rerollPersonalRecommendationExpiresOldOpenRecommendationImmediately() throws Exception {
+    @DisplayName("24시간이 지났어도 scheduler가 닫기 전이면 개인 추천을 재요청할 수 있다")
+    void rerollPersonalRecommendationAllowsExpiredByTimeUntilSchedulerClosesIt() throws Exception {
         Member member = saveMember("reroll-expired-user", "재요청만료");
         String accessToken = accessToken(member);
         AttributeCategory spicy = attributeCategoryRepository.save(
@@ -437,14 +437,73 @@ class PersonalRecommendationIntegrationTest {
                                   "contextJson": {}
                                 }
                                 """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.requestId").isNumber());
+
+        PersonalRecommendation rerolledRecommendation = personalRecommendationRepository.findById(requestId)
+                .orElseThrow();
+        assertThat(rerolledRecommendation.getClosedAt()).isNotNull();
+        assertThat(rerolledRecommendation.getCloseReason()).isEqualTo(
+                PersonalRecommendationCloseReason.REROLLED_WITHOUT_SKIP);
+        assertThat(personalRecommendationRepository.count()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("scheduler가 만료 종료한 개인 추천은 선택할 수 없다")
+    void selectPersonalRecommendationRejectsSchedulerExpiredRecommendation() throws Exception {
+        Member member = saveMember("select-scheduler-expired-user", "스케줄러선택만료");
+        String accessToken = accessToken(member);
+        AttributeCategory spicy = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 10));
+        MenuItem bibimbap = menuItemRepository.save(new MenuItem("BIBIMBAP", "비빔밥", "채소와 밥"));
+        saveMenuAttribute(bibimbap, spicy);
+        saveTasteProfile(member, spicy, null);
+
+        JsonNode recommendation = createRecommendation(accessToken);
+        long requestId = recommendation.path("requestId").asLong();
+        long candidateId = recommendation.path("candidates").get(0).path("id").asLong();
+        expireRequestedAt(requestId);
+        personalRecommendationExpirationService.expireOpenPersonalRecommendations();
+
+        mockMvc.perform(patch("/api/v1/personal/recommendations/{requestId}", requestId)
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "selectedCandidateId": %d
+                                }
+                                """.formatted(candidateId)))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error.code").value("PERSONAL_RECOMMENDATION_EXPIRED"));
+    }
 
-        PersonalRecommendation expiredRecommendation = personalRecommendationRepository.findById(requestId)
-                .orElseThrow();
-        assertThat(expiredRecommendation.getClosedAt()).isNotNull();
-        assertThat(expiredRecommendation.getCloseReason()).isEqualTo(PersonalRecommendationCloseReason.EXPIRED);
-        assertThat(personalRecommendationRepository.count()).isEqualTo(1);
+    @Test
+    @DisplayName("scheduler가 만료 종료한 개인 추천은 재요청할 수 없다")
+    void rerollPersonalRecommendationRejectsSchedulerExpiredRecommendation() throws Exception {
+        Member member = saveMember("reroll-scheduler-expired-user", "스케줄러재요청만료");
+        String accessToken = accessToken(member);
+        AttributeCategory spicy = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 10));
+        MenuItem bibimbap = menuItemRepository.save(new MenuItem("BIBIMBAP", "비빔밥", "채소와 밥"));
+        saveMenuAttribute(bibimbap, spicy);
+        saveTasteProfile(member, spicy, null);
+
+        JsonNode recommendation = createRecommendation(accessToken);
+        long requestId = recommendation.path("requestId").asLong();
+        expireRequestedAt(requestId);
+        personalRecommendationExpirationService.expireOpenPersonalRecommendations();
+
+        mockMvc.perform(post("/api/v1/personal/recommendations/{requestId}/reroll", requestId)
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "rerollType": "INPUT_CHANGED",
+                                  "contextJson": {}
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("PERSONAL_RECOMMENDATION_EXPIRED"));
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
Closes #234 

## 📝 작업 내용
- 선택/재요청에서 expiration service를 호출해 즉시 만료 저장하던 흐름 제거

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 만료 상태 관리는 최대 1시간 오차까지는 허용함
