### PR TITLE
[Refactor] 취향 프로필 수정시 응답값에 현재 진행 중인 요청 ID 전달

### DIFF
--- a/src/main/java/matchuri/backend/api/member/MemberApi.java
+++ b/src/main/java/matchuri/backend/api/member/MemberApi.java
@@ -13,6 +13,7 @@ import matchuri.backend.api.member.dto.docs.CreateMemberApiResponse;
 import matchuri.backend.api.member.dto.docs.LoginIdExistsApiResponse;
 import matchuri.backend.api.member.dto.docs.MemberProfileApiResponse;
 import matchuri.backend.api.member.dto.docs.MemberTasteProfileSummaryApiResponse;
+import matchuri.backend.api.member.dto.docs.MemberTasteProfileUpdateApiResponse;
 import matchuri.backend.api.member.dto.docs.NicknameExistsApiResponse;
 import matchuri.backend.api.member.dto.docs.RegisterLocalMemberApiResponse;
 import matchuri.backend.api.member.dto.docs.UpdateMemberPasswordApiResponse;
@@ -25,6 +26,7 @@ import matchuri.backend.api.member.dto.response.CreateMemberResponse;
 import matchuri.backend.api.member.dto.response.LoginIdExistsResponse;
 import matchuri.backend.api.member.dto.response.MemberProfileResponse;
 import matchuri.backend.api.member.dto.response.MemberTasteProfileSummaryResponse;
+import matchuri.backend.api.member.dto.response.MemberTasteProfileUpdateResponse;
 import matchuri.backend.api.member.dto.response.NicknameExistsResponse;
 import matchuri.backend.api.member.dto.response.RegisterLocalMemberResponse;
 import matchuri.backend.api.member.dto.response.UpdateMemberPasswordResponse;
@@ -646,7 +648,9 @@ public interface MemberApi {
                     - 특정 목록을 비우려면 빈 배열을 보내야 합니다.
                     - 존재하지 않거나 비활성화된 참조 데이터 ID는 거절됩니다.
                     - `dislikedMenuItemIds`는 활성 `MenuItem` 검색/선택 결과의 ID 목록입니다.
-                    - 성공 시 조회 API와 동일한 구조를 반환합니다.
+                    - 성공 시 조회 API와 동일한 취향 프로필 구조에 `openPersonalRecommendationId`를 함께 반환합니다.
+                    - `openPersonalRecommendationId`가 있으면 취향 변경을 반영하기 위해 해당 추천 ID로 `INPUT_CHANGED` 재요청을 이어갈 수 있습니다.
+                    - 진행 중인 개인 추천이 없으면 `openPersonalRecommendationId`는 `null`입니다.
                     - `profileVersion`은 수정 시각 대체값이 아니라 프로필 정책/구조 버전이므로, 단순 저장만으로는 바뀌지 않습니다.
                     """)
     @ApiResponses({
@@ -655,7 +659,7 @@ public interface MemberApi {
                     description = "저장 성공",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = MemberTasteProfileSummaryApiResponse.class),
+                            schema = @Schema(implementation = MemberTasteProfileUpdateApiResponse.class),
                             examples = @ExampleObject(
                                     name = "saved",
                                     value = """
@@ -689,7 +693,8 @@ public interface MemberApi {
                                                     "name": "돈까스"
                                                   }
                                                 ],
-                                                "updatedAt": "2026-04-20T18:00:00"
+                                                "updatedAt": "2026-04-20T18:00:00",
+                                                "openPersonalRecommendationId": 9001
                                               },
                                               "error": null
                                             }
@@ -825,7 +830,7 @@ public interface MemberApi {
                     )
             )
     })
-    ApiResponse<MemberTasteProfileSummaryResponse> updateMyTasteProfile(UpdateMemberTasteProfileRequest request);
+    ApiResponse<MemberTasteProfileUpdateResponse> updateMyTasteProfile(UpdateMemberTasteProfileRequest request);
 
     @Operation(
             summary = "회원 탈퇴",

--- a/src/main/java/matchuri/backend/api/member/MemberController.java
+++ b/src/main/java/matchuri/backend/api/member/MemberController.java
@@ -11,6 +11,7 @@ import matchuri.backend.api.member.dto.response.CreateMemberResponse;
 import matchuri.backend.api.member.dto.response.LoginIdExistsResponse;
 import matchuri.backend.api.member.dto.response.MemberProfileResponse;
 import matchuri.backend.api.member.dto.response.MemberTasteProfileSummaryResponse;
+import matchuri.backend.api.member.dto.response.MemberTasteProfileUpdateResponse;
 import matchuri.backend.api.member.dto.response.NicknameExistsResponse;
 import matchuri.backend.api.member.dto.response.RegisterLocalMemberResponse;
 import matchuri.backend.api.member.dto.response.UpdateMemberPasswordResponse;
@@ -124,12 +125,11 @@ public class MemberController implements MemberApi {
 
     @Override
     @PatchMapping("/me/taste-profile")
-    public ApiResponse<MemberTasteProfileSummaryResponse> updateMyTasteProfile(
+    public ApiResponse<MemberTasteProfileUpdateResponse> updateMyTasteProfile(
             @Valid @RequestBody UpdateMemberTasteProfileRequest request) {
         var command = memberMapper.toUpdateMemberTasteProfileCommand(request);
         var result = memberService.updateMyTasteProfile(command);
-        MemberTasteProfileSummaryResponse response = memberMapper.toMemberTasteProfileSummaryResponse(result);
-
+        var response = memberMapper.toMemberTasteProfileUpdateResponse(result);
         return ApiResponse.success(response);
     }
 

--- a/src/main/java/matchuri/backend/api/member/dto/docs/MemberTasteProfileUpdateApiResponse.java
+++ b/src/main/java/matchuri/backend/api/member/dto/docs/MemberTasteProfileUpdateApiResponse.java
@@ -1,0 +1,18 @@
+package matchuri.backend.api.member.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.member.dto.response.MemberTasteProfileUpdateResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "내 취향 프로필 저장 API의 공통 응답 envelope입니다.")
+public record MemberTasteProfileUpdateApiResponse(
+        @Schema(description = "요청 성공 여부입니다.", example = "true")
+        boolean success,
+
+        @Schema(description = "성공 시 반환되는 내 취향 프로필 저장 payload입니다.")
+        MemberTasteProfileUpdateResponse data,
+
+        @Schema(description = "실패 시 반환되는 에러 정보입니다.")
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/member/dto/response/MemberTasteProfileUpdateResponse.java
+++ b/src/main/java/matchuri/backend/api/member/dto/response/MemberTasteProfileUpdateResponse.java
@@ -1,0 +1,33 @@
+package matchuri.backend.api.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MemberTasteProfileUpdateResponse(
+        @Schema(description = "현재 로그인한 회원 ID입니다.", example = "1")
+        Long memberId,
+
+        @Schema(description = "현재 프로필 정책/구조가 어떤 버전을 따르는지 나타내는 서버 관리 버전입니다.", example = "v1")
+        String profileVersion,
+
+        @Schema(description = "현재 선택된 attribute category 목록입니다.")
+        List<MemberTasteAttributeCategoryResponse> attributeCategories,
+
+        @Schema(description = "현재 선택된 restriction ingredient 목록입니다.")
+        List<MemberTasteRestrictionIngredientResponse> restrictionIngredients,
+
+        @Schema(description = "현재 선택된 disliked menu item 목록입니다.")
+        List<MemberTasteDislikedMenuItemResponse> dislikedMenuItems,
+
+        @Schema(description = "취향 프로필이 마지막으로 갱신된 시각입니다. 프로필이 없으면 null입니다.", example = "2026-04-17T12:30:45")
+        LocalDateTime updatedAt,
+
+        @Schema(
+                description = "취향 수정 시점에 INPUT_CHANGED 재요청으로 이어갈 수 있는 미종료 개인 추천 ID입니다. 없으면 null입니다.",
+                example = "9001",
+                nullable = true
+        )
+        Long openPersonalRecommendationId
+) {
+}

--- a/src/main/java/matchuri/backend/api/member/mapper/MemberMapper.java
+++ b/src/main/java/matchuri/backend/api/member/mapper/MemberMapper.java
@@ -12,6 +12,7 @@ import matchuri.backend.api.member.dto.response.MemberProfileResponse;
 import matchuri.backend.api.member.dto.response.MemberTasteAttributeCategoryResponse;
 import matchuri.backend.api.member.dto.response.MemberTasteDislikedMenuItemResponse;
 import matchuri.backend.api.member.dto.response.MemberTasteProfileSummaryResponse;
+import matchuri.backend.api.member.dto.response.MemberTasteProfileUpdateResponse;
 import matchuri.backend.api.member.dto.response.MemberTasteRestrictionIngredientResponse;
 import matchuri.backend.api.member.dto.response.NicknameExistsResponse;
 import matchuri.backend.api.member.dto.response.RegisterLocalMemberResponse;
@@ -32,6 +33,7 @@ import matchuri.backend.domain.member.entity.SocialProviderType;
 import matchuri.backend.domain.member.result.CreateMemberResult;
 import matchuri.backend.domain.member.result.MemberProfileResult;
 import matchuri.backend.domain.member.result.MemberTasteProfileSummaryResult;
+import matchuri.backend.domain.member.result.MemberTasteUpdateResult;
 import matchuri.backend.domain.member.result.OnboardingStatusResult;
 import matchuri.backend.domain.member.result.RegisterLocalMemberResult;
 import matchuri.backend.domain.member.result.UpdateMemberPasswordResult;
@@ -147,6 +149,20 @@ public class MemberMapper {
                         ))
                         .toList(),
                 result.updatedAt()
+        );
+    }
+
+    public MemberTasteProfileUpdateResponse toMemberTasteProfileUpdateResponse(MemberTasteUpdateResult result) {
+        MemberTasteProfileSummaryResult profileResult = result.profile();
+        MemberTasteProfileSummaryResponse response = toMemberTasteProfileSummaryResponse(profileResult);
+        return new MemberTasteProfileUpdateResponse(
+                response.memberId(),
+                response.profileVersion(),
+                response.attributeCategories(),
+                response.restrictionIngredients(),
+                response.dislikedMenuItems(),
+                response.updatedAt(),
+                result.openPersonalRecommendationId()
         );
     }
 

--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
@@ -186,8 +186,12 @@ public interface RecommendationApi {
                     이전 개인 추천을 종료하고 새 개인 추천을 실행합니다.
 
                     `NOT_SATISFIED`는 이전 추천 후보 전체를 `SKIP` 행동 로그로 저장하고
-                    source 추천을 `REROLLED_WITH_SKIP`으로 종료합니다.
-                    `INPUT_CHANGED`는 `SKIP` 로그 없이 source 추천을 `REROLLED_WITHOUT_SKIP`으로 종료합니다.
+                    source 추천을 `REROLLED_WITH_SKIP`으로 종료합니다. \n
+                    `INPUT_CHANGED`는 `SKIP` 로그 없이 source 추천을 `REROLLED_WITHOUT_SKIP`으로 종료합니다. \n
+                    
+                    - 추천 결과 페이지 "재요청" 버튼
+                    - 취향 프로필 수정 후 모달 내부 "재요청" 버튼
+                    - 개인 메뉴 추천 페이지에서 진행 중인 요청이 있을 때
                     """
     )
     @ApiResponses({

--- a/src/main/java/matchuri/backend/domain/member/result/MemberTasteUpdateResult.java
+++ b/src/main/java/matchuri/backend/domain/member/result/MemberTasteUpdateResult.java
@@ -1,0 +1,7 @@
+package matchuri.backend.domain.member.result;
+
+public record MemberTasteUpdateResult(
+        MemberTasteProfileSummaryResult profile,
+        Long openPersonalRecommendationId
+) {
+}

--- a/src/main/java/matchuri/backend/domain/member/service/MemberService.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberService.java
@@ -8,6 +8,7 @@ import matchuri.backend.domain.member.command.UpdateMemberTasteProfileCommand;
 import matchuri.backend.domain.member.result.CreateMemberResult;
 import matchuri.backend.domain.member.result.MemberProfileResult;
 import matchuri.backend.domain.member.result.MemberTasteProfileSummaryResult;
+import matchuri.backend.domain.member.result.MemberTasteUpdateResult;
 import matchuri.backend.domain.member.result.RegisterLocalMemberResult;
 import matchuri.backend.domain.member.result.UpdateMemberPasswordResult;
 import matchuri.backend.domain.member.result.UpdateMemberResult;
@@ -31,7 +32,7 @@ public interface MemberService {
 
     UpdateMemberPasswordResult updateMyPassword(UpdateMemberPasswordCommand command);
 
-    MemberTasteProfileSummaryResult updateMyTasteProfile(UpdateMemberTasteProfileCommand command);
+    MemberTasteUpdateResult updateMyTasteProfile(UpdateMemberTasteProfileCommand command);
 
     WithdrawMemberResult withdraw();
 }

--- a/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
@@ -29,6 +29,7 @@ import matchuri.backend.domain.member.repository.MemberTasteProfileRestrictionIn
 import matchuri.backend.domain.member.result.CreateMemberResult;
 import matchuri.backend.domain.member.result.MemberProfileResult;
 import matchuri.backend.domain.member.result.MemberTasteProfileSummaryResult;
+import matchuri.backend.domain.member.result.MemberTasteUpdateResult;
 import matchuri.backend.domain.member.result.RegisterLocalMemberResult;
 import matchuri.backend.domain.member.result.UpdateMemberPasswordResult;
 import matchuri.backend.domain.member.result.UpdateMemberResult;
@@ -42,6 +43,8 @@ import matchuri.backend.domain.menu.entity.MenuItem;
 import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
 import matchuri.backend.domain.menu.repository.IngredientRepository;
 import matchuri.backend.domain.menu.repository.MenuItemRepository;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
+import matchuri.backend.domain.recommendation.repository.PersonalRecommendationRepository;
 import matchuri.backend.global.exception.BusinessException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -67,6 +70,7 @@ public class MemberServiceImpl implements MemberService {
     private final ActiveMemberReader activeMemberReader;
     private final OnboardingStatusResolver onboardingStatusResolver;
     private final EmailVerificationTokenVerifier emailVerificationTokenVerifier;
+    private final PersonalRecommendationRepository personalRecommendationRepository;
 
     @Override
     public boolean existsByLoginId(String loginId) {
@@ -119,6 +123,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    @Transactional
     public MemberTasteProfileSummaryResult getMyTasteProfile() {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
 
@@ -171,24 +176,15 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional
-    public MemberTasteProfileSummaryResult updateMyTasteProfile(UpdateMemberTasteProfileCommand command) {
+    public MemberTasteUpdateResult updateMyTasteProfile(UpdateMemberTasteProfileCommand command) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
         List<Long> attributeCategoryIds = command.attributeCategoryIds();
         List<Long> restrictionIngredientIds = command.restrictionIngredientIds();
         List<Long> dislikedMenuItemIds = command.dislikedMenuItemIds();
 
-        validateNoDuplicateIds(
-                attributeCategoryIds,
-                MemberErrorCode.DUPLICATE_TASTE_ATTRIBUTE_CATEGORY
-        );
-        validateNoDuplicateIds(
-                restrictionIngredientIds,
-                MemberErrorCode.DUPLICATE_TASTE_RESTRICTION_INGREDIENT
-        );
-        validateNoDuplicateIds(
-                dislikedMenuItemIds,
-                MemberErrorCode.DUPLICATE_TASTE_DISLIKED_MENU_ITEM
-        );
+        validateNoDuplicateIds(attributeCategoryIds, MemberErrorCode.DUPLICATE_TASTE_ATTRIBUTE_CATEGORY);
+        validateNoDuplicateIds(restrictionIngredientIds, MemberErrorCode.DUPLICATE_TASTE_RESTRICTION_INGREDIENT);
+        validateNoDuplicateIds(dislikedMenuItemIds, MemberErrorCode.DUPLICATE_TASTE_DISLIKED_MENU_ITEM);
 
         Map<Long, AttributeCategory> attributeCategoriesById = loadActiveAttributeCategories(attributeCategoryIds);
         Map<Long, Ingredient> ingredientsById = loadActiveIngredients(restrictionIngredientIds);
@@ -203,7 +199,16 @@ public class MemberServiceImpl implements MemberService {
         replaceRestrictionIngredientMappings(tasteProfile, restrictionIngredientIds, ingredientsById);
         replaceDislikedMenuItemMappings(tasteProfile, dislikedMenuItemIds, menuItemsById);
 
-        return MemberTasteProfileSummaryResult.of(
+        Long openPersonalRecommendationId =
+                personalRecommendationRepository
+                        .findFirstByMemberIdAndStatusAndSelectedCandidateIsNullAndClosedAtIsNullOrderByRequestedAtDescIdDesc(
+                                member.getId(),
+                                PersonalRecommendationStatus.COMPLETED
+                        )
+                        .map(recommendation -> recommendation.getId())
+                        .orElse(null);
+
+        MemberTasteProfileSummaryResult memberTasteProfileSummaryResult = MemberTasteProfileSummaryResult.of(
                 member.getId(),
                 tasteProfile,
                 memberTasteProfileCategoryRepository.findAllByProfileIdOrderByDisplay(tasteProfile.getId()),
@@ -211,6 +216,8 @@ public class MemberServiceImpl implements MemberService {
                         tasteProfile.getId()),
                 memberTasteProfileDislikedMenuItemRepository.findAllByProfileIdOrderByDisplay(tasteProfile.getId())
         );
+
+        return new MemberTasteUpdateResult(memberTasteProfileSummaryResult, openPersonalRecommendationId);
     }
 
     @Override

--- a/src/main/java/matchuri/backend/domain/recommendation/repository/PersonalRecommendationRepository.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/repository/PersonalRecommendationRepository.java
@@ -23,4 +23,9 @@ public interface PersonalRecommendationRepository extends JpaRepository<Personal
             PersonalRecommendationStatus status,
             LocalDateTime requestedAt
     );
+
+    Optional<PersonalRecommendation> findFirstByMemberIdAndStatusAndSelectedCandidateIsNullAndClosedAtIsNullOrderByRequestedAtDescIdDesc(
+            long memberId,
+            PersonalRecommendationStatus status
+    );
 }

--- a/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
@@ -497,7 +497,8 @@ class MemberAuthIntegrationTest {
                 .andExpect(jsonPath("$.data.attributeCategories[0].code").value("SPICY"))
                 .andExpect(jsonPath("$.data.restrictionIngredients[0].code").value("PEANUT"))
                 .andExpect(jsonPath("$.data.dislikedMenuItems[0].code").value("PORK_CUTLET"))
-                .andExpect(jsonPath("$.data.updatedAt").exists());
+                .andExpect(jsonPath("$.data.updatedAt").exists())
+                .andExpect(jsonPath("$.data.openPersonalRecommendationId").value(nullValue()));
 
         mockMvc.perform(get("/api/v1/members/me")
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken)))

--- a/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
+++ b/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
@@ -3,6 +3,7 @@ package matchuri.backend.domain.member.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -35,6 +36,7 @@ import matchuri.backend.domain.member.repository.MemberTasteProfileRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileRestrictionIngredientRepository;
 import matchuri.backend.domain.member.result.MemberProfileResult;
 import matchuri.backend.domain.member.result.MemberTasteProfileSummaryResult;
+import matchuri.backend.domain.member.result.MemberTasteUpdateResult;
 import matchuri.backend.domain.member.result.OnboardingNextStep;
 import matchuri.backend.domain.member.result.OnboardingStatusResult;
 import matchuri.backend.domain.member.result.RegisterLocalMemberResult;
@@ -49,6 +51,9 @@ import matchuri.backend.domain.menu.entity.MenuItem;
 import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
 import matchuri.backend.domain.menu.repository.IngredientRepository;
 import matchuri.backend.domain.menu.repository.MenuItemRepository;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
+import matchuri.backend.domain.recommendation.repository.PersonalRecommendationRepository;
 import matchuri.backend.global.exception.BusinessException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -103,6 +108,9 @@ class MemberServiceImplTest {
 
     @Mock
     private EmailVerificationTokenVerifier emailVerificationTokenVerifier;
+
+    @Mock
+    private PersonalRecommendationRepository personalRecommendationRepository;
 
     @InjectMocks
     private MemberServiceImpl memberService;
@@ -349,18 +357,61 @@ class MemberServiceImplTest {
         when(memberTasteProfileDislikedMenuItemRepository.findAllByProfileIdOrderByDisplay(savedProfile.getId()))
                 .thenReturn(List.of(new MemberTasteProfileDislikedMenuItem(savedProfile, menuItem)));
 
-        MemberTasteProfileSummaryResult result = memberService.updateMyTasteProfile(
+        MemberTasteUpdateResult result = memberService.updateMyTasteProfile(
                 new UpdateMemberTasteProfileCommand(List.of(1L), List.of(101L), List.of(1001L))
         );
+        MemberTasteProfileSummaryResult profile = result.profile();
 
-        assertThat(result.profileVersion()).isEqualTo("v1");
-        assertThat(result.attributeCategories()).hasSize(1);
-        assertThat(result.restrictionIngredients()).hasSize(1);
-        assertThat(result.dislikedMenuItems()).hasSize(1);
+        assertThat(profile.profileVersion()).isEqualTo("v1");
+        assertThat(profile.attributeCategories()).hasSize(1);
+        assertThat(profile.restrictionIngredients()).hasSize(1);
+        assertThat(profile.dislikedMenuItems()).hasSize(1);
+        assertThat(result.openPersonalRecommendationId()).isNull();
         verify(memberTasteProfileRepository).saveAndFlush(any(MemberTasteProfile.class));
         verify(memberTasteProfileCategoryRepository).saveAll(any());
         verify(memberTasteProfileRestrictionIngredientRepository).saveAll(any());
         verify(memberTasteProfileDislikedMenuItemRepository).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("내 취향 프로필 저장은 미종료 개인 추천이 있으면 재요청용 추천 ID를 함께 반환한다")
+    void updateMyTasteProfileReturnsOpenPersonalRecommendationId() {
+        Member member = Member.builder()
+                .id(1L)
+                .loginId("tester01")
+                .memberRole(MemberRole.MEMBER)
+                .status(MemberStatus.ACTIVE)
+                .social(false)
+                .build();
+        MemberTasteProfile profile = new MemberTasteProfile(member, "v1");
+        PersonalRecommendation openRecommendation = mock(PersonalRecommendation.class);
+
+        when(activeMemberReader.getCurrentAuthenticatedActiveMember()).thenReturn(member);
+        when(memberTasteProfileRepository.findByMemberId(1L)).thenReturn(Optional.of(profile));
+        when(attributeCategoryRepository.findAllByIdInAndActiveTrue(List.of())).thenReturn(List.of());
+        when(ingredientRepository.findAllByIdInAndActiveTrue(List.of())).thenReturn(List.of());
+        when(menuItemRepository.findAllByIdInAndActiveTrue(List.of())).thenReturn(List.of());
+        when(memberTasteProfileCategoryRepository.findAllByProfileId(profile.getId())).thenReturn(List.of());
+        when(memberTasteProfileRestrictionIngredientRepository.findAllByProfileId(profile.getId())).thenReturn(List.of());
+        when(memberTasteProfileDislikedMenuItemRepository.findAllByProfileId(profile.getId())).thenReturn(List.of());
+        when(memberTasteProfileCategoryRepository.findAllByProfileIdOrderByDisplay(profile.getId())).thenReturn(List.of());
+        when(memberTasteProfileRestrictionIngredientRepository.findAllByProfileIdOrderByDisplay(profile.getId()))
+                .thenReturn(List.of());
+        when(memberTasteProfileDislikedMenuItemRepository.findAllByProfileIdOrderByDisplay(profile.getId()))
+                .thenReturn(List.of());
+        when(personalRecommendationRepository
+                .findFirstByMemberIdAndStatusAndSelectedCandidateIsNullAndClosedAtIsNullOrderByRequestedAtDescIdDesc(
+                        1L,
+                        PersonalRecommendationStatus.COMPLETED
+                ))
+                .thenReturn(Optional.of(openRecommendation));
+        when(openRecommendation.getId()).thenReturn(9001L);
+
+        MemberTasteUpdateResult result = memberService.updateMyTasteProfile(
+                new UpdateMemberTasteProfileCommand(List.of(), List.of(), List.of())
+        );
+
+        assertThat(result.openPersonalRecommendationId()).isEqualTo(9001L);
     }
 
     @Test
@@ -482,13 +533,15 @@ class MemberServiceImplTest {
         when(memberTasteProfileDislikedMenuItemRepository.findAllByProfileIdOrderByDisplay(profile.getId())).thenReturn(
                 List.of());
 
-        MemberTasteProfileSummaryResult result = memberService.updateMyTasteProfile(
+        MemberTasteUpdateResult result = memberService.updateMyTasteProfile(
                 new UpdateMemberTasteProfileCommand(List.of(), List.of(), List.of())
         );
+        MemberTasteProfileSummaryResult profileResult = result.profile();
 
-        assertThat(result.profileVersion()).isEqualTo("v1");
-        assertThat(result.attributeCategories()).isEmpty();
-        assertThat(result.restrictionIngredients()).isEmpty();
-        assertThat(result.dislikedMenuItems()).isEmpty();
+        assertThat(profileResult.profileVersion()).isEqualTo("v1");
+        assertThat(profileResult.attributeCategories()).isEmpty();
+        assertThat(profileResult.restrictionIngredients()).isEmpty();
+        assertThat(profileResult.dislikedMenuItems()).isEmpty();
+        assertThat(result.openPersonalRecommendationId()).isNull();
     }
 }

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -185,7 +185,7 @@ class OpenApiDocumentationIntegrationTest {
                         .value("MEMBER_AGREEMENT_REQUIRED"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/members/me/taste-profile'].patch.responses['200'].content['application/json'].schema.$ref")
-                        .value("#/components/schemas/MemberTasteProfileSummaryApiResponse"))
+                        .value("#/components/schemas/MemberTasteProfileUpdateApiResponse"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/members/me/taste-profile'].patch.responses['400'].content['application/json'].examples.invalidAttributeCategory.value.error.code")
                         .value("MEMBER_INVALID_TASTE_ATTRIBUTE_CATEGORY"))
@@ -207,6 +207,9 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath(
                         "$.components.schemas.MemberTasteProfileSummaryResponse.properties.memberId.description")
                         .value("현재 로그인한 회원 ID입니다."))
+                .andExpect(jsonPath(
+                        "$.components.schemas.MemberTasteProfileUpdateResponse.properties.openPersonalRecommendationId.description")
+                        .value(org.hamcrest.Matchers.containsString("INPUT_CHANGED 재요청")))
                 .andExpect(jsonPath(
                         "$.components.schemas.MemberTasteAttributeCategoryResponse.properties.categoryType.description")
                         .value("선택된 attribute category의 상위 유형입니다."))


### PR DESCRIPTION
## 관련 이슈
Closes #227 

## 📝 작업 내용
- `PATCH /api/v1/members/me/taste-profile` 응답값에 현재 진행 중인 개인 추천 이력의 ID를 반환합니다.

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- `openPersonalRecommendationId`가 추가됐으며 해당 값은 nullable 합니다.
