### PR TITLE
[Refactor] personal_recommendations의 lifecycle를 close_reason이 아닌 stauts로 제어

### DIFF
--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
@@ -318,7 +318,7 @@ public interface RecommendationApi {
                     개인 추천 후보 중 하나를 최종 선택으로 반영합니다.
 
                     선택된 후보는 개인 추천에 저장되며 `member_menu_actions`에 `CHOOSE` 로그가 함께 기록됩니다.
-                    선택 성공 시 개인 추천은 `closeReason=SELECTED`, `closedAt=선택 시각`으로 종료됩니다.
+                    선택 성공 시 개인 추천은 `status=SELECTED`, `closedAt=선택 시각`으로 종료됩니다.
                     """
     )
     @ApiResponses({

--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationMapper.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationMapper.java
@@ -74,7 +74,6 @@ public class RecommendationMapper {
                 result.status(),
                 result.requestedAt(),
                 result.closedAt(),
-                result.closeReason(),
                 toCandidateResponses(result.candidates())
         );
     }
@@ -84,7 +83,6 @@ public class RecommendationMapper {
                 result.id(),
                 result.status(),
                 result.closedAt(),
-                result.closeReason(),
                 toContextMap(result.contextJson()),
                 toCandidateResponses(result.candidates()),
                 result.selectedCandidateId()
@@ -106,17 +104,16 @@ public class RecommendationMapper {
                 result.id(),
                 result.status(),
                 result.requestedAt(),
-                result.closedAt(),
-                result.closeReason()
+                result.closedAt()
         );
     }
 
     public SelectPersonalRecommendationResponse toSelectResponse(SelectPersonalRecommendationResult result) {
         return new SelectPersonalRecommendationResponse(
                 result.id(),
+                result.status(),
                 result.selectedCandidateId(),
                 result.closedAt(),
-                result.closeReason(),
                 result.updatedAt()
         );
     }

--- a/src/main/java/matchuri/backend/api/recommendation/dto/docs/RecommendationApiExamples.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/docs/RecommendationApiExamples.java
@@ -119,10 +119,9 @@ public final class RecommendationApiExamples {
                 "content": [
                   {
                     "id": 9001,
-                    "status": "COMPLETED",
+                    "status": "OPEN",
                     "requestedAt": "2026-05-06T12:10:00",
-                    "closedAt": null,
-                    "closeReason": null
+                    "closedAt": null
                   }
                 ],
                 "pageInfo": {
@@ -145,10 +144,9 @@ public final class RecommendationApiExamples {
               "success": true,
               "data": {
                 "requestId": 9001,
-                "status": "COMPLETED",
+                "status": "OPEN",
                 "requestedAt": "2026-05-06T12:10:00",
                 "closedAt": null,
-                "closeReason": null,
                 "candidates": [
                   {
                     "id": 10001,
@@ -182,10 +180,9 @@ public final class RecommendationApiExamples {
               "success": true,
               "data": {
                 "requestId": 9002,
-                "status": "COMPLETED",
+                "status": "OPEN",
                 "requestedAt": "2026-05-06T12:20:00",
                 "closedAt": null,
-                "closeReason": null,
                 "candidates": [
                   {
                     "id": 10004,
@@ -212,9 +209,8 @@ public final class RecommendationApiExamples {
               "success": true,
               "data": {
                 "id": 9001,
-                "status": "COMPLETED",
+                "status": "SELECTED",
                 "closedAt": "2026-05-06T12:15:00",
-                "closeReason": "SELECTED",
                 "contextJson": {
                   "mealTime": "LUNCH",
                   "budgetLevel": 2,
@@ -378,9 +374,9 @@ public final class RecommendationApiExamples {
               "success": true,
               "data": {
                 "id": 9001,
+                "status": "SELECTED",
                 "selectedCandidateId": 10001,
                 "closedAt": "2026-05-06T12:15:00",
-                "closeReason": "SELECTED",
                 "updatedAt": "2026-05-06T12:15:00"
               },
               "error": null

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationDetailResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationDetailResponse.java
@@ -4,21 +4,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCloseReason;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 
 public record PersonalRecommendationDetailResponse(
         @Schema(description = "개인 추천 요청 ID입니다.", example = "9001")
         Long id,
 
-        @Schema(description = "개인 추천 처리 상태입니다.", example = "COMPLETED")
+        @Schema(description = "개인 추천 lifecycle 상태입니다.", example = "OPEN")
         PersonalRecommendationStatus status,
 
-        @Schema(description = "추천 종료 시각입니다. 아직 선택/재요청/만료로 종료되지 않았다면 null입니다.", example = "2026-05-06T12:15:00")
+        @Schema(description = "추천 종료 시각입니다. 아직 종료되지 않았다면 null입니다.", example = "2026-05-06T12:15:00")
         LocalDateTime closedAt,
-
-        @Schema(description = "추천 종료 사유입니다. 아직 종료되지 않았다면 null입니다.", example = "SELECTED")
-        PersonalRecommendationCloseReason closeReason,
 
         @Schema(description = "요청 컨텍스트 JSON입니다.")
         Map<String, Object> contextJson,
@@ -32,9 +28,8 @@ public record PersonalRecommendationDetailResponse(
     public static PersonalRecommendationDetailResponse mockSelected() {
         return new PersonalRecommendationDetailResponse(
                 9001L,
-                PersonalRecommendationStatus.COMPLETED,
+                PersonalRecommendationStatus.SELECTED,
                 LocalDateTime.of(2026, 5, 6, 12, 15),
-                PersonalRecommendationCloseReason.SELECTED,
                 PersonalRecommendationMocks.contextJson(),
                 PersonalRecommendationMocks.candidates(),
                 10001L

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationRequestResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationRequestResponse.java
@@ -3,24 +3,20 @@ package matchuri.backend.api.recommendation.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
-import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCloseReason;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 
 public record PersonalRecommendationRequestResponse(
         @Schema(description = "개인 추천 요청 ID입니다.", example = "9001")
         Long requestId,
 
-        @Schema(description = "개인 추천 처리 상태입니다.", example = "COMPLETED")
+        @Schema(description = "개인 추천 lifecycle 상태입니다.", example = "OPEN")
         PersonalRecommendationStatus status,
 
         @Schema(description = "추천 요청 시각입니다.", example = "2026-05-06T12:10:00")
         LocalDateTime requestedAt,
 
-        @Schema(description = "추천 종료 시각입니다. 아직 선택/재요청/만료로 종료되지 않았다면 null입니다.", example = "2026-05-06T12:15:00")
+        @Schema(description = "추천 종료 시각입니다. 아직 종료되지 않았다면 null입니다.", example = "2026-05-06T12:15:00")
         LocalDateTime closedAt,
-
-        @Schema(description = "추천 종료 사유입니다. 아직 종료되지 않았다면 null입니다.", example = "SELECTED")
-        PersonalRecommendationCloseReason closeReason,
 
         @Schema(description = "추천 후보 목록입니다.")
         List<PersonalRecommendationCandidateResponse> candidates
@@ -28,9 +24,8 @@ public record PersonalRecommendationRequestResponse(
     public static PersonalRecommendationRequestResponse mockCompleted() {
         return new PersonalRecommendationRequestResponse(
                 9001L,
-                PersonalRecommendationStatus.COMPLETED,
+                PersonalRecommendationStatus.OPEN,
                 LocalDateTime.of(2026, 5, 6, 12, 10),
-                null,
                 null,
                 PersonalRecommendationMocks.candidates()
         );

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationResponse.java
@@ -1,22 +1,19 @@
 package matchuri.backend.api.recommendation.dto.response;
 
 import java.time.LocalDateTime;
-import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCloseReason;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 
 public record PersonalRecommendationResponse(
         long id,
         PersonalRecommendationStatus status,
         LocalDateTime requestedAt,
-        LocalDateTime closedAt,
-        PersonalRecommendationCloseReason closeReason
+        LocalDateTime closedAt
 ) {
     public static PersonalRecommendationResponse mock() {
         return new PersonalRecommendationResponse(
                 9001L,
-                PersonalRecommendationStatus.COMPLETED,
+                PersonalRecommendationStatus.OPEN,
                 LocalDateTime.of(2026, 5, 6, 12, 10),
-                null,
                 null
         );
     }

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/SelectPersonalRecommendationResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/SelectPersonalRecommendationResponse.java
@@ -2,11 +2,14 @@ package matchuri.backend.api.recommendation.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
-import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCloseReason;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 
 public record SelectPersonalRecommendationResponse(
         @Schema(description = "개인 추천 요청 ID입니다.", example = "9001")
         Long id,
+
+        @Schema(description = "개인 추천 lifecycle 상태입니다.", example = "SELECTED")
+        PersonalRecommendationStatus status,
 
         @Schema(description = "최종 선택 후보 ID입니다.", example = "10001")
         Long selectedCandidateId,
@@ -14,18 +17,15 @@ public record SelectPersonalRecommendationResponse(
         @Schema(description = "추천 종료 시각입니다.", example = "2026-05-06T12:15:00")
         LocalDateTime closedAt,
 
-        @Schema(description = "추천 종료 사유입니다.", example = "SELECTED")
-        PersonalRecommendationCloseReason closeReason,
-
         @Schema(description = "선택 반영 시각입니다.", example = "2026-05-06T12:15:00")
         LocalDateTime updatedAt
 ) {
     public static SelectPersonalRecommendationResponse mockSelected(Long selectedCandidateId) {
         return new SelectPersonalRecommendationResponse(
                 9001L,
+                PersonalRecommendationStatus.SELECTED,
                 selectedCandidateId,
                 LocalDateTime.of(2026, 5, 6, 12, 15),
-                PersonalRecommendationCloseReason.SELECTED,
                 LocalDateTime.of(2026, 5, 6, 12, 15)
         );
     }

--- a/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
@@ -203,7 +203,7 @@ public class MemberServiceImpl implements MemberService {
                 personalRecommendationRepository
                         .findFirstByMemberIdAndStatusAndSelectedCandidateIsNullAndClosedAtIsNullOrderByRequestedAtDescIdDesc(
                                 member.getId(),
-                                PersonalRecommendationStatus.COMPLETED
+                                PersonalRecommendationStatus.OPEN
                         )
                         .map(recommendation -> recommendation.getId())
                         .orElse(null);

--- a/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendation.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendation.java
@@ -41,15 +41,11 @@ public class PersonalRecommendation extends BaseEntity {
     private Member member;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20, comment = "개인 추천 상태")
+    @Column(nullable = false, length = 30, comment = "개인 추천 lifecycle 상태")
     private PersonalRecommendationStatus status;
 
     @Column(name = "closed_at", comment = "추천 종료 시각")
     private LocalDateTime closedAt;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "close_reason", length = 30, comment = "추천 종료 사유")
-    private PersonalRecommendationCloseReason closeReason;
 
     @Column(name = "requested_at", nullable = false, comment = "추천 실행 시각")
     private LocalDateTime requestedAt;
@@ -74,49 +70,41 @@ public class PersonalRecommendation extends BaseEntity {
                 member,
                 contextJson,
                 LocalDateTime.now(),
-                PersonalRecommendationStatus.REQUESTED
+                PersonalRecommendationStatus.OPEN
         );
     }
 
-    public void markFiltered() {
-        this.status = PersonalRecommendationStatus.FILTERED;
-    }
-
-    public void markScored() {
-        this.status = PersonalRecommendationStatus.SCORED;
-    }
-
-    public void complete() {
-        this.status = PersonalRecommendationStatus.COMPLETED;
-    }
-
-    public void fail() {
-        this.status = PersonalRecommendationStatus.FAILED;
+    public void fail(LocalDateTime closedAt) {
+        close(PersonalRecommendationStatus.FAILED, closedAt);
     }
 
     public void select(PersonalRecommendationCandidate selectedCandidate, LocalDateTime closedAt) {
         this.selectedCandidate = selectedCandidate;
-        close(PersonalRecommendationCloseReason.SELECTED, closedAt);
+        close(PersonalRecommendationStatus.SELECTED, closedAt);
     }
 
     public void closeAsRerolledWithSkip(LocalDateTime closedAt) {
-        close(PersonalRecommendationCloseReason.REROLLED_WITH_SKIP, closedAt);
+        close(PersonalRecommendationStatus.REROLLED_WITH_SKIP, closedAt);
     }
 
     public void closeAsRerolledWithoutSkip(LocalDateTime closedAt) {
-        close(PersonalRecommendationCloseReason.REROLLED_WITHOUT_SKIP, closedAt);
+        close(PersonalRecommendationStatus.REROLLED_WITHOUT_SKIP, closedAt);
     }
 
     public void expire(LocalDateTime closedAt) {
-        close(PersonalRecommendationCloseReason.EXPIRED, closedAt);
+        close(PersonalRecommendationStatus.EXPIRED, closedAt);
     }
 
     public boolean isClosed() {
         return this.closedAt != null;
     }
 
-    private void close(PersonalRecommendationCloseReason closeReason, LocalDateTime closedAt) {
-        this.closeReason = closeReason;
+    public boolean isOpen() {
+        return this.status == PersonalRecommendationStatus.OPEN;
+    }
+
+    private void close(PersonalRecommendationStatus status, LocalDateTime closedAt) {
+        this.status = status;
         this.closedAt = closedAt;
     }
 

--- a/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendationCloseReason.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendationCloseReason.java
@@ -1,8 +1,0 @@
-package matchuri.backend.domain.recommendation.entity;
-
-public enum PersonalRecommendationCloseReason {
-    SELECTED,
-    REROLLED_WITH_SKIP,
-    REROLLED_WITHOUT_SKIP,
-    EXPIRED
-}

--- a/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendationStatus.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendationStatus.java
@@ -1,9 +1,10 @@
 package matchuri.backend.domain.recommendation.entity;
 
 public enum PersonalRecommendationStatus {
-    REQUESTED,
-    FILTERED,
-    SCORED,
-    COMPLETED,
+    OPEN,
+    SELECTED,
+    REROLLED_WITH_SKIP,
+    REROLLED_WITHOUT_SKIP,
+    EXPIRED,
     FAILED
 }

--- a/src/main/java/matchuri/backend/domain/recommendation/result/PersonalRecommendationResult.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/result/PersonalRecommendationResult.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCandidate;
-import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCloseReason;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 
 public record PersonalRecommendationResult(
@@ -12,7 +11,6 @@ public record PersonalRecommendationResult(
         PersonalRecommendationStatus status,
         LocalDateTime requestedAt,
         LocalDateTime closedAt,
-        PersonalRecommendationCloseReason closeReason,
         String contextJson,
         Long selectedCandidateId,
         List<PersonalRecommendationCandidateResult> candidates
@@ -30,7 +28,6 @@ public record PersonalRecommendationResult(
                 personalRecommendation.getStatus(),
                 personalRecommendation.getRequestedAt(),
                 personalRecommendation.getClosedAt(),
-                personalRecommendation.getCloseReason(),
                 personalRecommendation.getContextJson(),
                 selectedCandidateId,
                 candidates.stream()

--- a/src/main/java/matchuri/backend/domain/recommendation/result/PersonalRecommendationSummaryResult.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/result/PersonalRecommendationSummaryResult.java
@@ -2,23 +2,20 @@ package matchuri.backend.domain.recommendation.result;
 
 import java.time.LocalDateTime;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
-import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCloseReason;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 
 public record PersonalRecommendationSummaryResult(
         Long id,
         PersonalRecommendationStatus status,
         LocalDateTime requestedAt,
-        LocalDateTime closedAt,
-        PersonalRecommendationCloseReason closeReason
+        LocalDateTime closedAt
 ) {
     public static PersonalRecommendationSummaryResult from(PersonalRecommendation personalRecommendation) {
         return new PersonalRecommendationSummaryResult(
                 personalRecommendation.getId(),
                 personalRecommendation.getStatus(),
                 personalRecommendation.getRequestedAt(),
-                personalRecommendation.getClosedAt(),
-                personalRecommendation.getCloseReason()
+                personalRecommendation.getClosedAt()
         );
     }
 }

--- a/src/main/java/matchuri/backend/domain/recommendation/result/SelectPersonalRecommendationResult.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/result/SelectPersonalRecommendationResult.java
@@ -3,13 +3,13 @@ package matchuri.backend.domain.recommendation.result;
 import java.time.LocalDateTime;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCandidate;
-import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCloseReason;
+import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 
 public record SelectPersonalRecommendationResult(
         Long id,
+        PersonalRecommendationStatus status,
         Long selectedCandidateId,
         LocalDateTime closedAt,
-        PersonalRecommendationCloseReason closeReason,
         LocalDateTime updatedAt
 ) {
     public static SelectPersonalRecommendationResult of(
@@ -18,9 +18,9 @@ public record SelectPersonalRecommendationResult(
     ) {
         return new SelectPersonalRecommendationResult(
                 personalRecommendation.getId(),
+                personalRecommendation.getStatus(),
                 selectedCandidate.getId(),
                 personalRecommendation.getClosedAt(),
-                personalRecommendation.getCloseReason(),
                 personalRecommendation.getUpdatedAt()
         );
     }

--- a/src/main/java/matchuri/backend/domain/recommendation/service/PersonalRecommendationExpirationService.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/PersonalRecommendationExpirationService.java
@@ -33,7 +33,7 @@ public class PersonalRecommendationExpirationService {
         LocalDateTime now = LocalDateTime.now();
         List<PersonalRecommendation> targets = personalRecommendationRepository
                 .findByStatusAndSelectedCandidateIsNullAndClosedAtIsNullAndRequestedAtLessThanEqual(
-                        PersonalRecommendationStatus.COMPLETED,
+                        PersonalRecommendationStatus.OPEN,
                         expirationThreshold(now)
                 );
 
@@ -43,9 +43,8 @@ public class PersonalRecommendationExpirationService {
     }
 
     public boolean isExpired(PersonalRecommendation recommendation, LocalDateTime now) {
-        return recommendation.getStatus() == PersonalRecommendationStatus.COMPLETED
+        return recommendation.getStatus() == PersonalRecommendationStatus.OPEN
                 && recommendation.getSelectedCandidate() == null
-                && !recommendation.isClosed()
                 && !recommendation.getRequestedAt().plusHours(EXPIRATION_HOURS).isAfter(now);
     }
 

--- a/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
@@ -39,7 +39,6 @@ import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendatio
 import matchuri.backend.domain.recommendation.command.GuestPersonalRecommendationCommand;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCandidate;
-import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCloseReason;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationRerollType;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 import matchuri.backend.domain.recommendation.exception.GuestRecommendationErrorCode;
@@ -168,9 +167,6 @@ public class RecommendationServiceImpl implements RecommendationService {
         MenuRecommendationResult recommendationResult = algorithm.recommend(input);
 
         PersonalRecommendation personalRecommendation = PersonalRecommendation.of(member, contextJson);
-        personalRecommendation.markFiltered();
-        personalRecommendation.markScored();
-        personalRecommendation.complete();
         PersonalRecommendation savedPersonalRecommendation =
                 personalRecommendationRepository.save(personalRecommendation);
 
@@ -311,7 +307,7 @@ public class RecommendationServiceImpl implements RecommendationService {
         LocalDateTime now = LocalDateTime.now();
 
         for (PersonalRecommendation recommendation : recommendations) {
-            if (!isUnclosedCompletedRecommendation(recommendation)) {
+            if (!recommendation.isOpen()) {
                 continue;
             }
 
@@ -323,18 +319,12 @@ public class RecommendationServiceImpl implements RecommendationService {
         }
     }
 
-    private boolean isUnclosedCompletedRecommendation(PersonalRecommendation recommendation) {
-        return recommendation.getStatus() == PersonalRecommendationStatus.COMPLETED
-                && recommendation.getSelectedCandidate() == null
-                && !recommendation.isClosed();
-    }
-
     private void validatePersonalRecommendationOpen(PersonalRecommendation recommendation) {
-        if (recommendation.getCloseReason() == PersonalRecommendationCloseReason.EXPIRED) {
+        if (recommendation.getStatus() == PersonalRecommendationStatus.EXPIRED) {
             throw new BusinessException(RecommendationErrorCode.EXPIRED, recommendation.getId());
         }
 
-        if (recommendation.isClosed()) {
+        if (!recommendation.isOpen()) {
             throw new BusinessException(RecommendationErrorCode.ALREADY_CLOSED, recommendation.getId());
         }
     }

--- a/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
@@ -45,7 +45,6 @@ import matchuri.backend.domain.menu.repository.MenuAttributeCategoryRepository;
 import matchuri.backend.domain.menu.repository.MenuIngredientRepository;
 import matchuri.backend.domain.menu.repository.MenuItemRepository;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
-import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCloseReason;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 import matchuri.backend.domain.recommendation.repository.PersonalRecommendationCandidateRepository;
 import matchuri.backend.domain.recommendation.repository.PersonalRecommendationRepository;
@@ -171,9 +170,8 @@ class PersonalRecommendationIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.error").value(nullValue()))
-                .andExpect(jsonPath("$.data.status").value(PersonalRecommendationStatus.COMPLETED.name()))
+                .andExpect(jsonPath("$.data.status").value(PersonalRecommendationStatus.OPEN.name()))
                 .andExpect(jsonPath("$.data.closedAt").value(nullValue()))
-                .andExpect(jsonPath("$.data.closeReason").value(nullValue()))
                 .andExpect(jsonPath("$.data.candidates.length()").value(2))
                 .andExpect(jsonPath("$.data.candidates[0].menuId").value(bibimbap.getId()))
                 .andExpect(jsonPath("$.data.candidates[0].rankNo").value(1))
@@ -193,7 +191,6 @@ class PersonalRecommendationIntegrationTest {
                 .andExpect(jsonPath("$.data.id").value(requestId))
                 .andExpect(jsonPath("$.data.contextJson.mealTime").value("LUNCH"))
                 .andExpect(jsonPath("$.data.closedAt").value(nullValue()))
-                .andExpect(jsonPath("$.data.closeReason").value(nullValue()))
                 .andExpect(jsonPath("$.data.candidates.length()").value(2))
                 .andExpect(jsonPath("$.data.selectedCandidateId").value(nullValue()));
 
@@ -210,7 +207,6 @@ class PersonalRecommendationIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.content[0].id").value(requestId))
                 .andExpect(jsonPath("$.data.content[0].closedAt").value(nullValue()))
-                .andExpect(jsonPath("$.data.content[0].closeReason").value(nullValue()))
                 .andExpect(jsonPath("$.data.pageInfo.totalElements").value(1));
 
         mockMvc.perform(patch("/api/v1/personal/recommendations/{requestId}", requestId)
@@ -223,23 +219,23 @@ class PersonalRecommendationIntegrationTest {
                                 """.formatted(firstCandidateId)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.id").value(requestId))
+                .andExpect(jsonPath("$.data.status").value(PersonalRecommendationStatus.SELECTED.name()))
                 .andExpect(jsonPath("$.data.selectedCandidateId").value(firstCandidateId))
-                .andExpect(jsonPath("$.data.closedAt").exists())
-                .andExpect(jsonPath("$.data.closeReason").value(PersonalRecommendationCloseReason.SELECTED.name()));
+                .andExpect(jsonPath("$.data.closedAt").exists());
 
         assertThat(memberMenuActionRepository.count()).isEqualTo(1);
         assertThat(memberMenuActionRepository.findAll().getFirst().getActionType()).isEqualTo(ActionType.CHOOSE);
 
         PersonalRecommendation selectedRecommendation = personalRecommendationRepository.findById(requestId)
                 .orElseThrow();
+        assertThat(selectedRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.SELECTED);
         assertThat(selectedRecommendation.getClosedAt()).isNotNull();
-        assertThat(selectedRecommendation.getCloseReason()).isEqualTo(PersonalRecommendationCloseReason.SELECTED);
 
         mockMvc.perform(get("/api/v1/personal/recommendations/{requestId}", requestId)
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.closedAt").exists())
-                .andExpect(jsonPath("$.data.closeReason").value(PersonalRecommendationCloseReason.SELECTED.name()));
+                .andExpect(jsonPath("$.data.status").value(PersonalRecommendationStatus.SELECTED.name()))
+                .andExpect(jsonPath("$.data.closedAt").exists());
     }
 
     @Test
@@ -281,7 +277,7 @@ class PersonalRecommendationIntegrationTest {
                                 }
                                 """))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.status").value(PersonalRecommendationStatus.COMPLETED.name()))
+                .andExpect(jsonPath("$.data.status").value(PersonalRecommendationStatus.OPEN.name()))
                 .andExpect(jsonPath("$.data.candidates.length()").value(0));
 
         assertThat(personalRecommendationRepository.count()).isEqualTo(1);
@@ -316,8 +312,8 @@ class PersonalRecommendationIntegrationTest {
         assertThat(personalRecommendationRepository.count()).isEqualTo(1);
         PersonalRecommendation openRecommendation = personalRecommendationRepository.findById(firstRequestId)
                 .orElseThrow();
+        assertThat(openRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.OPEN);
         assertThat(openRecommendation.getClosedAt()).isNull();
-        assertThat(openRecommendation.getCloseReason()).isNull();
     }
 
     @Test
@@ -349,10 +345,10 @@ class PersonalRecommendationIntegrationTest {
                 .orElseThrow();
         PersonalRecommendation newRecommendation = personalRecommendationRepository.findById(secondRequestId)
                 .orElseThrow();
+        assertThat(expiredRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.EXPIRED);
         assertThat(expiredRecommendation.getClosedAt()).isNotNull();
-        assertThat(expiredRecommendation.getCloseReason()).isEqualTo(PersonalRecommendationCloseReason.EXPIRED);
+        assertThat(newRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.OPEN);
         assertThat(newRecommendation.getClosedAt()).isNull();
-        assertThat(newRecommendation.getCloseReason()).isNull();
     }
 
     @Test
@@ -375,8 +371,8 @@ class PersonalRecommendationIntegrationTest {
         PersonalRecommendation expiredRecommendation = personalRecommendationRepository.findById(requestId)
                 .orElseThrow();
         assertThat(expiredCount).isEqualTo(1);
+        assertThat(expiredRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.EXPIRED);
         assertThat(expiredRecommendation.getClosedAt()).isNotNull();
-        assertThat(expiredRecommendation.getCloseReason()).isEqualTo(PersonalRecommendationCloseReason.EXPIRED);
     }
 
     @Test
@@ -402,15 +398,15 @@ class PersonalRecommendationIntegrationTest {
                                 {
                                   "selectedCandidateId": %d
                                 }
-                                """.formatted(candidateId)))
+                """.formatted(candidateId)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.closeReason").value(PersonalRecommendationCloseReason.SELECTED.name()));
+                .andExpect(jsonPath("$.data.status").value(PersonalRecommendationStatus.SELECTED.name()));
 
         PersonalRecommendation selectedRecommendation = personalRecommendationRepository.findById(requestId)
                 .orElseThrow();
         assertThat(selectedRecommendation.getSelectedCandidate()).isNotNull();
+        assertThat(selectedRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.SELECTED);
         assertThat(selectedRecommendation.getClosedAt()).isNotNull();
-        assertThat(selectedRecommendation.getCloseReason()).isEqualTo(PersonalRecommendationCloseReason.SELECTED);
     }
 
     @Test
@@ -442,9 +438,8 @@ class PersonalRecommendationIntegrationTest {
 
         PersonalRecommendation rerolledRecommendation = personalRecommendationRepository.findById(requestId)
                 .orElseThrow();
+        assertThat(rerolledRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.REROLLED_WITHOUT_SKIP);
         assertThat(rerolledRecommendation.getClosedAt()).isNotNull();
-        assertThat(rerolledRecommendation.getCloseReason()).isEqualTo(
-                PersonalRecommendationCloseReason.REROLLED_WITHOUT_SKIP);
         assertThat(personalRecommendationRepository.count()).isEqualTo(2);
     }
 
@@ -542,7 +537,7 @@ class PersonalRecommendationIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.requestId").isNumber())
                 .andExpect(jsonPath("$.data.closedAt").value(nullValue()))
-                .andExpect(jsonPath("$.data.closeReason").value(nullValue()))
+                .andExpect(jsonPath("$.data.status").value(PersonalRecommendationStatus.OPEN.name()))
                 .andReturn();
 
         long rerolledRequestId = objectMapper.readTree(rerollResult.getResponse().getContentAsString())
@@ -560,9 +555,8 @@ class PersonalRecommendationIntegrationTest {
 
         PersonalRecommendation sourceRecommendation = personalRecommendationRepository.findById(sourceRequestId)
                 .orElseThrow();
+        assertThat(sourceRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.REROLLED_WITH_SKIP);
         assertThat(sourceRecommendation.getClosedAt()).isNotNull();
-        assertThat(sourceRecommendation.getCloseReason()).isEqualTo(
-                PersonalRecommendationCloseReason.REROLLED_WITH_SKIP);
 
         jdbcTemplate.update(
                 "update member_menu_actions set created_at = ? where personal_recommendation_id = ?",
@@ -638,9 +632,8 @@ class PersonalRecommendationIntegrationTest {
 
         PersonalRecommendation sourceRecommendation = personalRecommendationRepository.findById(sourceRequestId)
                 .orElseThrow();
+        assertThat(sourceRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.REROLLED_WITHOUT_SKIP);
         assertThat(sourceRecommendation.getClosedAt()).isNotNull();
-        assertThat(sourceRecommendation.getCloseReason()).isEqualTo(
-                PersonalRecommendationCloseReason.REROLLED_WITHOUT_SKIP);
     }
 
     @Test

--- a/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
+++ b/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
@@ -402,7 +402,7 @@ class MemberServiceImplTest {
         when(personalRecommendationRepository
                 .findFirstByMemberIdAndStatusAndSelectedCandidateIsNullAndClosedAtIsNullOrderByRequestedAtDescIdDesc(
                         1L,
-                        PersonalRecommendationStatus.COMPLETED
+                        PersonalRecommendationStatus.OPEN
                 ))
                 .thenReturn(Optional.of(openRecommendation));
         when(openRecommendation.getId()).thenReturn(9001L);

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -271,8 +271,8 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/personal/recommendations'].post.responses['200'].content['application/json'].examples.success.value.data.candidates[0].menuName")
                         .value("비빔밥"))
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/personal/recommendations'].post.responses['200'].content['application/json'].examples.success.value.data.closeReason")
-                        .value(nullValue()))
+                        "$.paths['/api/v1/personal/recommendations'].post.responses['200'].content['application/json'].examples.success.value.data.status")
+                        .value("OPEN"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/personal/recommendations'].post.responses['200'].content['application/json'].examples.success.value.data.resultJson")
                         .doesNotExist())
@@ -300,7 +300,7 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/personal/recommendations/{requestId}'].get.responses['200'].content['application/json'].examples.success.value.data.contextJson.mealTime")
                         .value("LUNCH"))
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/personal/recommendations/{requestId}'].get.responses['200'].content['application/json'].examples.success.value.data.closeReason")
+                        "$.paths['/api/v1/personal/recommendations/{requestId}'].get.responses['200'].content['application/json'].examples.success.value.data.status")
                         .value("SELECTED"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/personal/recommendations/{requestId}'].get.responses['200'].content['application/json'].examples.success.value.data.resultJson")
@@ -318,7 +318,7 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/personal/recommendations/{requestId}'].patch.responses['200'].content['application/json'].examples.success.value.data.selectedCandidateId")
                         .value(10001))
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/personal/recommendations/{requestId}'].patch.responses['200'].content['application/json'].examples.success.value.data.closeReason")
+                        "$.paths['/api/v1/personal/recommendations/{requestId}'].patch.responses['200'].content['application/json'].examples.success.value.data.status")
                         .value("SELECTED"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/personal/recommendations/{requestId}'].patch.responses['404'].content['application/json'].examples.notFound.value.error.code")


### PR DESCRIPTION
## 관련 이슈
Closes #246 

## 📝 작업 내용
- `personal_recommendations`의 기존의 `close_reason`을 `status`의 `open`/`close`로 관리
- `close_reason`는 제거
- API 명세 최신화

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [x] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항


```json
{
  "success": true,
  "data": {
    "content": [
      {
        "id": 3,
        "status": "OPEN",
        "requestedAt": "2026-05-23T09:28:21.811045",
        "closedAt": null
      },
      {
        "id": 2,
        "status": "REROLLED_WITH_SKIP",
        "requestedAt": "2026-05-23T09:28:09.854814",
        "closedAt": "2026-05-23T09:28:21.640269"
      },
      {
        "id": 1,
        "status": "SELECTED",
        "requestedAt": "2026-05-23T09:27:24.070853",
        "closedAt": "2026-05-23T09:27:58.659337"
      }
    ],
    "pageInfo": {
      "page": 0,
      "size": 20,
      "totalElements": 3,
      "totalPages": 1,
      "first": true,
      "last": true,
      "hasNext": false,
      "hasPrevious": false
    }
  },
  "error": null
}

```