### PR TITLE
[feat] 그룹 추천 생성 API 구현

### DIFF
--- a/init/sql/01-schema.sql
+++ b/init/sql/01-schema.sql
@@ -281,7 +281,7 @@ CREATE TABLE group_invites (
 CREATE TABLE group_recommendations (
     id BIGINT NOT NULL AUTO_INCREMENT,
     room_id BIGINT NOT NULL,
-    status VARCHAR(20) NOT NULL,
+    status VARCHAR(30) NOT NULL,
     started_at DATETIME(6) NOT NULL,
     ended_at DATETIME(6),
     selected_candidate_id BIGINT,
@@ -298,6 +298,8 @@ CREATE TABLE group_recommendation_candidates (
     group_recommendation_id BIGINT NOT NULL,
     menu_id BIGINT NOT NULL,
     rank_no INT NOT NULL,
+    score DOUBLE NOT NULL,
+    candidate_meta_json JSON,
     created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
     updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
     PRIMARY KEY (id),

--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -369,13 +369,16 @@ public interface GroupApi {
     ApiResponse<DeleteGroupResponse> deleteGroup(Long groupId);
 
     @Operation(
-            summary = "그룹 추천 시작 (Mock API)",
+            summary = "그룹 추천 시작",
             description = """
                     그룹 추천을 시작하고 후보 메뉴를 생성합니다.
 
-                    Mock API 상태:
-                    - request body validation만 수행합니다.
-                    - 그룹 취향 집계와 후보 생성 알고리즘은 아직 수행하지 않습니다.
+                    - 로그인한 활성 회원만 사용할 수 있습니다.
+                    - MVP에서는 해당 그룹의 `OWNER`만 시작할 수 있습니다.
+                    - 한 그룹에는 동시에 `OPEN` 그룹 추천을 1개만 허용합니다.
+                    - 그룹 활성 멤버의 취향 프로필을 모아 후보를 생성합니다.
+                    - 취향 프로필이 없는 멤버는 빈 취향으로 반영합니다.
+                    - 생성된 후보에는 추천 점수와 내부 메타데이터를 저장합니다.
                     - API 경로는 사용자 흐름상 `recommendations`를 사용하며, 최신 저장 테이블은 `group_recommendations` 기준입니다.
                     """
     )

--- a/src/main/java/matchuri/backend/api/group/GroupController.java
+++ b/src/main/java/matchuri/backend/api/group/GroupController.java
@@ -28,6 +28,7 @@ import matchuri.backend.api.group.dto.response.LeaveGroupResponse;
 import matchuri.backend.api.group.dto.response.RespondGroupInviteResponse;
 import matchuri.backend.api.group.dto.response.UpdateGroupResponse;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
+import matchuri.backend.domain.group.command.CreateGroupRecommendationCommand;
 import matchuri.backend.domain.group.command.CreateNicknameGroupInviteCommand;
 import matchuri.backend.domain.group.command.DeleteGroupCommand;
 import matchuri.backend.domain.group.command.GetMyGroupInvitesCommand;
@@ -39,6 +40,7 @@ import matchuri.backend.domain.group.command.UpdateGroupCommand;
 import matchuri.backend.domain.group.entity.GroupInviteStatus;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.result.CreateGroupResult;
+import matchuri.backend.domain.group.result.CreateGroupRecommendationResult;
 import matchuri.backend.domain.group.result.CreateNicknameGroupInviteResult;
 import matchuri.backend.domain.group.result.DeleteGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
@@ -192,7 +194,10 @@ public class GroupController implements GroupApi {
             @PathVariable Long groupId,
             @Valid @RequestBody CreateGroupRecommendationRequest request
     ) {
-        return ApiResponse.success(CreateGroupRecommendationResponse.mockOpen());
+        CreateGroupRecommendationCommand command = groupMapper.toCreateGroupRecommendationCommand(groupId, request);
+        CreateGroupRecommendationResult result = groupService.createGroupRecommendation(command);
+
+        return ApiResponse.success(groupMapper.toCreateGroupRecommendationResponse(result));
     }
 
     @Override

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -1,5 +1,10 @@
 package matchuri.backend.api.group;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import matchuri.backend.api.group.dto.request.CreateGroupRecommendationRequest;
 import matchuri.backend.api.group.dto.request.CreateGroupRequest;
 import matchuri.backend.api.group.dto.request.CreateNicknameGroupInviteRequest;
 import matchuri.backend.api.group.dto.request.JoinGroupRequest;
@@ -7,16 +12,19 @@ import matchuri.backend.api.group.dto.request.RespondGroupInviteRequest;
 import matchuri.backend.api.group.dto.request.UpdateGroupRequest;
 import matchuri.backend.api.group.dto.response.CreateNicknameGroupInviteResponse;
 import matchuri.backend.api.group.dto.response.CreateGroupResponse;
+import matchuri.backend.api.group.dto.response.CreateGroupRecommendationResponse;
 import matchuri.backend.api.group.dto.response.DeleteGroupResponse;
 import matchuri.backend.api.group.dto.response.GroupDetailResponse;
 import matchuri.backend.api.group.dto.response.GroupInviteSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupMemberSummaryResponse;
+import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateResponse;
 import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
 import matchuri.backend.api.group.dto.response.JoinGroupResponse;
 import matchuri.backend.api.group.dto.response.LeaveGroupResponse;
 import matchuri.backend.api.group.dto.response.RespondGroupInviteResponse;
 import matchuri.backend.api.group.dto.response.UpdateGroupResponse;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
+import matchuri.backend.domain.group.command.CreateGroupRecommendationCommand;
 import matchuri.backend.domain.group.command.CreateNicknameGroupInviteCommand;
 import matchuri.backend.domain.group.command.DeleteGroupCommand;
 import matchuri.backend.domain.group.command.GetMyGroupInvitesCommand;
@@ -28,11 +36,13 @@ import matchuri.backend.domain.group.command.UpdateGroupCommand;
 import matchuri.backend.domain.group.entity.GroupInviteStatus;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.result.CreateGroupResult;
+import matchuri.backend.domain.group.result.CreateGroupRecommendationResult;
 import matchuri.backend.domain.group.result.CreateNicknameGroupInviteResult;
 import matchuri.backend.domain.group.result.DeleteGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
 import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
+import matchuri.backend.domain.group.result.GroupRecommendationCandidateResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
 import matchuri.backend.domain.group.result.LeaveGroupResult;
@@ -41,7 +51,10 @@ import matchuri.backend.domain.group.result.UpdateGroupResult;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class GroupMapper {
+
+    private final ObjectMapper objectMapper;
 
     public CreateGroupCommand toCreateGroupCommand(CreateGroupRequest request) {
         return new CreateGroupCommand(
@@ -56,6 +69,25 @@ public class GroupMapper {
                 result.groupId(),
                 result.inviteCode(),
                 result.status()
+        );
+    }
+
+    public CreateGroupRecommendationCommand toCreateGroupRecommendationCommand(
+            Long groupId,
+            CreateGroupRecommendationRequest request
+    ) {
+        return new CreateGroupRecommendationCommand(groupId, toContextJson(request.contextJson()));
+    }
+
+    public CreateGroupRecommendationResponse toCreateGroupRecommendationResponse(
+            CreateGroupRecommendationResult result
+    ) {
+        return new CreateGroupRecommendationResponse(
+                result.sessionId(),
+                result.status(),
+                result.candidates().stream()
+                        .map(this::toGroupRecommendationCandidateResponse)
+                        .toList()
         );
     }
 
@@ -206,5 +238,28 @@ public class GroupMapper {
                 result.status(),
                 result.joinedAt()
         );
+    }
+
+    private GroupRecommendationCandidateResponse toGroupRecommendationCandidateResponse(
+            GroupRecommendationCandidateResult result
+    ) {
+        return new GroupRecommendationCandidateResponse(
+                result.candidateId(),
+                result.menuId(),
+                result.menuName(),
+                result.rankNo(),
+                result.score(),
+                result.voteCount()
+        );
+    }
+
+    private String toContextJson(Map<String, Object> contextJson) {
+        try {
+            Map<String, Object> normalizedContextJson = contextJson == null ? Map.of() : contextJson;
+
+            return objectMapper.writeValueAsString(normalizedContextJson);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalArgumentException("contextJson을 JSON 문자열로 변환할 수 없습니다.", exception);
+        }
     }
 }

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationCandidateResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationCandidateResponse.java
@@ -15,7 +15,7 @@ public record GroupRecommendationCandidateResponse(
         @Schema(description = "추천 순위입니다.", example = "1")
         Integer rankNo,
 
-        @Schema(description = "Mock 추천 점수입니다.", example = "91.5")
+        @Schema(description = "추천 점수입니다.", example = "91.5")
         Double score,
 
         @Schema(description = "현재 찬성 투표 수입니다.", example = "3")

--- a/src/main/java/matchuri/backend/domain/group/command/CreateGroupRecommendationCommand.java
+++ b/src/main/java/matchuri/backend/domain/group/command/CreateGroupRecommendationCommand.java
@@ -1,0 +1,7 @@
+package matchuri.backend.domain.group.command;
+
+public record CreateGroupRecommendationCommand(
+        Long groupId,
+        String contextJson
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendation.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendation.java
@@ -36,7 +36,7 @@ public class GroupRecommendation extends BaseEntity {
     private GroupRoom room;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20, comment = "그룹 추천 상태")
+    @Column(nullable = false, length = 30, comment = "그룹 추천 상태")
     private GroupRecommendationStatus status;
 
     @Column(name = "started_at", nullable = false, comment = "시작 시각")
@@ -59,19 +59,34 @@ public class GroupRecommendation extends BaseEntity {
         this.status = GroupRecommendationStatus.OPEN;
     }
 
-    public void close(LocalDateTime endedAt) {
-        this.status = GroupRecommendationStatus.CLOSED;
-        this.endedAt = endedAt;
-    }
-
     public void finalizeWith(GroupRecommendationCandidate selectedCandidate, LocalDateTime endedAt) {
         this.status = GroupRecommendationStatus.FINALIZED;
         this.selectedCandidate = selectedCandidate;
         this.endedAt = endedAt;
     }
 
+    public void rerollWithSkip(LocalDateTime endedAt) {
+        this.status = GroupRecommendationStatus.REROLLED_WITH_SKIP;
+        this.endedAt = endedAt;
+    }
+
+    public void rerollWithoutSkip(LocalDateTime endedAt) {
+        this.status = GroupRecommendationStatus.REROLLED_WITHOUT_SKIP;
+        this.endedAt = endedAt;
+    }
+
     public void cancel(LocalDateTime endedAt) {
         this.status = GroupRecommendationStatus.CANCELED;
+        this.endedAt = endedAt;
+    }
+
+    public void expire(LocalDateTime endedAt) {
+        this.status = GroupRecommendationStatus.EXPIRED;
+        this.endedAt = endedAt;
+    }
+
+    public void fail(LocalDateTime endedAt) {
+        this.status = GroupRecommendationStatus.FAILED;
         this.endedAt = endedAt;
     }
 }

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationCandidate.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationCandidate.java
@@ -47,13 +47,23 @@ public class GroupRecommendationCandidate extends BaseEntity {
     @Column(name = "rank_no", nullable = false, comment = "후보 순위")
     private int rankNo;
 
+    @Column(nullable = false, comment = "추천 점수")
+    private double score;
+
+    @Column(name = "candidate_meta_json", columnDefinition = "json", comment = "후보 메타 JSON")
+    private String candidateMetaJson;
+
     public GroupRecommendationCandidate(
             GroupRecommendation groupRecommendation,
             MenuItem menuItem,
-            int rankNo
+            int rankNo,
+            double score,
+            String candidateMetaJson
     ) {
         this.groupRecommendation = groupRecommendation;
         this.menuItem = menuItem;
         this.rankNo = rankNo;
+        this.score = score;
+        this.candidateMetaJson = candidateMetaJson;
     }
 }

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationStatus.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationStatus.java
@@ -2,7 +2,10 @@ package matchuri.backend.domain.group.entity;
 
 public enum GroupRecommendationStatus {
     OPEN,
-    CLOSED,
     FINALIZED,
-    CANCELED
+    REROLLED_WITH_SKIP,
+    REROLLED_WITHOUT_SKIP,
+    CANCELED,
+    EXPIRED,
+    FAILED
 }

--- a/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
@@ -31,7 +31,9 @@ public enum GroupErrorCode implements ErrorCode {
     INVITE_SELF_NOT_ALLOWED(HttpStatus.CONFLICT, "자기 자신은 그룹에 초대할 수 없습니다. memberId : {0}"),
     INVITE_TARGET_ALREADY_MEMBER(HttpStatus.CONFLICT, "이미 그룹에 참여 중인 회원입니다. groupId : {0}, memberId : {1}"),
     INVITE_ALREADY_PENDING(HttpStatus.CONFLICT, "이미 대기 중인 그룹 초대가 있습니다. groupId : {0}, memberId : {1}"),
-    INVITE_CODE_GENERATION_FAILED(HttpStatus.CONFLICT, "그룹 고정 초대 코드 생성에 실패했습니다.");
+    INVITE_CODE_GENERATION_FAILED(HttpStatus.CONFLICT, "그룹 고정 초대 코드 생성에 실패했습니다."),
+    RECOMMENDATION_CREATE_FORBIDDEN(HttpStatus.FORBIDDEN, "그룹 추천 생성 권한이 없습니다. groupId : {0}"),
+    RECOMMENDATION_OPEN_EXISTS(HttpStatus.CONFLICT, "이미 열린 그룹 추천이 있습니다. groupId : {0}");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationCandidateRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationCandidateRepository.java
@@ -1,0 +1,7 @@
+package matchuri.backend.domain.group.repository;
+
+import matchuri.backend.domain.group.entity.GroupRecommendationCandidate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupRecommendationCandidateRepository extends JpaRepository<GroupRecommendationCandidate, Long> {
+}

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationRepository.java
@@ -1,0 +1,10 @@
+package matchuri.backend.domain.group.repository;
+
+import matchuri.backend.domain.group.entity.GroupRecommendation;
+import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupRecommendationRepository extends JpaRepository<GroupRecommendation, Long> {
+
+    boolean existsByRoomIdAndStatus(Long roomId, GroupRecommendationStatus status);
+}

--- a/src/main/java/matchuri/backend/domain/group/result/CreateGroupRecommendationResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/CreateGroupRecommendationResult.java
@@ -1,0 +1,11 @@
+package matchuri.backend.domain.group.result;
+
+import java.util.List;
+import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
+
+public record CreateGroupRecommendationResult(
+        Long sessionId,
+        GroupRecommendationStatus status,
+        List<GroupRecommendationCandidateResult> candidates
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/result/GroupRecommendationCandidateResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupRecommendationCandidateResult.java
@@ -1,0 +1,23 @@
+package matchuri.backend.domain.group.result;
+
+import matchuri.backend.domain.group.entity.GroupRecommendationCandidate;
+
+public record GroupRecommendationCandidateResult(
+        Long candidateId,
+        Long menuId,
+        String menuName,
+        Integer rankNo,
+        Double score,
+        Integer voteCount
+) {
+    public static GroupRecommendationCandidateResult from(GroupRecommendationCandidate candidate, int voteCount) {
+        return new GroupRecommendationCandidateResult(
+                candidate.getId(),
+                candidate.getMenuItem().getId(),
+                candidate.getMenuItem().getName(),
+                candidate.getRankNo(),
+                candidate.getScore(),
+                voteCount
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/domain/group/service/GroupService.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupService.java
@@ -2,6 +2,7 @@ package matchuri.backend.domain.group.service;
 
 import lombok.NonNull;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
+import matchuri.backend.domain.group.command.CreateGroupRecommendationCommand;
 import matchuri.backend.domain.group.command.CreateNicknameGroupInviteCommand;
 import matchuri.backend.domain.group.command.DeleteGroupCommand;
 import matchuri.backend.domain.group.command.GetMyGroupInvitesCommand;
@@ -11,6 +12,7 @@ import matchuri.backend.domain.group.command.LeaveGroupCommand;
 import matchuri.backend.domain.group.command.RespondGroupInviteCommand;
 import matchuri.backend.domain.group.command.UpdateGroupCommand;
 import matchuri.backend.domain.group.result.CreateGroupResult;
+import matchuri.backend.domain.group.result.CreateGroupRecommendationResult;
 import matchuri.backend.domain.group.result.CreateNicknameGroupInviteResult;
 import matchuri.backend.domain.group.result.DeleteGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
@@ -25,6 +27,8 @@ import org.springframework.data.domain.Page;
 public interface GroupService {
 
     CreateGroupResult createGroup(CreateGroupCommand command);
+
+    CreateGroupRecommendationResult createGroupRecommendation(CreateGroupRecommendationCommand command);
 
     CreateNicknameGroupInviteResult createNicknameInvite(CreateNicknameGroupInviteCommand command);
 

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -1,11 +1,16 @@
 package matchuri.backend.domain.group.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
+import matchuri.backend.domain.group.command.CreateGroupRecommendationCommand;
 import matchuri.backend.domain.group.command.CreateNicknameGroupInviteCommand;
 import matchuri.backend.domain.group.command.DeleteGroupCommand;
 import matchuri.backend.domain.group.command.GetMyGroupInvitesCommand;
@@ -19,17 +24,24 @@ import matchuri.backend.domain.group.entity.GroupInviteResponseType;
 import matchuri.backend.domain.group.entity.GroupInviteStatus;
 import matchuri.backend.domain.group.entity.GroupMemberRole;
 import matchuri.backend.domain.group.entity.GroupMemberStatus;
+import matchuri.backend.domain.group.entity.GroupRecommendation;
+import matchuri.backend.domain.group.entity.GroupRecommendationCandidate;
+import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
 import matchuri.backend.domain.group.entity.GroupRoom;
 import matchuri.backend.domain.group.entity.GroupRoomMember;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.exception.GroupErrorCode;
 import matchuri.backend.domain.group.repository.GroupInviteRepository;
+import matchuri.backend.domain.group.repository.GroupRecommendationCandidateRepository;
+import matchuri.backend.domain.group.repository.GroupRecommendationRepository;
 import matchuri.backend.domain.group.repository.GroupRoomMemberCountProjection;
 import matchuri.backend.domain.group.repository.GroupRoomMemberRepository;
 import matchuri.backend.domain.group.repository.GroupRoomRepository;
 import matchuri.backend.domain.group.result.CreateGroupResult;
+import matchuri.backend.domain.group.result.CreateGroupRecommendationResult;
 import matchuri.backend.domain.group.result.CreateNicknameGroupInviteResult;
 import matchuri.backend.domain.group.result.DeleteGroupResult;
+import matchuri.backend.domain.group.result.GroupRecommendationCandidateResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
 import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
@@ -40,9 +52,26 @@ import matchuri.backend.domain.group.result.RespondGroupInviteResult;
 import matchuri.backend.domain.group.result.UpdateGroupResult;
 import matchuri.backend.domain.group.support.GroupInviteCodeGenerator;
 import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.entity.MemberTasteProfile;
 import matchuri.backend.domain.member.entity.MemberStatus;
 import matchuri.backend.domain.member.repository.MemberRepository;
 import matchuri.backend.domain.member.support.member.ActiveMemberReader;
+import matchuri.backend.domain.menu.entity.AttributeCategory;
+import matchuri.backend.domain.menu.entity.Ingredient;
+import matchuri.backend.domain.menu.entity.MenuAttributeCategory;
+import matchuri.backend.domain.menu.entity.MenuItem;
+import matchuri.backend.domain.menu.repository.MenuIngredientRepository;
+import matchuri.backend.domain.menu.repository.MenuItemRepository;
+import matchuri.backend.domain.recommendation.algorithm.MenuRecommendationAlgorithm;
+import matchuri.backend.domain.recommendation.algorithm.MenuRecommendationAlgorithmResolver;
+import matchuri.backend.domain.recommendation.algorithm.RecommendationAlgorithmType;
+import matchuri.backend.domain.recommendation.algorithm.RecommendationTargetType;
+import matchuri.backend.domain.recommendation.algorithm.input.MenuRecommendationInput;
+import matchuri.backend.domain.recommendation.algorithm.input.MenuRecommendationProfile;
+import matchuri.backend.domain.recommendation.algorithm.input.RecommendationContextSnapshot;
+import matchuri.backend.domain.recommendation.algorithm.input.TasteProfileSnapshot;
+import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendationCandidateResult;
+import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendationResult;
 import matchuri.backend.global.exception.BusinessException;
 import org.jspecify.annotations.NonNull;
 import org.springframework.data.domain.Page;
@@ -57,13 +86,20 @@ public class GroupServiceImpl implements GroupService {
 
     private static final int MAX_INVITE_CODE_GENERATION_ATTEMPTS = 5;
     private static final int NICKNAME_INVITE_EXPIRATION_HOURS = 24;
+    private static final int GROUP_RECOMMENDATION_CANDIDATE_LIMIT = 3;
 
     private final ActiveMemberReader activeMemberReader;
     private final MemberRepository memberRepository;
     private final GroupRoomRepository groupRoomRepository;
     private final GroupRoomMemberRepository groupRoomMemberRepository;
     private final GroupInviteRepository groupInviteRepository;
+    private final GroupRecommendationRepository groupRecommendationRepository;
+    private final GroupRecommendationCandidateRepository groupRecommendationCandidateRepository;
+    private final MenuItemRepository menuItemRepository;
+    private final MenuIngredientRepository menuIngredientRepository;
+    private final MenuRecommendationAlgorithmResolver menuRecommendationAlgorithmResolver;
     private final GroupInviteCodeGenerator groupInviteCodeGenerator;
+    private final ObjectMapper objectMapper;
 
     @Override
     public CreateGroupResult createGroup(CreateGroupCommand command) {
@@ -83,6 +119,66 @@ public class GroupServiceImpl implements GroupService {
                 savedGroupRoom.getId(),
                 savedGroupRoom.getInviteCode(),
                 savedGroupRoom.getStatus()
+        );
+    }
+
+    @Override
+    public CreateGroupRecommendationResult createGroupRecommendation(CreateGroupRecommendationCommand command) {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        GroupRoom room = groupRoomRepository.findByIdAndStatusNot(command.groupId(), GroupRoomStatus.DELETED)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.NOT_FOUND, command.groupId()));
+
+        if (!room.isActive()) {
+            throw new BusinessException(GroupErrorCode.NOT_ACTIVE, room.getId());
+        }
+
+        GroupRoomMember membership = groupRoomMemberRepository
+                .findActiveMembershipInNotDeletedRoom(room.getId(), member.getId())
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.ACCESS_DENIED, room.getId()));
+
+        if (!membership.isOwner()) {
+            throw new BusinessException(GroupErrorCode.RECOMMENDATION_CREATE_FORBIDDEN, room.getId());
+        }
+
+        if (groupRecommendationRepository.existsByRoomIdAndStatus(room.getId(), GroupRecommendationStatus.OPEN)) {
+            throw new BusinessException(GroupErrorCode.RECOMMENDATION_OPEN_EXISTS, room.getId());
+        }
+
+        List<GroupRoomMember> activeMembers = groupRoomMemberRepository.findActiveMembersByRoomId(room.getId());
+        List<MenuItem> menuItems = menuItemRepository.searchActiveMenuItems(null, List.of(), true, List.of(), true);
+        Map<Long, MenuItem> menuItemById = menuItems.stream()
+                .collect(Collectors.toMap(MenuItem::getId, Function.identity()));
+
+        MenuRecommendationAlgorithm algorithm =
+                menuRecommendationAlgorithmResolver.resolve(RecommendationAlgorithmType.GROUP);
+        MenuRecommendationResult recommendationResult = algorithm.recommend(new MenuRecommendationInput(
+                RecommendationTargetType.GROUP,
+                toTasteProfileSnapshots(activeMembers),
+                toMenuRecommendationProfiles(menuItems),
+                RecommendationContextSnapshot.of(command.contextJson()),
+                GROUP_RECOMMENDATION_CANDIDATE_LIMIT,
+                List.of(),
+                List.of(),
+                Map.of()
+        ));
+
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                room,
+                command.contextJson(),
+                LocalDateTime.now()
+        ));
+        List<GroupRecommendationCandidate> candidates = saveGroupRecommendationCandidates(
+                recommendation,
+                recommendationResult,
+                menuItemById
+        );
+
+        return new CreateGroupRecommendationResult(
+                recommendation.getId(),
+                recommendation.getStatus(),
+                candidates.stream()
+                        .map(candidate -> GroupRecommendationCandidateResult.from(candidate, 0))
+                        .toList()
         );
     }
 
@@ -337,6 +433,96 @@ public class GroupServiceImpl implements GroupService {
                 room.getStatus(),
                 members
         );
+    }
+
+    private List<TasteProfileSnapshot> toTasteProfileSnapshots(List<GroupRoomMember> activeMembers) {
+        return activeMembers.stream()
+                .map(GroupRoomMember::getMember)
+                .map(member -> toTasteProfileSnapshot(member, member.getTasteProfile()))
+                .toList();
+    }
+
+    private TasteProfileSnapshot toTasteProfileSnapshot(Member member, MemberTasteProfile tasteProfile) {
+        if (tasteProfile == null) {
+            return new TasteProfileSnapshot(
+                    member.getId(),
+                    String.valueOf(member.getId()),
+                    List.of(),
+                    List.of(),
+                    List.of()
+            );
+        }
+
+        return new TasteProfileSnapshot(
+                member.getId(),
+                String.valueOf(member.getId()),
+                tasteProfile.getPreferAttributeCategories().stream()
+                        .map(AttributeCategory::getId)
+                        .toList(),
+                tasteProfile.getRestrictionIngredients().stream()
+                        .map(Ingredient::getId)
+                        .toList(),
+                tasteProfile.getDisLikeMenuItems().stream()
+                        .map(MenuItem::getId)
+                        .toList()
+        );
+    }
+
+    private List<MenuRecommendationProfile> toMenuRecommendationProfiles(List<MenuItem> menuItems) {
+        Map<Long, List<Long>> ingredientIdsByMenuId = menuIngredientRepository.findAll().stream()
+                .collect(Collectors.groupingBy(
+                        menuIngredient -> menuIngredient.getMenu().getId(),
+                        Collectors.mapping(menuIngredient -> menuIngredient.getIngredient().getId(),
+                                Collectors.toList())
+                ));
+
+        return menuItems.stream()
+                .map(menuItem -> new MenuRecommendationProfile(
+                        menuItem.getId(),
+                        menuItem.getCode(),
+                        menuItem.getName(),
+                        menuItem.getMenuAttributeCategories().stream()
+                                .map(MenuAttributeCategory::getAttributeCategory)
+                                .map(AttributeCategory::getId)
+                                .toList(),
+                        ingredientIdsByMenuId.getOrDefault(menuItem.getId(), List.of())
+                ))
+                .toList();
+    }
+
+    private List<GroupRecommendationCandidate> saveGroupRecommendationCandidates(
+            GroupRecommendation recommendation,
+            MenuRecommendationResult recommendationResult,
+            Map<Long, MenuItem> menuItemById
+    ) {
+        List<GroupRecommendationCandidate> candidates = recommendationResult.candidates().stream()
+                .map(candidate -> new GroupRecommendationCandidate(
+                        recommendation,
+                        menuItemById.get(candidate.menuId()),
+                        candidate.rankNo(),
+                        candidate.score(),
+                        toCandidateMetaJson(recommendationResult, candidate)
+                ))
+                .toList();
+
+        return groupRecommendationCandidateRepository.saveAll(candidates);
+    }
+
+    private String toCandidateMetaJson(
+            MenuRecommendationResult recommendationResult,
+            MenuRecommendationCandidateResult candidate
+    ) {
+        Map<String, Object> meta = new LinkedHashMap<>();
+        meta.put("algorithmType", recommendationResult.algorithmType().name());
+        meta.put("algorithmVersion", recommendationResult.algorithmVersion());
+        meta.put("scoreBreakdown", candidate.scoreBreakdown());
+        meta.put("candidateMeta", candidate.meta());
+
+        try {
+            return objectMapper.writeValueAsString(meta);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("그룹 추천 후보 메타 정보를 JSON으로 변환할 수 없습니다.", exception);
+        }
     }
 
     private Map<Long, Long> countActiveMembers(Page<@NonNull GroupRoomMember> memberships) {

--- a/src/main/java/matchuri/backend/domain/recommendation/algorithm/group/GroupMenuRecommendationAlgorithmV1.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/algorithm/group/GroupMenuRecommendationAlgorithmV1.java
@@ -1,0 +1,142 @@
+package matchuri.backend.domain.recommendation.algorithm.group;
+
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.IntStream;
+import matchuri.backend.domain.recommendation.algorithm.MenuRecommendationAlgorithm;
+import matchuri.backend.domain.recommendation.algorithm.RecommendationAlgorithmType;
+import matchuri.backend.domain.recommendation.algorithm.input.MenuRecommendationInput;
+import matchuri.backend.domain.recommendation.algorithm.input.MenuRecommendationProfile;
+import matchuri.backend.domain.recommendation.algorithm.input.TasteProfileSnapshot;
+import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendationCandidateResult;
+import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendationResult;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GroupMenuRecommendationAlgorithmV1 implements MenuRecommendationAlgorithm {
+
+    private static final String VERSION = "v1";
+    private static final double PARTICIPANT_PREFERENCE_SCORE = 50.0;
+    private static final double DISLIKED_MENU_PENALTY = 25.0;
+
+    @Override
+    public RecommendationAlgorithmType type() {
+        return RecommendationAlgorithmType.GROUP;
+    }
+
+    @Override
+    public String version() {
+        return VERSION;
+    }
+
+    @Override
+    public MenuRecommendationResult recommend(MenuRecommendationInput input) {
+        Set<Long> restrictedIngredientIds = collectRestrictionIngredientIds(input.participants());
+
+        List<ScoredMenu> scoredMenus = input.menus().stream()
+                .filter(menu -> !containsAny(menu.ingredientIds(), restrictedIngredientIds))
+                .filter(menu -> !input.recentlySkippedMenuIds().contains(menu.menuId()))
+                .map(menu -> score(menu, input.participants()))
+                .sorted(Comparator.comparing(ScoredMenu::totalScore).reversed()
+                        .thenComparing(scoredMenu -> scoredMenu.menu().menuId()))
+                .limit(input.candidateLimit())
+                .toList();
+
+        return new MenuRecommendationResult(type(), version(), toCandidates(scoredMenus));
+    }
+
+    private ScoredMenu score(MenuRecommendationProfile menu, List<TasteProfileSnapshot> participants) {
+        long preferenceMatchingCount = 0;
+        double preferenceScore = 0;
+        int dislikedMemberCount = 0;
+
+        for (TasteProfileSnapshot participant : participants) {
+            long participantMatchingCount = countMatches(
+                    menu.attributeCategoryIds(),
+                    participant.preferredAttributeCategoryIds()
+            );
+            preferenceMatchingCount += participantMatchingCount;
+
+            if (!participant.preferredAttributeCategoryIds().isEmpty()) {
+                preferenceScore += participantMatchingCount
+                        * (PARTICIPANT_PREFERENCE_SCORE / participant.preferredAttributeCategoryIds().size());
+            }
+
+            if (participant.dislikedMenuItemIds().contains(menu.menuId())) {
+                dislikedMemberCount++;
+            }
+        }
+
+        double dislikedPenalty = dislikedMemberCount * DISLIKED_MENU_PENALTY;
+
+        return new ScoredMenu(
+                menu,
+                participants.size(),
+                preferenceMatchingCount,
+                dislikedMemberCount,
+                preferenceScore,
+                dislikedPenalty,
+                preferenceScore - dislikedPenalty
+        );
+    }
+
+    private List<MenuRecommendationCandidateResult> toCandidates(List<ScoredMenu> scoredMenus) {
+        return IntStream.range(0, scoredMenus.size())
+                .mapToObj(index -> {
+                    ScoredMenu scoredMenu = scoredMenus.get(index);
+
+                    return new MenuRecommendationCandidateResult(
+                            scoredMenu.menu().menuId(),
+                            index + 1,
+                            scoredMenu.totalScore(),
+                            Map.of(
+                                    "preferenceMatchingCount", scoredMenu.preferenceMatchingCount(),
+                                    "dislikedMemberCount", scoredMenu.dislikedMemberCount(),
+                                    "preferenceScore", scoredMenu.preferenceScore(),
+                                    "dislikedPenalty", scoredMenu.dislikedPenalty()
+                            ),
+                            Map.of(
+                                    "participantCount", scoredMenu.participantCount()
+                            )
+                    );
+                })
+                .toList();
+    }
+
+    private Set<Long> collectRestrictionIngredientIds(List<TasteProfileSnapshot> participants) {
+        Set<Long> restrictedIngredientIds = new HashSet<>();
+
+        for (TasteProfileSnapshot participant : participants) {
+            restrictedIngredientIds.addAll(participant.restrictionIngredientIds());
+        }
+
+        return restrictedIngredientIds;
+    }
+
+    private long countMatches(List<Long> sourceIds, List<Long> targetIds) {
+        Set<Long> targetIdSet = new HashSet<>(targetIds);
+
+        return sourceIds.stream()
+                .filter(targetIdSet::contains)
+                .count();
+    }
+
+    private boolean containsAny(List<Long> sourceIds, Set<Long> targetIds) {
+        return sourceIds.stream()
+                .anyMatch(targetIds::contains);
+    }
+
+    private record ScoredMenu(
+            MenuRecommendationProfile menu,
+            int participantCount,
+            long preferenceMatchingCount,
+            int dislikedMemberCount,
+            double preferenceScore,
+            double dislikedPenalty,
+            double totalScore
+    ) {
+    }
+}

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -15,7 +15,11 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Date;
+import java.util.List;
 import javax.crypto.SecretKey;
+import matchuri.backend.domain.group.entity.GroupRecommendation;
+import matchuri.backend.domain.group.entity.GroupRecommendationCandidate;
+import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
 import matchuri.backend.domain.group.entity.GroupInvite;
 import matchuri.backend.domain.group.entity.GroupInviteStatus;
 import matchuri.backend.domain.group.entity.GroupMemberRole;
@@ -24,13 +28,34 @@ import matchuri.backend.domain.group.entity.GroupRoom;
 import matchuri.backend.domain.group.entity.GroupRoomMember;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.repository.GroupInviteRepository;
+import matchuri.backend.domain.group.repository.GroupRecommendationCandidateRepository;
+import matchuri.backend.domain.group.repository.GroupRecommendationRepository;
 import matchuri.backend.domain.group.repository.GroupRoomMemberRepository;
 import matchuri.backend.domain.group.repository.GroupRoomRepository;
 import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.entity.MemberRole;
 import matchuri.backend.domain.member.entity.MemberStatus;
+import matchuri.backend.domain.member.entity.MemberTasteProfile;
+import matchuri.backend.domain.member.entity.MemberTasteProfileCategory;
+import matchuri.backend.domain.member.entity.MemberTasteProfileDislikedMenuItem;
+import matchuri.backend.domain.member.entity.MemberTasteProfileRestrictionIngredient;
 import matchuri.backend.domain.member.repository.MemberRepository;
+import matchuri.backend.domain.member.repository.MemberTasteProfileCategoryRepository;
+import matchuri.backend.domain.member.repository.MemberTasteProfileDislikedMenuItemRepository;
+import matchuri.backend.domain.member.repository.MemberTasteProfileRepository;
+import matchuri.backend.domain.member.repository.MemberTasteProfileRestrictionIngredientRepository;
 import matchuri.backend.domain.member.support.agreement.RequiredAgreementVersions;
+import matchuri.backend.domain.menu.entity.AttributeCategory;
+import matchuri.backend.domain.menu.entity.CategoryType;
+import matchuri.backend.domain.menu.entity.Ingredient;
+import matchuri.backend.domain.menu.entity.MenuAttributeCategory;
+import matchuri.backend.domain.menu.entity.MenuIngredient;
+import matchuri.backend.domain.menu.entity.MenuItem;
+import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
+import matchuri.backend.domain.menu.repository.IngredientRepository;
+import matchuri.backend.domain.menu.repository.MenuAttributeCategoryRepository;
+import matchuri.backend.domain.menu.repository.MenuIngredientRepository;
+import matchuri.backend.domain.menu.repository.MenuItemRepository;
 import matchuri.backend.global.config.MatchuriProperties;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -67,6 +92,39 @@ class GroupIntegrationTest {
     @Autowired
     private GroupInviteRepository groupInviteRepository;
 
+    @Autowired
+    private GroupRecommendationRepository groupRecommendationRepository;
+
+    @Autowired
+    private GroupRecommendationCandidateRepository groupRecommendationCandidateRepository;
+
+    @Autowired
+    private MenuItemRepository menuItemRepository;
+
+    @Autowired
+    private AttributeCategoryRepository attributeCategoryRepository;
+
+    @Autowired
+    private IngredientRepository ingredientRepository;
+
+    @Autowired
+    private MenuAttributeCategoryRepository menuAttributeCategoryRepository;
+
+    @Autowired
+    private MenuIngredientRepository menuIngredientRepository;
+
+    @Autowired
+    private MemberTasteProfileRepository memberTasteProfileRepository;
+
+    @Autowired
+    private MemberTasteProfileCategoryRepository memberTasteProfileCategoryRepository;
+
+    @Autowired
+    private MemberTasteProfileRestrictionIngredientRepository memberTasteProfileRestrictionIngredientRepository;
+
+    @Autowired
+    private MemberTasteProfileDislikedMenuItemRepository memberTasteProfileDislikedMenuItemRepository;
+
     @BeforeEach
     void setUp() {
         clearData();
@@ -78,9 +136,20 @@ class GroupIntegrationTest {
     }
 
     private void clearData() {
+        groupRecommendationCandidateRepository.deleteAll();
+        groupRecommendationRepository.deleteAll();
         groupInviteRepository.deleteAll();
         groupRoomMemberRepository.deleteAll();
         groupRoomRepository.deleteAll();
+        memberTasteProfileDislikedMenuItemRepository.deleteAll();
+        memberTasteProfileRestrictionIngredientRepository.deleteAll();
+        memberTasteProfileCategoryRepository.deleteAll();
+        memberTasteProfileRepository.deleteAll();
+        menuIngredientRepository.deleteAll();
+        menuAttributeCategoryRepository.deleteAll();
+        menuItemRepository.deleteAll();
+        ingredientRepository.deleteAll();
+        attributeCategoryRepository.deleteAll();
         memberRepository.deleteAll();
     }
 
@@ -145,6 +214,138 @@ class GroupIntegrationTest {
 
         assertThat(groupRoomRepository.count()).isZero();
         assertThat(groupRoomMemberRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("그룹 추천 생성은 OWNER가 그룹 취향 기반 후보를 저장한다")
+    void createGroupRecommendationCreatesCandidatesForOwner() throws Exception {
+        Member owner = saveMember("recommendation-owner", "추천방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "추천 그룹");
+        AttributeCategory spicy = saveCategory("spicy", "매콤한", 1);
+        MenuItem kimchiStew = saveMenu("kimchi-stew", "김치찌개", spicy);
+        saveMenu("salad", "샐러드");
+        saveMenu("gimbap", "김밥");
+        saveTasteProfile(owner, new AttributeCategory[]{spicy}, new Ingredient[]{}, new MenuItem[]{});
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "contextJson": {
+                                    "mealTime": "LUNCH"
+                                  }
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.sessionId").isNumber())
+                .andExpect(jsonPath("$.data.status").value(GroupRecommendationStatus.OPEN.name()))
+                .andExpect(jsonPath("$.data.candidates.length()").value(3))
+                .andExpect(jsonPath("$.data.candidates[0].menuId").value(kimchiStew.getId()))
+                .andExpect(jsonPath("$.data.candidates[0].score").value(50.0))
+                .andExpect(jsonPath("$.data.candidates[0].voteCount").value(0));
+
+        assertThat(groupRecommendationRepository.count()).isEqualTo(1);
+        assertThat(groupRecommendationCandidateRepository.count()).isEqualTo(3);
+
+        GroupRecommendation savedRecommendation = groupRecommendationRepository.findAll().getFirst();
+        List<GroupRecommendationCandidate> candidates = groupRecommendationCandidateRepository.findAll();
+
+        assertThat(savedRecommendation.getRoom().getId()).isEqualTo(groupRoom.getId());
+        assertThat(savedRecommendation.getStatus()).isEqualTo(GroupRecommendationStatus.OPEN);
+        assertThat(savedRecommendation.getContextJson()).contains("LUNCH");
+        assertThat(candidates)
+                .extracting(candidate -> candidate.getCandidateMetaJson())
+                .allSatisfy(candidateMetaJson -> {
+                    assertThat(candidateMetaJson).contains("GROUP");
+                    assertThat(candidateMetaJson).contains("scoreBreakdown");
+                });
+    }
+
+    @Test
+    @DisplayName("그룹 추천 생성은 OWNER가 아닌 활성 멤버이면 거절한다")
+    void createGroupRecommendationFailsForNonOwnerMember() throws Exception {
+        Member owner = saveMember("recommendation-forbidden-owner", "추천권한방장");
+        Member member = saveMember("recommendation-forbidden-member", "추천권한멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "추천 권한 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                member,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "contextJson": {}
+                                }
+                                """))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_CREATE_FORBIDDEN"));
+
+        assertThat(groupRecommendationRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("그룹 추천 생성은 열린 그룹 추천이 있으면 거절한다")
+    void createGroupRecommendationFailsWhenOpenRecommendationExists() throws Exception {
+        Member owner = saveMember("recommendation-open-owner", "열린추천방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "열린 추천 그룹");
+        groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "contextJson": {}
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_OPEN_EXISTS"));
+    }
+
+    @Test
+    @DisplayName("그룹 추천 생성은 한 명이라도 제한한 재료가 포함된 메뉴를 제외한다")
+    void createGroupRecommendationExcludesAnyRestrictedIngredient() throws Exception {
+        Member owner = saveMember("recommendation-restriction-owner", "제한방장");
+        Member member = saveMember("recommendation-restriction-member", "제한멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "제한 추천 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                member,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        Ingredient pork = saveIngredient("pork", "돼지고기", 1);
+        MenuItem porkCutlet = saveMenu("pork-cutlet", "돈까스");
+        MenuItem bibimbap = saveMenu("bibimbap", "비빔밥");
+        saveMenuIngredient(porkCutlet, pork);
+        saveTasteProfile(member, new AttributeCategory[]{}, new Ingredient[]{pork}, new MenuItem[]{});
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "contextJson": {}
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.candidates.length()").value(1))
+                .andExpect(jsonPath("$.data.candidates[0].menuId").value(bibimbap.getId()));
+
+        assertThat(groupRecommendationCandidateRepository.findAll())
+                .extracting(candidate -> candidate.getMenuItem().getId())
+                .doesNotContain(porkCutlet.getId());
     }
 
     @Test
@@ -1191,6 +1392,53 @@ class GroupIntegrationTest {
 
     private GroupRoom saveGroupOwnedBy(Member member, String name) {
         return groupRoomRepository.save(GroupRoom.createOwnedBy(name, nextInviteCode(), member, null, null));
+    }
+
+    private AttributeCategory saveCategory(String code, String name, int sortOrder) {
+        return attributeCategoryRepository.save(new AttributeCategory(CategoryType.FLAVOR, code, name, sortOrder));
+    }
+
+    private Ingredient saveIngredient(String code, String name, int sortOrder) {
+        return ingredientRepository.save(new Ingredient(code, name, false, sortOrder));
+    }
+
+    private MenuItem saveMenu(String code, String name, AttributeCategory... categories) {
+        MenuItem menuItem = menuItemRepository.save(new MenuItem(code, name, name + " 설명"));
+
+        for (AttributeCategory category : categories) {
+            menuAttributeCategoryRepository.save(new MenuAttributeCategory(menuItem, category));
+        }
+
+        return menuItem;
+    }
+
+    private void saveMenuIngredient(MenuItem menuItem, Ingredient ingredient) {
+        menuIngredientRepository.save(new MenuIngredient(menuItem, ingredient));
+    }
+
+    private void saveTasteProfile(
+            Member member,
+            AttributeCategory[] categories,
+            Ingredient[] restrictionIngredients,
+            MenuItem[] dislikedMenuItems
+    ) {
+        MemberTasteProfile profile = memberTasteProfileRepository.save(new MemberTasteProfile(member, "v1"));
+
+        for (AttributeCategory category : categories) {
+            memberTasteProfileCategoryRepository.save(new MemberTasteProfileCategory(profile, category));
+        }
+
+        for (Ingredient ingredient : restrictionIngredients) {
+            memberTasteProfileRestrictionIngredientRepository.save(
+                    new MemberTasteProfileRestrictionIngredient(profile, ingredient)
+            );
+        }
+
+        for (MenuItem dislikedMenuItem : dislikedMenuItems) {
+            memberTasteProfileDislikedMenuItemRepository.save(
+                    new MemberTasteProfileDislikedMenuItem(profile, dislikedMenuItem)
+            );
+        }
     }
 
     private String nextInviteCode() {


### PR DESCRIPTION
## Summary
- 그룹 추천 생성 API를 mock 응답에서 실제 저장/추천 생성 흐름으로 전환
- 그룹 추천 v1 알고리즘과 후보 score/candidate_meta_json 저장 추가
- 그룹 추천 상태 컬럼 길이 확장 및 OWNER 생성 권한/열린 추천 단일성 검증 추가

## Tests
- ./gradlew --no-daemon test