### PR TITLE
[feat] 그룹 추천 조회 API 구현

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -402,12 +402,11 @@ public interface GroupApi {
     );
 
     @Operation(
-            summary = "그룹 추천 세션 상세 조회 (Mock API)",
+            summary = "그룹 추천 세션 상세 조회",
             description = """
                     그룹 추천 상태, 후보, 투표 진행률, 최종 후보를 조회합니다.
 
-                    Mock API 상태:
-                    - `groupId`, `sessionId` 존재 여부와 접근 권한은 아직 검증하지 않습니다.
+                    - 해당 그룹의 활성 멤버만 조회할 수 있습니다.
                     - `sessionId`는 API 표현 이름이며 저장 모델은 `group_recommendations.id`로 해석합니다.
                     """
     )
@@ -428,12 +427,12 @@ public interface GroupApi {
     ApiResponse<GroupRecommendationSessionResponse> getRecommendation(Long groupId, Long sessionId);
 
     @Operation(
-            summary = "그룹 추천 후보 목록 조회 (Mock API)",
+            summary = "그룹 추천 후보 목록 조회",
             description = """
                     그룹 추천 후보 메뉴 목록만 조회합니다.
 
-                    Mock API 상태:
-                    - 후보 3개와 현재 투표수를 고정 응답으로 반환합니다.
+                    - 해당 그룹의 활성 멤버만 조회할 수 있습니다.
+                    - 후보별 현재 투표 수를 함께 반환합니다.
                     - 실제 저장 테이블은 `group_recommendation_candidates` 기준입니다.
                     """
     )

--- a/src/main/java/matchuri/backend/api/group/GroupController.java
+++ b/src/main/java/matchuri/backend/api/group/GroupController.java
@@ -3,6 +3,7 @@ package matchuri.backend.api.group;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.api.group.dto.request.CreateGroupRecommendationRequest;
@@ -45,6 +46,8 @@ import matchuri.backend.domain.group.result.CreateNicknameGroupInviteResult;
 import matchuri.backend.domain.group.result.DeleteGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
+import matchuri.backend.domain.group.result.GroupRecommendationCandidateResult;
+import matchuri.backend.domain.group.result.GroupRecommendationResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
 import matchuri.backend.domain.group.result.LeaveGroupResult;
@@ -206,7 +209,9 @@ public class GroupController implements GroupApi {
             @PathVariable Long groupId,
             @PathVariable Long sessionId
     ) {
-        return ApiResponse.success(GroupRecommendationSessionResponse.mockOpen());
+        GroupRecommendationResult result = groupService.getGroupRecommendation(groupId, sessionId);
+
+        return ApiResponse.success(groupMapper.toGroupRecommendationSessionResponse(result));
     }
 
     @Override
@@ -215,7 +220,10 @@ public class GroupController implements GroupApi {
             @PathVariable Long groupId,
             @PathVariable Long sessionId
     ) {
-        return ApiResponse.success(GroupRecommendationCandidateListResponse.mock());
+        List<GroupRecommendationCandidateResult> results =
+                groupService.getGroupRecommendationCandidates(groupId, sessionId);
+
+        return ApiResponse.success(groupMapper.toGroupRecommendationCandidateListResponse(sessionId, results));
     }
 
     @Override

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -2,6 +2,7 @@ package matchuri.backend.api.group;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.api.group.dto.request.CreateGroupRecommendationRequest;
@@ -17,8 +18,11 @@ import matchuri.backend.api.group.dto.response.DeleteGroupResponse;
 import matchuri.backend.api.group.dto.response.GroupDetailResponse;
 import matchuri.backend.api.group.dto.response.GroupInviteSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupMemberSummaryResponse;
+import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateListResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateResponse;
+import matchuri.backend.api.group.dto.response.GroupRecommendationSessionResponse;
 import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
+import matchuri.backend.api.group.dto.response.GroupVoteProgressResponse;
 import matchuri.backend.api.group.dto.response.JoinGroupResponse;
 import matchuri.backend.api.group.dto.response.LeaveGroupResponse;
 import matchuri.backend.api.group.dto.response.RespondGroupInviteResponse;
@@ -43,6 +47,8 @@ import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
 import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
 import matchuri.backend.domain.group.result.GroupRecommendationCandidateResult;
+import matchuri.backend.domain.group.result.GroupRecommendationResult;
+import matchuri.backend.domain.group.result.GroupVoteProgressResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
 import matchuri.backend.domain.group.result.LeaveGroupResult;
@@ -213,7 +219,34 @@ public class GroupMapper {
                 result.members().stream()
                         .map(this::toGroupMemberSummaryResponse)
                         .toList(),
-                null
+                result.activeRecommendation() == null
+                        ? null
+                        : toGroupRecommendationSessionResponse(result.activeRecommendation())
+        );
+    }
+
+    public GroupRecommendationSessionResponse toGroupRecommendationSessionResponse(GroupRecommendationResult result) {
+        return new GroupRecommendationSessionResponse(
+                result.sessionId(),
+                result.status(),
+                result.candidates().stream()
+                        .map(this::toGroupRecommendationCandidateResponse)
+                        .toList(),
+                toGroupVoteProgressResponse(result.voteProgress()),
+                result.finalCandidate() == null ? null : toGroupRecommendationCandidateResponse(result.finalCandidate()),
+                result.createdAt()
+        );
+    }
+
+    public GroupRecommendationCandidateListResponse toGroupRecommendationCandidateListResponse(
+            Long sessionId,
+            List<GroupRecommendationCandidateResult> candidates
+    ) {
+        return new GroupRecommendationCandidateListResponse(
+                sessionId,
+                candidates.stream()
+                        .map(this::toGroupRecommendationCandidateResponse)
+                        .toList()
         );
     }
 
@@ -250,6 +283,13 @@ public class GroupMapper {
                 result.rankNo(),
                 result.score(),
                 result.voteCount()
+        );
+    }
+
+    private GroupVoteProgressResponse toGroupVoteProgressResponse(GroupVoteProgressResult result) {
+        return new GroupVoteProgressResponse(
+                result.totalMemberCount(),
+                result.votedMemberCount()
         );
     }
 

--- a/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
@@ -33,7 +33,8 @@ public enum GroupErrorCode implements ErrorCode {
     INVITE_ALREADY_PENDING(HttpStatus.CONFLICT, "이미 대기 중인 그룹 초대가 있습니다. groupId : {0}, memberId : {1}"),
     INVITE_CODE_GENERATION_FAILED(HttpStatus.CONFLICT, "그룹 고정 초대 코드 생성에 실패했습니다."),
     RECOMMENDATION_CREATE_FORBIDDEN(HttpStatus.FORBIDDEN, "그룹 추천 생성 권한이 없습니다. groupId : {0}"),
-    RECOMMENDATION_OPEN_EXISTS(HttpStatus.CONFLICT, "이미 열린 그룹 추천이 있습니다. groupId : {0}");
+    RECOMMENDATION_OPEN_EXISTS(HttpStatus.CONFLICT, "이미 열린 그룹 추천이 있습니다. groupId : {0}"),
+    RECOMMENDATION_NOT_FOUND(HttpStatus.NOT_FOUND, "그룹 추천을 찾을 수 없습니다. groupRecommendationId : {0}");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationCandidateRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationCandidateRepository.java
@@ -1,7 +1,10 @@
 package matchuri.backend.domain.group.repository;
 
+import java.util.List;
 import matchuri.backend.domain.group.entity.GroupRecommendationCandidate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GroupRecommendationCandidateRepository extends JpaRepository<GroupRecommendationCandidate, Long> {
+
+    List<GroupRecommendationCandidate> findByGroupRecommendationIdOrderByRankNoAsc(Long groupRecommendationId);
 }

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationRepository.java
@@ -1,5 +1,6 @@
 package matchuri.backend.domain.group.repository;
 
+import java.util.Optional;
 import matchuri.backend.domain.group.entity.GroupRecommendation;
 import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,4 +8,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface GroupRecommendationRepository extends JpaRepository<GroupRecommendation, Long> {
 
     boolean existsByRoomIdAndStatus(Long roomId, GroupRecommendationStatus status);
+
+    Optional<GroupRecommendation> findByIdAndRoomId(Long id, Long roomId);
+
+    Optional<GroupRecommendation> findFirstByRoomIdAndStatusOrderByStartedAtDescIdDesc(
+            Long roomId,
+            GroupRecommendationStatus status
+    );
 }

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationVoteCountProjection.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationVoteCountProjection.java
@@ -1,0 +1,8 @@
+package matchuri.backend.domain.group.repository;
+
+public interface GroupRecommendationVoteCountProjection {
+
+    Long getCandidateId();
+
+    Long getVoteCount();
+}

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationVoteRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationVoteRepository.java
@@ -1,0 +1,23 @@
+package matchuri.backend.domain.group.repository;
+
+import java.util.Collection;
+import java.util.List;
+import matchuri.backend.domain.group.entity.GroupRecommendationVote;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface GroupRecommendationVoteRepository extends JpaRepository<GroupRecommendationVote, Long> {
+
+    long countByGroupRecommendationId(Long groupRecommendationId);
+
+    @Query("""
+            select vote.candidate.id as candidateId, count(vote) as voteCount
+            from GroupRecommendationVote vote
+            where vote.candidate.id in :candidateIds
+            group by vote.candidate.id
+            """)
+    List<GroupRecommendationVoteCountProjection> countVotesByCandidateIds(
+            @Param("candidateIds") Collection<Long> candidateIds
+    );
+}

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRoomMemberRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRoomMemberRepository.java
@@ -97,4 +97,6 @@ public interface GroupRoomMemberRepository extends JpaRepository<GroupRoomMember
               groupMember.id asc
             """)
     List<GroupRoomMember> findActiveMembersByRoomId(@Param("roomId") Long roomId);
+
+    long countByRoomIdAndStatus(Long roomId, GroupMemberStatus status);
 }

--- a/src/main/java/matchuri/backend/domain/group/result/GroupDetailResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupDetailResult.java
@@ -11,6 +11,7 @@ public record GroupDetailResult(
         BigDecimal latitude,
         BigDecimal longitude,
         GroupRoomStatus status,
-        List<GroupMemberSummaryResult> members
+        List<GroupMemberSummaryResult> members,
+        GroupRecommendationResult activeRecommendation
 ) {
 }

--- a/src/main/java/matchuri/backend/domain/group/result/GroupRecommendationResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupRecommendationResult.java
@@ -1,0 +1,15 @@
+package matchuri.backend.domain.group.result;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
+
+public record GroupRecommendationResult(
+        Long sessionId,
+        GroupRecommendationStatus status,
+        List<GroupRecommendationCandidateResult> candidates,
+        GroupVoteProgressResult voteProgress,
+        GroupRecommendationCandidateResult finalCandidate,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/result/GroupVoteProgressResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupVoteProgressResult.java
@@ -1,0 +1,7 @@
+package matchuri.backend.domain.group.result;
+
+public record GroupVoteProgressResult(
+        Integer totalMemberCount,
+        Integer votedMemberCount
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/service/GroupService.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupService.java
@@ -1,5 +1,6 @@
 package matchuri.backend.domain.group.service;
 
+import java.util.List;
 import lombok.NonNull;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.CreateGroupRecommendationCommand;
@@ -17,6 +18,8 @@ import matchuri.backend.domain.group.result.CreateNicknameGroupInviteResult;
 import matchuri.backend.domain.group.result.DeleteGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
+import matchuri.backend.domain.group.result.GroupRecommendationCandidateResult;
+import matchuri.backend.domain.group.result.GroupRecommendationResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
 import matchuri.backend.domain.group.result.LeaveGroupResult;
@@ -29,6 +32,10 @@ public interface GroupService {
     CreateGroupResult createGroup(CreateGroupCommand command);
 
     CreateGroupRecommendationResult createGroupRecommendation(CreateGroupRecommendationCommand command);
+
+    GroupRecommendationResult getGroupRecommendation(Long groupId, Long sessionId);
+
+    List<GroupRecommendationCandidateResult> getGroupRecommendationCandidates(Long groupId, Long sessionId);
 
     CreateNicknameGroupInviteResult createNicknameInvite(CreateNicknameGroupInviteCommand command);
 

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -34,6 +34,8 @@ import matchuri.backend.domain.group.exception.GroupErrorCode;
 import matchuri.backend.domain.group.repository.GroupInviteRepository;
 import matchuri.backend.domain.group.repository.GroupRecommendationCandidateRepository;
 import matchuri.backend.domain.group.repository.GroupRecommendationRepository;
+import matchuri.backend.domain.group.repository.GroupRecommendationVoteCountProjection;
+import matchuri.backend.domain.group.repository.GroupRecommendationVoteRepository;
 import matchuri.backend.domain.group.repository.GroupRoomMemberCountProjection;
 import matchuri.backend.domain.group.repository.GroupRoomMemberRepository;
 import matchuri.backend.domain.group.repository.GroupRoomRepository;
@@ -42,6 +44,8 @@ import matchuri.backend.domain.group.result.CreateGroupRecommendationResult;
 import matchuri.backend.domain.group.result.CreateNicknameGroupInviteResult;
 import matchuri.backend.domain.group.result.DeleteGroupResult;
 import matchuri.backend.domain.group.result.GroupRecommendationCandidateResult;
+import matchuri.backend.domain.group.result.GroupRecommendationResult;
+import matchuri.backend.domain.group.result.GroupVoteProgressResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
 import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
@@ -95,6 +99,7 @@ public class GroupServiceImpl implements GroupService {
     private final GroupInviteRepository groupInviteRepository;
     private final GroupRecommendationRepository groupRecommendationRepository;
     private final GroupRecommendationCandidateRepository groupRecommendationCandidateRepository;
+    private final GroupRecommendationVoteRepository groupRecommendationVoteRepository;
     private final MenuItemRepository menuItemRepository;
     private final MenuIngredientRepository menuIngredientRepository;
     private final MenuRecommendationAlgorithmResolver menuRecommendationAlgorithmResolver;
@@ -180,6 +185,33 @@ public class GroupServiceImpl implements GroupService {
                         .map(candidate -> GroupRecommendationCandidateResult.from(candidate, 0))
                         .toList()
         );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public GroupRecommendationResult getGroupRecommendation(Long groupId, Long sessionId) {
+        GroupRecommendation recommendation = getAccessibleGroupRecommendation(groupId, sessionId);
+        List<GroupRecommendationCandidate> candidates =
+                groupRecommendationCandidateRepository.findByGroupRecommendationIdOrderByRankNoAsc(sessionId);
+        Map<Long, Long> voteCounts = countVotesByCandidateIds(candidates);
+
+        return toGroupRecommendationResult(recommendation, candidates, voteCounts);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<GroupRecommendationCandidateResult> getGroupRecommendationCandidates(Long groupId, Long sessionId) {
+        getAccessibleGroupRecommendation(groupId, sessionId);
+        List<GroupRecommendationCandidate> candidates =
+                groupRecommendationCandidateRepository.findByGroupRecommendationIdOrderByRankNoAsc(sessionId);
+        Map<Long, Long> voteCounts = countVotesByCandidateIds(candidates);
+
+        return candidates.stream()
+                .map(candidate -> GroupRecommendationCandidateResult.from(
+                        candidate,
+                        voteCounts.getOrDefault(candidate.getId(), 0L).intValue()
+                ))
+                .toList();
     }
 
     @Override
@@ -424,6 +456,11 @@ public class GroupServiceImpl implements GroupService {
                 .map(this::toMemberSummaryResult)
                 .toList();
 
+        GroupRecommendationResult activeRecommendation = groupRecommendationRepository
+                .findFirstByRoomIdAndStatusOrderByStartedAtDescIdDesc(groupId, GroupRecommendationStatus.OPEN)
+                .map(this::toGroupRecommendationResult)
+                .orElse(null);
+
         return new GroupDetailResult(
                 room.getId(),
                 room.getName(),
@@ -431,8 +468,79 @@ public class GroupServiceImpl implements GroupService {
                 room.getLatitude(),
                 room.getLongitude(),
                 room.getStatus(),
-                members
+                members,
+                activeRecommendation
         );
+    }
+
+    private GroupRecommendation getAccessibleGroupRecommendation(Long groupId, Long sessionId) {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        GroupRoom room = groupRoomRepository.findByIdAndStatusNot(groupId, GroupRoomStatus.DELETED)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.NOT_FOUND, groupId));
+
+        if (!groupRoomMemberRepository.existsActiveMembershipInNotDeletedRoom(room.getId(), member.getId())) {
+            throw new BusinessException(GroupErrorCode.ACCESS_DENIED, room.getId());
+        }
+
+        return groupRecommendationRepository.findByIdAndRoomId(sessionId, room.getId())
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_FOUND, sessionId));
+    }
+
+    private GroupRecommendationResult toGroupRecommendationResult(GroupRecommendation recommendation) {
+        List<GroupRecommendationCandidate> candidates = groupRecommendationCandidateRepository
+                .findByGroupRecommendationIdOrderByRankNoAsc(recommendation.getId());
+        Map<Long, Long> voteCounts = countVotesByCandidateIds(candidates);
+
+        return toGroupRecommendationResult(recommendation, candidates, voteCounts);
+    }
+
+    private GroupRecommendationResult toGroupRecommendationResult(
+            GroupRecommendation recommendation,
+            List<GroupRecommendationCandidate> candidates,
+            Map<Long, Long> voteCounts
+    ) {
+        GroupRecommendationCandidateResult finalCandidate = recommendation.getSelectedCandidate() == null
+                ? null
+                : GroupRecommendationCandidateResult.from(
+                        recommendation.getSelectedCandidate(),
+                        voteCounts.getOrDefault(recommendation.getSelectedCandidate().getId(), 0L).intValue()
+                );
+
+        return new GroupRecommendationResult(
+                recommendation.getId(),
+                recommendation.getStatus(),
+                candidates.stream()
+                        .map(candidate -> GroupRecommendationCandidateResult.from(
+                                candidate,
+                                voteCounts.getOrDefault(candidate.getId(), 0L).intValue()
+                        ))
+                        .toList(),
+                new GroupVoteProgressResult(
+                        (int) groupRoomMemberRepository.countByRoomIdAndStatus(
+                                recommendation.getRoom().getId(),
+                                GroupMemberStatus.ACTIVE
+                        ),
+                        (int) groupRecommendationVoteRepository.countByGroupRecommendationId(recommendation.getId())
+                ),
+                finalCandidate,
+                recommendation.getCreatedAt()
+        );
+    }
+
+    private Map<Long, Long> countVotesByCandidateIds(List<GroupRecommendationCandidate> candidates) {
+        List<Long> candidateIds = candidates.stream()
+                .map(GroupRecommendationCandidate::getId)
+                .toList();
+
+        if (candidateIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return groupRecommendationVoteRepository.countVotesByCandidateIds(candidateIds).stream()
+                .collect(Collectors.toMap(
+                        GroupRecommendationVoteCountProjection::getCandidateId,
+                        GroupRecommendationVoteCountProjection::getVoteCount
+                ));
     }
 
     private List<TasteProfileSnapshot> toTasteProfileSnapshots(List<GroupRoomMember> activeMembers) {

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -349,6 +349,80 @@ class GroupIntegrationTest {
     }
 
     @Test
+    @DisplayName("그룹 추천 상세 조회는 활성 멤버에게 후보와 투표 진행률을 반환한다")
+    void getGroupRecommendationReturnsCandidatesAndVoteProgress() throws Exception {
+        Member owner = saveMember("recommendation-detail-owner", "추천상세방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "추천 상세 그룹");
+        MenuItem menuItem = saveMenu("detail-menu", "상세 메뉴");
+        GroupRecommendation recommendation = saveGroupRecommendation(groupRoom);
+        GroupRecommendationCandidate candidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, menuItem, 1, 42.5, "{\"algorithmType\":\"GROUP\"}")
+        );
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}/recommendations/{sessionId}",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.sessionId").value(recommendation.getId()))
+                .andExpect(jsonPath("$.data.status").value(GroupRecommendationStatus.OPEN.name()))
+                .andExpect(jsonPath("$.data.candidates.length()").value(1))
+                .andExpect(jsonPath("$.data.candidates[0].candidateId").value(candidate.getId()))
+                .andExpect(jsonPath("$.data.candidates[0].menuId").value(menuItem.getId()))
+                .andExpect(jsonPath("$.data.candidates[0].score").value(42.5))
+                .andExpect(jsonPath("$.data.candidates[0].voteCount").value(0))
+                .andExpect(jsonPath("$.data.voteProgress.totalMemberCount").value(1))
+                .andExpect(jsonPath("$.data.voteProgress.votedMemberCount").value(0))
+                .andExpect(jsonPath("$.data.finalCandidate").value(nullValue()))
+                .andExpect(jsonPath("$.data.createdAt").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("그룹 추천 상세 조회는 비멤버 접근을 거절한다")
+    void getGroupRecommendationFailsForNonMember() throws Exception {
+        Member owner = saveMember("recommendation-detail-access-owner", "추천상세권한방장");
+        Member other = saveMember("recommendation-detail-access-other", "추천상세권한없음");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "추천 상세 권한 그룹");
+        GroupRecommendation recommendation = saveGroupRecommendation(groupRoom);
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}/recommendations/{sessionId}",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(other))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("GROUP_ACCESS_DENIED"));
+    }
+
+    @Test
+    @DisplayName("그룹 추천 후보 목록 조회는 후보만 rank 순서로 반환한다")
+    void getGroupRecommendationCandidatesReturnsCandidateList() throws Exception {
+        Member owner = saveMember("recommendation-candidates-owner", "추천후보방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "추천 후보 그룹");
+        MenuItem firstMenu = saveMenu("candidate-first", "첫 후보");
+        MenuItem secondMenu = saveMenu("candidate-second", "두 번째 후보");
+        GroupRecommendation recommendation = saveGroupRecommendation(groupRoom);
+        GroupRecommendationCandidate secondCandidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, secondMenu, 2, 10.0, "{}")
+        );
+        GroupRecommendationCandidate firstCandidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, firstMenu, 1, 20.0, "{}")
+        );
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}/recommendations/{sessionId}/candidates",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.sessionId").value(recommendation.getId()))
+                .andExpect(jsonPath("$.data.candidates.length()").value(2))
+                .andExpect(jsonPath("$.data.candidates[0].candidateId").value(firstCandidate.getId()))
+                .andExpect(jsonPath("$.data.candidates[0].rankNo").value(1))
+                .andExpect(jsonPath("$.data.candidates[1].candidateId").value(secondCandidate.getId()))
+                .andExpect(jsonPath("$.data.candidates[1].rankNo").value(2));
+    }
+
+    @Test
     @DisplayName("내 그룹 목록은 현재 회원이 활성 멤버인 삭제되지 않은 그룹만 조회한다")
     void getMyGroupsReturnsActiveMembershipRoomsOnly() throws Exception {
         Member member = saveMember("group-list-user", "목록사용자");
@@ -442,6 +516,28 @@ class GroupIntegrationTest {
                 .andExpect(jsonPath("$.data.members[1].memberId").value(activeMember.getId()))
                 .andExpect(jsonPath("$.data.members[1].nickname").value("상세멤버"))
                 .andExpect(jsonPath("$.data.activeRecommendation").value(nullValue()));
+    }
+
+    @Test
+    @DisplayName("그룹 상세 조회는 열린 그룹 추천이 있으면 activeRecommendation을 반환한다")
+    void getGroupReturnsActiveRecommendation() throws Exception {
+        Member owner = saveMember("detail-active-recommendation-owner", "상세추천방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "상세 추천 그룹");
+        MenuItem menuItem = saveMenu("active-recommendation-menu", "진행 중 후보");
+        GroupRecommendation recommendation = saveGroupRecommendation(groupRoom);
+        GroupRecommendationCandidate candidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, menuItem, 1, 33.0, "{}")
+        );
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.activeRecommendation.sessionId").value(recommendation.getId()))
+                .andExpect(jsonPath("$.data.activeRecommendation.status").value(GroupRecommendationStatus.OPEN.name()))
+                .andExpect(jsonPath("$.data.activeRecommendation.candidates.length()").value(1))
+                .andExpect(jsonPath("$.data.activeRecommendation.candidates[0].candidateId").value(candidate.getId()))
+                .andExpect(jsonPath("$.data.activeRecommendation.voteProgress.totalMemberCount").value(1))
+                .andExpect(jsonPath("$.data.activeRecommendation.voteProgress.votedMemberCount").value(0));
     }
 
     @Test
@@ -1414,6 +1510,14 @@ class GroupIntegrationTest {
 
     private void saveMenuIngredient(MenuItem menuItem, Ingredient ingredient) {
         menuIngredientRepository.save(new MenuIngredient(menuItem, ingredient));
+    }
+
+    private GroupRecommendation saveGroupRecommendation(GroupRoom groupRoom) {
+        return groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
     }
 
     private void saveTasteProfile(


### PR DESCRIPTION
## Summary
- 그룹 추천 상세/후보 조회 API를 실제 저장 모델에 연결
- 후보별 voteCount와 투표 진행률 계산 추가
- 그룹 상세 조회에 OPEN activeRecommendation 연결

## Stacked on
- #249

## Tests
- ./gradlew --no-daemon test