### PR TITLE
[Feat] 그룹 메뉴 추천과 후보에 대한 상세 조회 API 구현

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -131,7 +131,7 @@ public interface GroupApi {
                     - 현재 회원이 해당 그룹의 `ACTIVE` 멤버일 때만 조회할 수 있습니다.
                     - 그룹의 모든 `ACTIVE` 멤버에게 고정 초대 코드를 함께 반환합니다.
                     - 삭제된 그룹은 조회할 수 없습니다.
-                    - 그룹 추천 구현 전까지 `activeRecommendation`은 null입니다.
+                    - 열린 그룹 추천이 있으면 `activeRecommendation`을 함께 반환합니다.
                     """
     )
     @ApiResponses({
@@ -402,13 +402,15 @@ public interface GroupApi {
     );
 
     @Operation(
-            summary = "그룹 추천 세션 상세 조회 (Mock API)",
+            summary = "그룹 추천 세션 상세 조회",
             description = """
                     그룹 추천 상태, 후보, 투표 진행률, 최종 후보를 조회합니다.
 
-                    Mock API 상태:
-                    - `groupId`, `sessionId` 존재 여부와 접근 권한은 아직 검증하지 않습니다.
+                    구현 기준:
+                    - 로그인한 활성 회원만 사용할 수 있습니다.
+                    - 현재 회원이 해당 그룹의 `ACTIVE` 멤버일 때만 조회할 수 있습니다.
                     - `sessionId`는 API 표현 이름이며 저장 모델은 `group_recommendations.id`로 해석합니다.
+                    - 후보별 현재 투표 수와 전체 투표 진행률을 함께 반환합니다.
                     """
     )
     @ApiResponses({
@@ -428,12 +430,15 @@ public interface GroupApi {
     ApiResponse<GroupRecommendationSessionResponse> getRecommendation(Long groupId, Long sessionId);
 
     @Operation(
-            summary = "그룹 추천 후보 목록 조회 (Mock API)",
+            summary = "그룹 추천 후보 목록 조회",
             description = """
                     그룹 추천 후보 메뉴 목록만 조회합니다.
 
-                    Mock API 상태:
-                    - 후보 3개와 현재 투표수를 고정 응답으로 반환합니다.
+                    구현 기준:
+                    - 로그인한 활성 회원만 사용할 수 있습니다.
+                    - 현재 회원이 해당 그룹의 `ACTIVE` 멤버일 때만 조회할 수 있습니다.
+                    - 후보는 추천 순위 오름차순으로 반환합니다.
+                    - 후보별 현재 투표 수를 함께 반환합니다.
                     - 실제 저장 테이블은 `group_recommendation_candidates` 기준입니다.
                     """
     )

--- a/src/main/java/matchuri/backend/api/group/GroupController.java
+++ b/src/main/java/matchuri/backend/api/group/GroupController.java
@@ -45,6 +45,8 @@ import matchuri.backend.domain.group.result.CreateNicknameGroupInviteResult;
 import matchuri.backend.domain.group.result.DeleteGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
+import matchuri.backend.domain.group.result.GroupRecommendationCandidateListResult;
+import matchuri.backend.domain.group.result.GroupRecommendationResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
 import matchuri.backend.domain.group.result.LeaveGroupResult;
@@ -206,7 +208,9 @@ public class GroupController implements GroupApi {
             @PathVariable Long groupId,
             @PathVariable Long sessionId
     ) {
-        return ApiResponse.success(GroupRecommendationSessionResponse.mockOpen());
+        GroupRecommendationResult result = groupService.getGroupRecommendation(groupId, sessionId);
+
+        return ApiResponse.success(groupMapper.toGroupRecommendationSessionResponse(result));
     }
 
     @Override
@@ -215,7 +219,10 @@ public class GroupController implements GroupApi {
             @PathVariable Long groupId,
             @PathVariable Long sessionId
     ) {
-        return ApiResponse.success(GroupRecommendationCandidateListResponse.mock());
+        GroupRecommendationCandidateListResult result =
+                groupService.getGroupRecommendationCandidates(groupId, sessionId);
+
+        return ApiResponse.success(groupMapper.toGroupRecommendationCandidateListResponse(result));
     }
 
     @Override

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -17,8 +17,11 @@ import matchuri.backend.api.group.dto.response.DeleteGroupResponse;
 import matchuri.backend.api.group.dto.response.GroupDetailResponse;
 import matchuri.backend.api.group.dto.response.GroupInviteSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupMemberSummaryResponse;
+import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateListResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateResponse;
+import matchuri.backend.api.group.dto.response.GroupRecommendationSessionResponse;
 import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
+import matchuri.backend.api.group.dto.response.GroupVoteProgressResponse;
 import matchuri.backend.api.group.dto.response.JoinGroupResponse;
 import matchuri.backend.api.group.dto.response.LeaveGroupResponse;
 import matchuri.backend.api.group.dto.response.RespondGroupInviteResponse;
@@ -42,8 +45,11 @@ import matchuri.backend.domain.group.result.DeleteGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
 import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
+import matchuri.backend.domain.group.result.GroupRecommendationCandidateListResult;
 import matchuri.backend.domain.group.result.GroupRecommendationCandidateResult;
+import matchuri.backend.domain.group.result.GroupRecommendationResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
+import matchuri.backend.domain.group.result.GroupVoteProgressResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
 import matchuri.backend.domain.group.result.LeaveGroupResult;
 import matchuri.backend.domain.group.result.RespondGroupInviteResult;
@@ -213,7 +219,37 @@ public class GroupMapper {
                 result.members().stream()
                         .map(this::toGroupMemberSummaryResponse)
                         .toList(),
-                null
+                result.activeRecommendation() == null
+                        ? null
+                        : toGroupRecommendationSessionResponse(result.activeRecommendation())
+        );
+    }
+
+    public GroupRecommendationSessionResponse toGroupRecommendationSessionResponse(
+            GroupRecommendationResult result
+    ) {
+        return new GroupRecommendationSessionResponse(
+                result.sessionId(),
+                result.status(),
+                result.candidates().stream()
+                        .map(this::toGroupRecommendationCandidateResponse)
+                        .toList(),
+                toGroupVoteProgressResponse(result.voteProgress()),
+                result.finalCandidate() == null
+                        ? null
+                        : toGroupRecommendationCandidateResponse(result.finalCandidate()),
+                result.createdAt()
+        );
+    }
+
+    public GroupRecommendationCandidateListResponse toGroupRecommendationCandidateListResponse(
+            GroupRecommendationCandidateListResult result
+    ) {
+        return new GroupRecommendationCandidateListResponse(
+                result.sessionId(),
+                result.candidates().stream()
+                        .map(this::toGroupRecommendationCandidateResponse)
+                        .toList()
         );
     }
 
@@ -250,6 +286,13 @@ public class GroupMapper {
                 result.rankNo(),
                 result.score(),
                 result.voteCount()
+        );
+    }
+
+    private GroupVoteProgressResponse toGroupVoteProgressResponse(GroupVoteProgressResult result) {
+        return new GroupVoteProgressResponse(
+                result.totalMemberCount(),
+                result.votedMemberCount()
         );
     }
 

--- a/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
@@ -33,7 +33,8 @@ public enum GroupErrorCode implements ErrorCode {
     INVITE_ALREADY_PENDING(HttpStatus.CONFLICT, "이미 대기 중인 그룹 초대가 있습니다. groupId : {0}, memberId : {1}"),
     INVITE_CODE_GENERATION_FAILED(HttpStatus.CONFLICT, "그룹 고정 초대 코드 생성에 실패했습니다."),
     RECOMMENDATION_CREATE_FORBIDDEN(HttpStatus.FORBIDDEN, "그룹 추천 생성 권한이 없습니다. groupId : {0}"),
-    RECOMMENDATION_OPEN_EXISTS(HttpStatus.CONFLICT, "이미 열린 그룹 추천이 있습니다. groupId : {0}");
+    RECOMMENDATION_OPEN_EXISTS(HttpStatus.CONFLICT, "이미 열린 그룹 추천이 있습니다. groupId : {0}"),
+    RECOMMENDATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 그룹 추천을 찾을 수 없습니다. sessionId : {0}");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupCandidateVoteCountProjection.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupCandidateVoteCountProjection.java
@@ -1,0 +1,8 @@
+package matchuri.backend.domain.group.repository;
+
+public interface GroupCandidateVoteCountProjection {
+
+    Long getCandidateId();
+
+    Long getVoteCount();
+}

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationCandidateRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationCandidateRepository.java
@@ -1,7 +1,10 @@
 package matchuri.backend.domain.group.repository;
 
+import java.util.List;
 import matchuri.backend.domain.group.entity.GroupRecommendationCandidate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GroupRecommendationCandidateRepository extends JpaRepository<GroupRecommendationCandidate, Long> {
+
+    List<GroupRecommendationCandidate> findAllByGroupRecommendationIdOrderByRankNoAsc(Long recommendationId);
 }

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationRepository.java
@@ -1,5 +1,6 @@
 package matchuri.backend.domain.group.repository;
 
+import java.util.Optional;
 import matchuri.backend.domain.group.entity.GroupRecommendation;
 import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,4 +8,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface GroupRecommendationRepository extends JpaRepository<GroupRecommendation, Long> {
 
     boolean existsByRoomIdAndStatus(Long roomId, GroupRecommendationStatus status);
+
+    Optional<GroupRecommendation> findByIdAndRoomId(Long id, Long roomId);
+
+    Optional<GroupRecommendation> findFirstByRoomIdAndStatusOrderByStartedAtDesc(
+            Long roomId,
+            GroupRecommendationStatus status
+    );
 }

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationVoteRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationVoteRepository.java
@@ -1,0 +1,22 @@
+package matchuri.backend.domain.group.repository;
+
+import java.util.List;
+import matchuri.backend.domain.group.entity.GroupRecommendationVote;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface GroupRecommendationVoteRepository extends JpaRepository<GroupRecommendationVote, Long> {
+
+    @Query("""
+            select vote.candidate.id as candidateId, count(vote.id) as voteCount
+            from GroupRecommendationVote vote
+            where vote.groupRecommendation.id = :recommendationId
+            group by vote.candidate.id
+            """)
+    List<GroupCandidateVoteCountProjection> countVotesByCandidateId(
+            @Param("recommendationId") Long recommendationId
+    );
+
+    long countByGroupRecommendationId(Long recommendationId);
+}

--- a/src/main/java/matchuri/backend/domain/group/result/GroupDetailResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupDetailResult.java
@@ -11,6 +11,7 @@ public record GroupDetailResult(
         BigDecimal latitude,
         BigDecimal longitude,
         GroupRoomStatus status,
-        List<GroupMemberSummaryResult> members
+        List<GroupMemberSummaryResult> members,
+        GroupRecommendationResult activeRecommendation
 ) {
 }

--- a/src/main/java/matchuri/backend/domain/group/result/GroupRecommendationCandidateListResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupRecommendationCandidateListResult.java
@@ -1,0 +1,9 @@
+package matchuri.backend.domain.group.result;
+
+import java.util.List;
+
+public record GroupRecommendationCandidateListResult(
+        Long sessionId,
+        List<GroupRecommendationCandidateResult> candidates
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/result/GroupRecommendationResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupRecommendationResult.java
@@ -1,0 +1,15 @@
+package matchuri.backend.domain.group.result;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
+
+public record GroupRecommendationResult(
+        Long sessionId,
+        GroupRecommendationStatus status,
+        List<GroupRecommendationCandidateResult> candidates,
+        GroupVoteProgressResult voteProgress,
+        GroupRecommendationCandidateResult finalCandidate,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/result/GroupVoteProgressResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupVoteProgressResult.java
@@ -1,0 +1,7 @@
+package matchuri.backend.domain.group.result;
+
+public record GroupVoteProgressResult(
+        Integer totalMemberCount,
+        Integer votedMemberCount
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/service/GroupService.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupService.java
@@ -17,6 +17,8 @@ import matchuri.backend.domain.group.result.CreateNicknameGroupInviteResult;
 import matchuri.backend.domain.group.result.DeleteGroupResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
+import matchuri.backend.domain.group.result.GroupRecommendationCandidateListResult;
+import matchuri.backend.domain.group.result.GroupRecommendationResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
 import matchuri.backend.domain.group.result.LeaveGroupResult;
@@ -29,6 +31,10 @@ public interface GroupService {
     CreateGroupResult createGroup(CreateGroupCommand command);
 
     CreateGroupRecommendationResult createGroupRecommendation(CreateGroupRecommendationCommand command);
+
+    GroupRecommendationResult getGroupRecommendation(Long groupId, Long sessionId);
+
+    GroupRecommendationCandidateListResult getGroupRecommendationCandidates(Long groupId, Long sessionId);
 
     CreateNicknameGroupInviteResult createNicknameInvite(CreateNicknameGroupInviteCommand command);
 

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -32,8 +32,10 @@ import matchuri.backend.domain.group.entity.GroupRoomMember;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.exception.GroupErrorCode;
 import matchuri.backend.domain.group.repository.GroupInviteRepository;
+import matchuri.backend.domain.group.repository.GroupCandidateVoteCountProjection;
 import matchuri.backend.domain.group.repository.GroupRecommendationCandidateRepository;
 import matchuri.backend.domain.group.repository.GroupRecommendationRepository;
+import matchuri.backend.domain.group.repository.GroupRecommendationVoteRepository;
 import matchuri.backend.domain.group.repository.GroupRoomMemberCountProjection;
 import matchuri.backend.domain.group.repository.GroupRoomMemberRepository;
 import matchuri.backend.domain.group.repository.GroupRoomRepository;
@@ -42,10 +44,13 @@ import matchuri.backend.domain.group.result.CreateGroupRecommendationResult;
 import matchuri.backend.domain.group.result.CreateNicknameGroupInviteResult;
 import matchuri.backend.domain.group.result.DeleteGroupResult;
 import matchuri.backend.domain.group.result.GroupRecommendationCandidateResult;
+import matchuri.backend.domain.group.result.GroupRecommendationCandidateListResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
 import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
+import matchuri.backend.domain.group.result.GroupRecommendationResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
+import matchuri.backend.domain.group.result.GroupVoteProgressResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
 import matchuri.backend.domain.group.result.LeaveGroupResult;
 import matchuri.backend.domain.group.result.RespondGroupInviteResult;
@@ -95,6 +100,7 @@ public class GroupServiceImpl implements GroupService {
     private final GroupInviteRepository groupInviteRepository;
     private final GroupRecommendationRepository groupRecommendationRepository;
     private final GroupRecommendationCandidateRepository groupRecommendationCandidateRepository;
+    private final GroupRecommendationVoteRepository groupRecommendationVoteRepository;
     private final MenuItemRepository menuItemRepository;
     private final MenuIngredientRepository menuIngredientRepository;
     private final MenuRecommendationAlgorithmResolver menuRecommendationAlgorithmResolver;
@@ -180,6 +186,33 @@ public class GroupServiceImpl implements GroupService {
                 candidates.stream()
                         .map(candidate -> GroupRecommendationCandidateResult.from(candidate, 0))
                         .toList()
+        );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public GroupRecommendationResult getGroupRecommendation(Long groupId, Long sessionId) {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        validateActiveMembership(groupId, member.getId());
+
+        GroupRecommendation recommendation = groupRecommendationRepository.findByIdAndRoomId(sessionId, groupId)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_FOUND, sessionId));
+
+        return toGroupRecommendationResult(recommendation);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public GroupRecommendationCandidateListResult getGroupRecommendationCandidates(Long groupId, Long sessionId) {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        validateActiveMembership(groupId, member.getId());
+
+        GroupRecommendation recommendation = groupRecommendationRepository.findByIdAndRoomId(sessionId, groupId)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_FOUND, sessionId));
+
+        return new GroupRecommendationCandidateListResult(
+                recommendation.getId(),
+                toCandidateResults(recommendation)
         );
     }
 
@@ -424,6 +457,10 @@ public class GroupServiceImpl implements GroupService {
                 .stream()
                 .map(this::toMemberSummaryResult)
                 .toList();
+        GroupRecommendationResult activeRecommendation = groupRecommendationRepository
+                .findFirstByRoomIdAndStatusOrderByStartedAtDesc(groupId, GroupRecommendationStatus.OPEN)
+                .map(this::toGroupRecommendationResult)
+                .orElse(null);
 
         return new GroupDetailResult(
                 room.getId(),
@@ -432,8 +469,69 @@ public class GroupServiceImpl implements GroupService {
                 room.getLatitude(),
                 room.getLongitude(),
                 room.getStatus(),
-                members
+                members,
+                activeRecommendation
         );
+    }
+
+    private GroupRoomMember validateActiveMembership(Long groupId, Long memberId) {
+        return groupRoomMemberRepository.findActiveMembershipInNotDeletedRoom(groupId, memberId)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.ACCESS_DENIED, groupId));
+    }
+
+    private GroupRecommendationResult toGroupRecommendationResult(GroupRecommendation recommendation) {
+        List<GroupRecommendationCandidateResult> candidates = toCandidateResults(recommendation);
+        GroupRecommendationCandidateResult finalCandidate = recommendation.getSelectedCandidate() == null
+                ? null
+                : candidates.stream()
+                        .filter(candidate -> candidate.candidateId().equals(
+                                recommendation.getSelectedCandidate().getId()))
+                        .findFirst()
+                        .orElseGet(() -> GroupRecommendationCandidateResult.from(
+                                recommendation.getSelectedCandidate(),
+                                0
+                        ));
+
+        return new GroupRecommendationResult(
+                recommendation.getId(),
+                recommendation.getStatus(),
+                candidates,
+                toVoteProgress(recommendation),
+                finalCandidate,
+                recommendation.getCreatedAt()
+        );
+    }
+
+    private List<GroupRecommendationCandidateResult> toCandidateResults(GroupRecommendation recommendation) {
+        Map<Long, Integer> voteCountsByCandidateId = countVotesByCandidateId(recommendation.getId());
+
+        return groupRecommendationCandidateRepository
+                .findAllByGroupRecommendationIdOrderByRankNoAsc(recommendation.getId())
+                .stream()
+                .map(candidate -> GroupRecommendationCandidateResult.from(
+                        candidate,
+                        voteCountsByCandidateId.getOrDefault(candidate.getId(), 0)
+                ))
+                .toList();
+    }
+
+    private Map<Long, Integer> countVotesByCandidateId(Long recommendationId) {
+        return groupRecommendationVoteRepository.countVotesByCandidateId(recommendationId)
+                .stream()
+                .collect(Collectors.toMap(
+                        GroupCandidateVoteCountProjection::getCandidateId,
+                        projection -> projection.getVoteCount().intValue()
+                ));
+    }
+
+    private GroupVoteProgressResult toVoteProgress(GroupRecommendation recommendation) {
+        int totalMemberCount = groupRoomMemberRepository.findActiveMembersByRoomId(recommendation.getRoom().getId())
+                .size();
+        int votedMemberCount = Math.toIntExact(
+                groupRecommendationVoteRepository.countByGroupRecommendationId(recommendation.getId())
+        );
+
+        return new GroupVoteProgressResult(totalMemberCount, votedMemberCount);
     }
 
     private List<TasteProfileSnapshot> toTasteProfileSnapshots(List<GroupRoomMember> activeMembers) {

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -20,6 +20,7 @@ import javax.crypto.SecretKey;
 import matchuri.backend.domain.group.entity.GroupRecommendation;
 import matchuri.backend.domain.group.entity.GroupRecommendationCandidate;
 import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
+import matchuri.backend.domain.group.entity.GroupRecommendationVote;
 import matchuri.backend.domain.group.entity.GroupInvite;
 import matchuri.backend.domain.group.entity.GroupInviteStatus;
 import matchuri.backend.domain.group.entity.GroupMemberRole;
@@ -30,6 +31,7 @@ import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.repository.GroupInviteRepository;
 import matchuri.backend.domain.group.repository.GroupRecommendationCandidateRepository;
 import matchuri.backend.domain.group.repository.GroupRecommendationRepository;
+import matchuri.backend.domain.group.repository.GroupRecommendationVoteRepository;
 import matchuri.backend.domain.group.repository.GroupRoomMemberRepository;
 import matchuri.backend.domain.group.repository.GroupRoomRepository;
 import matchuri.backend.domain.member.entity.Member;
@@ -99,6 +101,9 @@ class GroupIntegrationTest {
     private GroupRecommendationCandidateRepository groupRecommendationCandidateRepository;
 
     @Autowired
+    private GroupRecommendationVoteRepository groupRecommendationVoteRepository;
+
+    @Autowired
     private MenuItemRepository menuItemRepository;
 
     @Autowired
@@ -136,6 +141,7 @@ class GroupIntegrationTest {
     }
 
     private void clearData() {
+        groupRecommendationVoteRepository.deleteAll();
         groupRecommendationCandidateRepository.deleteAll();
         groupRecommendationRepository.deleteAll();
         groupInviteRepository.deleteAll();
@@ -346,6 +352,162 @@ class GroupIntegrationTest {
         assertThat(groupRecommendationCandidateRepository.findAll())
                 .extracting(candidate -> candidate.getMenuItem().getId())
                 .doesNotContain(porkCutlet.getId());
+    }
+
+    @Test
+    @DisplayName("그룹 추천 상세 조회는 후보와 투표 진행률을 실제 저장값으로 반환한다")
+    void getGroupRecommendationReturnsStoredSession() throws Exception {
+        Member owner = saveMember("recommendation-view-owner", "조회방장");
+        Member member = saveMember("recommendation-view-member", "조회멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "추천 조회 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                member,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        MenuItem bibimbap = saveMenu("view-bibimbap", "비빔밥");
+        MenuItem gimbap = saveMenu("view-gimbap", "김밥");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+        GroupRecommendationCandidate firstCandidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, bibimbap, 1, 70.0, "{}")
+        );
+        GroupRecommendationCandidate secondCandidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, gimbap, 2, 30.0, "{}")
+        );
+        groupRecommendationVoteRepository.save(new GroupRecommendationVote(recommendation, firstCandidate, owner));
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}/recommendations/{sessionId}",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.sessionId").value(recommendation.getId()))
+                .andExpect(jsonPath("$.data.status").value(GroupRecommendationStatus.OPEN.name()))
+                .andExpect(jsonPath("$.data.candidates.length()").value(2))
+                .andExpect(jsonPath("$.data.candidates[0].candidateId").value(firstCandidate.getId()))
+                .andExpect(jsonPath("$.data.candidates[0].menuId").value(bibimbap.getId()))
+                .andExpect(jsonPath("$.data.candidates[0].menuName").value("비빔밥"))
+                .andExpect(jsonPath("$.data.candidates[0].rankNo").value(1))
+                .andExpect(jsonPath("$.data.candidates[0].score").value(70.0))
+                .andExpect(jsonPath("$.data.candidates[0].voteCount").value(1))
+                .andExpect(jsonPath("$.data.candidates[1].candidateId").value(secondCandidate.getId()))
+                .andExpect(jsonPath("$.data.candidates[1].voteCount").value(0))
+                .andExpect(jsonPath("$.data.voteProgress.totalMemberCount").value(2))
+                .andExpect(jsonPath("$.data.voteProgress.votedMemberCount").value(1))
+                .andExpect(jsonPath("$.data.finalCandidate").value(nullValue()))
+                .andExpect(jsonPath("$.data.createdAt").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("그룹 추천 후보 목록 조회는 후보별 투표 수를 반환한다")
+    void getGroupRecommendationCandidatesReturnsVoteCounts() throws Exception {
+        Member owner = saveMember("recommendation-candidates-owner", "후보방장");
+        Member member = saveMember("recommendation-candidates-member", "후보멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "후보 조회 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                member,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        MenuItem ramen = saveMenu("candidate-ramen", "라멘");
+        MenuItem udon = saveMenu("candidate-udon", "우동");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+        GroupRecommendationCandidate firstCandidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, ramen, 1, 10.0, "{}")
+        );
+        GroupRecommendationCandidate secondCandidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, udon, 2, 5.0, "{}")
+        );
+        groupRecommendationVoteRepository.save(new GroupRecommendationVote(recommendation, secondCandidate, owner));
+        groupRecommendationVoteRepository.save(new GroupRecommendationVote(recommendation, secondCandidate, member));
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}/recommendations/{sessionId}/candidates",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.sessionId").value(recommendation.getId()))
+                .andExpect(jsonPath("$.data.candidates.length()").value(2))
+                .andExpect(jsonPath("$.data.candidates[0].candidateId").value(firstCandidate.getId()))
+                .andExpect(jsonPath("$.data.candidates[0].voteCount").value(0))
+                .andExpect(jsonPath("$.data.candidates[1].candidateId").value(secondCandidate.getId()))
+                .andExpect(jsonPath("$.data.candidates[1].voteCount").value(2));
+    }
+
+    @Test
+    @DisplayName("그룹 추천 조회는 활성 멤버가 아니면 거절한다")
+    void getGroupRecommendationFailsForNonMember() throws Exception {
+        Member owner = saveMember("recommendation-view-denied-owner", "조회거절방장");
+        Member other = saveMember("recommendation-view-denied-other", "조회거절비멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "조회 거절 그룹");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}/recommendations/{sessionId}",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(other))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("GROUP_ACCESS_DENIED"));
+    }
+
+    @Test
+    @DisplayName("그룹 추천 조회는 추천이 해당 그룹에 속하지 않으면 찾을 수 없음으로 처리한다")
+    void getGroupRecommendationFailsWhenRecommendationDoesNotBelongToGroup() throws Exception {
+        Member owner = saveMember("recommendation-wrong-group-owner", "다른그룹방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "조회 대상 그룹");
+        GroupRoom otherGroupRoom = saveGroupOwnedBy(owner, "다른 추천 그룹");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                otherGroupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}/recommendations/{sessionId}",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("그룹 상세 조회는 열린 그룹 추천이 있으면 activeRecommendation을 반환한다")
+    void getGroupReturnsActiveRecommendation() throws Exception {
+        Member owner = saveMember("group-active-recommendation-owner", "활성추천방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "활성 추천 그룹");
+        MenuItem menuItem = saveMenu("active-rec-menu", "활성추천메뉴");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+        GroupRecommendationCandidate candidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, menuItem, 1, 20.0, "{}")
+        );
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.activeRecommendation.sessionId").value(recommendation.getId()))
+                .andExpect(jsonPath("$.data.activeRecommendation.status").value(GroupRecommendationStatus.OPEN.name()))
+                .andExpect(jsonPath("$.data.activeRecommendation.candidates[0].candidateId").value(candidate.getId()))
+                .andExpect(jsonPath("$.data.activeRecommendation.voteProgress.totalMemberCount").value(1))
+                .andExpect(jsonPath("$.data.activeRecommendation.voteProgress.votedMemberCount").value(0));
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
Closes #238 

## 📝 작업 내용

- `GET /groups/{groupId}/recommendations/{sessionId}` real 전환
- `GET /groups/{groupId}/recommendations/{sessionId}/candidates` real 전환
- 후보별 `voteCount`, `voteProgress` 계산
- 그룹 상세 조회의 `activeRecommendation` 연결
- 비멤버 접근, 다른 그룹 추천 조회 실패 테스트 추가

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 
