### PR TITLE
[Feat] 그룹 메뉴 추천 후보 투표 참여 API

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -494,13 +494,15 @@ public interface GroupApi {
     );
 
     @Operation(
-            summary = "그룹 추천 후보 투표 (Mock API)",
+            summary = "그룹 추천 후보 투표",
             description = """
                     그룹 추천 후보에 투표합니다.
 
-                    Mock API 상태:
-                    - request body validation만 수행합니다.
-                    - 중복 투표, 후보 소속, 세션 상태 검증은 아직 수행하지 않습니다.
+                    정책:
+                    - 활성 그룹 멤버만 투표할 수 있습니다.
+                    - 열린 그룹 추천(`OPEN`)에만 투표할 수 있습니다.
+                    - 회원은 추천 세션당 한 번만 투표할 수 있습니다.
+                    - `voteValue`는 사용하지 않고 후보 선택 여부만 저장합니다.
                     - 실제 저장 테이블은 `group_recommendation_votes` 기준입니다.
                     """
     )

--- a/src/main/java/matchuri/backend/api/group/GroupController.java
+++ b/src/main/java/matchuri/backend/api/group/GroupController.java
@@ -49,6 +49,7 @@ import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
 import matchuri.backend.domain.group.result.GroupRecommendationCandidateListResult;
 import matchuri.backend.domain.group.result.GroupRecommendationResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
+import matchuri.backend.domain.group.result.GroupVoteResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
 import matchuri.backend.domain.group.result.LeaveGroupResult;
 import matchuri.backend.domain.group.result.RespondGroupInviteResult;
@@ -251,7 +252,10 @@ public class GroupController implements GroupApi {
             @PathVariable Long sessionId,
             @Valid @RequestBody VoteGroupRecommendationRequest request
     ) {
-        return ApiResponse.success(GroupVoteResponse.mockVoted(request.candidateId(), request.voteValue()));
+        GroupVoteResult result = groupService.voteGroupRecommendation(groupId, sessionId, request.candidateId());
+        GroupVoteResponse response = groupMapper.toGroupVoteResponse(result);
+
+        return ApiResponse.success(response);
     }
 
     @Override

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -23,6 +23,7 @@ import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateRespo
 import matchuri.backend.api.group.dto.response.GroupRecommendationSessionResponse;
 import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupVoteProgressResponse;
+import matchuri.backend.api.group.dto.response.GroupVoteResponse;
 import matchuri.backend.api.group.dto.response.JoinGroupResponse;
 import matchuri.backend.api.group.dto.response.LeaveGroupResponse;
 import matchuri.backend.api.group.dto.response.RespondGroupInviteResponse;
@@ -51,6 +52,7 @@ import matchuri.backend.domain.group.result.GroupRecommendationCandidateResult;
 import matchuri.backend.domain.group.result.GroupRecommendationResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.result.GroupVoteProgressResult;
+import matchuri.backend.domain.group.result.GroupVoteResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
 import matchuri.backend.domain.group.result.LeaveGroupResult;
 import matchuri.backend.domain.group.result.RespondGroupInviteResult;
@@ -258,6 +260,14 @@ public class GroupMapper {
                 result.candidates().stream()
                         .map(this::toGroupRecommendationCandidateResponse)
                         .toList()
+        );
+    }
+
+    public GroupVoteResponse toGroupVoteResponse(GroupVoteResult result) {
+        return new GroupVoteResponse(
+                result.voteId(),
+                result.candidateId(),
+                result.votedAt()
         );
     }
 

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -325,7 +325,6 @@ public final class GroupApiExamples {
               "data": {
                 "voteId": 91001,
                 "candidateId": 8001,
-                "voteValue": 1,
                 "votedAt": "2026-05-06T12:20:00"
               },
               "error": null

--- a/src/main/java/matchuri/backend/api/group/dto/request/VoteGroupRecommendationRequest.java
+++ b/src/main/java/matchuri/backend/api/group/dto/request/VoteGroupRecommendationRequest.java
@@ -1,8 +1,6 @@
 package matchuri.backend.api.group.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
@@ -10,12 +8,6 @@ public record VoteGroupRecommendationRequest(
         @Schema(description = "투표할 그룹 추천 후보 ID입니다.", example = "8001")
         @NotNull(message = "candidateId는 null일 수 없습니다.")
         @Positive(message = "candidateId는 양수여야 합니다.")
-        Long candidateId,
-
-        @Schema(description = "투표 값입니다. MVP에서는 1=찬성, 0=비선호로 사용합니다.", example = "1")
-        @NotNull(message = "voteValue는 null일 수 없습니다.")
-        @Min(value = 0, message = "voteValue는 0 또는 1이어야 합니다.")
-        @Max(value = 1, message = "voteValue는 0 또는 1이어야 합니다.")
-        Integer voteValue
+        Long candidateId
 ) {
 }

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupVoteResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupVoteResponse.java
@@ -10,18 +10,7 @@ public record GroupVoteResponse(
         @Schema(description = "투표한 후보 ID입니다.", example = "8001")
         Long candidateId,
 
-        @Schema(description = "투표 값입니다.", example = "1")
-        Integer voteValue,
-
         @Schema(description = "투표 시각입니다.", example = "2026-05-06T12:20:00")
         LocalDateTime votedAt
 ) {
-    public static GroupVoteResponse mockVoted(Long candidateId, Integer voteValue) {
-        return new GroupVoteResponse(
-                91001L,
-                candidateId,
-                voteValue,
-                LocalDateTime.of(2026, 5, 6, 12, 20)
-        );
-    }
 }

--- a/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
@@ -36,7 +36,9 @@ public enum GroupErrorCode implements ErrorCode {
     RECOMMENDATION_OPEN_EXISTS(HttpStatus.CONFLICT, "이미 열린 그룹 추천이 있습니다. groupId : {0}"),
     RECOMMENDATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 그룹 추천을 찾을 수 없습니다. sessionId : {0}"),
     RECOMMENDATION_NOT_OPEN(HttpStatus.CONFLICT, "열린 상태의 그룹 추천이 아닙니다. sessionId : {0}"),
-    RECOMMENDATION_REROLL_FORBIDDEN(HttpStatus.FORBIDDEN, "그룹 추천 재요청 권한이 없습니다. groupId : {0}");
+    RECOMMENDATION_REROLL_FORBIDDEN(HttpStatus.FORBIDDEN, "그룹 추천 재요청 권한이 없습니다. groupId : {0}"),
+    RECOMMENDATION_CANDIDATE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 그룹 추천 후보를 찾을 수 없습니다. candidateId : {0}"),
+    RECOMMENDATION_ALREADY_VOTED(HttpStatus.CONFLICT, "이미 해당 그룹 추천에 투표했습니다. sessionId : {0}, memberId : {1}");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationCandidateRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationCandidateRepository.java
@@ -1,10 +1,13 @@
 package matchuri.backend.domain.group.repository;
 
 import java.util.List;
+import java.util.Optional;
 import matchuri.backend.domain.group.entity.GroupRecommendationCandidate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GroupRecommendationCandidateRepository extends JpaRepository<GroupRecommendationCandidate, Long> {
 
     List<GroupRecommendationCandidate> findAllByGroupRecommendationIdOrderByRankNoAsc(Long recommendationId);
+
+    Optional<GroupRecommendationCandidate> findByIdAndGroupRecommendationId(Long id, Long recommendationId);
 }

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationVoteRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationVoteRepository.java
@@ -19,4 +19,6 @@ public interface GroupRecommendationVoteRepository extends JpaRepository<GroupRe
     );
 
     long countByGroupRecommendationId(Long recommendationId);
+
+    boolean existsByGroupRecommendationIdAndMemberId(Long recommendationId, Long memberId);
 }

--- a/src/main/java/matchuri/backend/domain/group/result/GroupVoteResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupVoteResult.java
@@ -1,0 +1,10 @@
+package matchuri.backend.domain.group.result;
+
+import java.time.LocalDateTime;
+
+public record GroupVoteResult(
+        Long voteId,
+        Long candidateId,
+        LocalDateTime votedAt
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/service/GroupService.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupService.java
@@ -21,6 +21,7 @@ import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
 import matchuri.backend.domain.group.result.GroupRecommendationCandidateListResult;
 import matchuri.backend.domain.group.result.GroupRecommendationResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
+import matchuri.backend.domain.group.result.GroupVoteResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
 import matchuri.backend.domain.group.result.LeaveGroupResult;
 import matchuri.backend.domain.group.result.RespondGroupInviteResult;
@@ -43,6 +44,8 @@ public interface GroupService {
     GroupRecommendationResult getGroupRecommendation(Long groupId, Long sessionId);
 
     GroupRecommendationCandidateListResult getGroupRecommendationCandidates(Long groupId, Long sessionId);
+
+    GroupVoteResult voteGroupRecommendation(Long groupId, Long sessionId, Long candidateId);
 
     CreateNicknameGroupInviteResult createNicknameInvite(CreateNicknameGroupInviteCommand command);
 

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -254,6 +254,43 @@ public class GroupServiceImpl implements GroupService {
     }
 
     @Override
+    public GroupVoteResult voteGroupRecommendation(Long groupId, Long sessionId, Long candidateId) {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        validateActiveMembership(groupId, member.getId());
+
+        GroupRecommendation recommendation = groupRecommendationRepository.findByIdAndRoomId(sessionId, groupId)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_FOUND, sessionId));
+
+        if (recommendation.getStatus() != GroupRecommendationStatus.OPEN) {
+            throw new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_OPEN, sessionId);
+        }
+
+        GroupRecommendationCandidate candidate = groupRecommendationCandidateRepository
+                .findByIdAndGroupRecommendationId(candidateId, recommendation.getId())
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.RECOMMENDATION_CANDIDATE_NOT_FOUND,
+                        candidateId));
+
+        if (groupRecommendationVoteRepository.existsByGroupRecommendationIdAndMemberId(
+                recommendation.getId(),
+                member.getId()
+        )) {
+            throw new BusinessException(GroupErrorCode.RECOMMENDATION_ALREADY_VOTED, sessionId, member.getId());
+        }
+
+        GroupRecommendationVote vote = groupRecommendationVoteRepository.save(new GroupRecommendationVote(
+                recommendation,
+                candidate,
+                member
+        ));
+
+        return new GroupVoteResult(
+                vote.getId(),
+                candidate.getId(),
+                vote.getCreatedAt()
+        );
+    }
+
+    @Override
     public CreateNicknameGroupInviteResult createNicknameInvite(CreateNicknameGroupInviteCommand command) {
         Member requestMember = activeMemberReader.getCurrentAuthenticatedActiveMember();
         GroupRoom room = groupRoomRepository.findByIdAndStatusNot(command.groupId(), GroupRoomStatus.DELETED)

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -631,6 +631,185 @@ class GroupIntegrationTest {
     }
 
     @Test
+    @DisplayName("그룹 추천 투표는 활성 멤버의 후보 선택을 저장한다")
+    void voteGroupRecommendationStoresMemberVote() throws Exception {
+        Member owner = saveMember("recommendation-vote-owner", "투표방장");
+        Member member = saveMember("recommendation-vote-member", "투표멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "투표 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                member,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        MenuItem menuItem = saveMenu("vote-menu", "투표메뉴");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+        GroupRecommendationCandidate candidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, menuItem, 1, 10.0, "{}")
+        );
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations/{sessionId}/votes",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "candidateId": %d
+                                }
+                                """.formatted(candidate.getId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.voteId").isNumber())
+                .andExpect(jsonPath("$.data.candidateId").value(candidate.getId()))
+                .andExpect(jsonPath("$.data.voteValue").doesNotExist())
+                .andExpect(jsonPath("$.data.votedAt").isNotEmpty());
+
+        List<GroupRecommendationVote> votes = groupRecommendationVoteRepository.findAll();
+        assertThat(votes).hasSize(1);
+        assertThat(votes.getFirst().getGroupRecommendation().getId()).isEqualTo(recommendation.getId());
+        assertThat(votes.getFirst().getCandidate().getId()).isEqualTo(candidate.getId());
+        assertThat(votes.getFirst().getMember().getId()).isEqualTo(member.getId());
+    }
+
+    @Test
+    @DisplayName("그룹 추천 투표는 같은 회원의 중복 투표를 거절한다")
+    void voteGroupRecommendationFailsForDuplicateVote() throws Exception {
+        Member owner = saveMember("recommendation-dup-vote-owner", "중복투표방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "중복 투표 그룹");
+        MenuItem menuItem = saveMenu("dup-vote-menu", "중복투표메뉴");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+        GroupRecommendationCandidate candidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, menuItem, 1, 10.0, "{}")
+        );
+        groupRecommendationVoteRepository.save(new GroupRecommendationVote(recommendation, candidate, owner));
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations/{sessionId}/votes",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "candidateId": %d
+                                }
+                                """.formatted(candidate.getId())))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_ALREADY_VOTED"));
+
+        assertThat(groupRecommendationVoteRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("그룹 추천 투표는 다른 추천의 후보이면 찾을 수 없음으로 처리한다")
+    void voteGroupRecommendationFailsWhenCandidateBelongsToOtherRecommendation() throws Exception {
+        Member owner = saveMember("recommendation-wrong-candidate-owner", "후보다름방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "후보 소속 그룹");
+        MenuItem menuItem = saveMenu("wrong-candidate-menu", "후보다름메뉴");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+        GroupRecommendation otherRecommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+        GroupRecommendationCandidate otherCandidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(otherRecommendation, menuItem, 1, 10.0, "{}")
+        );
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations/{sessionId}/votes",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "candidateId": %d
+                                }
+                                """.formatted(otherCandidate.getId())))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_CANDIDATE_NOT_FOUND"));
+
+        assertThat(groupRecommendationVoteRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("그룹 추천 투표는 열린 상태가 아니면 거절한다")
+    void voteGroupRecommendationFailsForNotOpenRecommendation() throws Exception {
+        Member owner = saveMember("recommendation-vote-closed-owner", "투표종료방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "투표 종료 그룹");
+        MenuItem menuItem = saveMenu("vote-closed-menu", "투표종료메뉴");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+        GroupRecommendationCandidate candidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, menuItem, 1, 10.0, "{}")
+        );
+        recommendation.rerollWithoutSkip(LocalDateTime.now());
+        groupRecommendationRepository.save(recommendation);
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations/{sessionId}/votes",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "candidateId": %d
+                                }
+                                """.formatted(candidate.getId())))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_NOT_OPEN"));
+
+        assertThat(groupRecommendationVoteRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("그룹 추천 투표는 활성 멤버가 아니면 거절한다")
+    void voteGroupRecommendationFailsForNonMember() throws Exception {
+        Member owner = saveMember("recommendation-vote-access-owner", "투표접근방장");
+        Member other = saveMember("recommendation-vote-access-other", "투표접근없음");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "투표 접근 그룹");
+        MenuItem menuItem = saveMenu("vote-access-menu", "투표접근메뉴");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+        GroupRecommendationCandidate candidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, menuItem, 1, 10.0, "{}")
+        );
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations/{sessionId}/votes",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(other)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "candidateId": %d
+                                }
+                                """.formatted(candidate.getId())))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("GROUP_ACCESS_DENIED"));
+
+        assertThat(groupRecommendationVoteRepository.count()).isZero();
+    }
+
+    @Test
     @DisplayName("그룹 추천 조회는 활성 멤버가 아니면 거절한다")
     void getGroupRecommendationFailsForNonMember() throws Exception {
         Member owner = saveMember("recommendation-view-denied-owner", "조회거절방장");

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -401,8 +401,11 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/candidates'].get.responses['200'].content['application/json'].examples.success.value.data.candidates[1].menuName")
                         .value("돈까스"))
                 .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/votes'].post.responses['200'].content['application/json'].examples.success.value.data.candidateId")
+                        .value(8001))
+                .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/votes'].post.responses['200'].content['application/json'].examples.success.value.data.voteValue")
-                        .value(1))
+                        .doesNotExist())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/finalize'].patch.responses['200'].content['application/json'].examples.success.value.data.finalCandidate.menuName")
                         .value("비빔밥"));


### PR DESCRIPTION
## 관련 이슈
Closes #240 

## 📝 작업 내용
- `POST /api/v1/groups/{groupId}/recommendations/{sessionId}/votes` 구현
- 활성 그룹 멤버 검증, 추천 OPEN 상태 검증, 후보 소속 검증, 중복 투표 방지 추가
- 신규 에러: `GROUP_RECOMMENDATION_CANDIDATE_NOT_FOUND`, `GROUP_RECOMMENDATION_ALREADY_VOTED`
- OpenAPI 예시와 문서 상태를 투표 API real 기준으로 갱신

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 그룹의 ACTIVE 멤버만 가능
- OPEN 상태의 그룹 추천에만 가능
- 투표는 번복이 없으며 하나의 후보에만 선택 가능