### PR TITLE
[Feat] 그룹 메뉴 추천 최종 확정 API

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -523,13 +523,16 @@ public interface GroupApi {
     ApiResponse<GroupVoteResponse> vote(Long groupId, Long sessionId, @Valid VoteGroupRecommendationRequest request);
 
     @Operation(
-            summary = "그룹 추천 최종 메뉴 확정 (Mock API)",
+            summary = "그룹 추천 최종 메뉴 확정",
             description = """
                     투표 결과를 바탕으로 그룹의 최종 메뉴를 확정합니다.
 
-                    Mock API 상태:
-                    - 실제 투표 집계와 동률 처리 정책은 아직 수행하지 않습니다.
-                    - 항상 1순위 후보를 최종 후보로 반환합니다.
+                    정책:
+                    - 해당 그룹의 `ACTIVE` `OWNER` 멤버만 최종 확정할 수 있습니다.
+                    - 최다 득표 후보를 최종 후보로 저장합니다.
+                    - 동률이면 추천 순위 `rankNo`가 가장 낮은 후보를 선택합니다.
+                    - 투표가 0건이면 `rankNo=1` 후보를 선택합니다.
+                    - 확정 후 그룹 추천 상태는 `FINALIZED`가 됩니다.
                     """
     )
     @ApiResponses({

--- a/src/main/java/matchuri/backend/api/group/GroupController.java
+++ b/src/main/java/matchuri/backend/api/group/GroupController.java
@@ -44,6 +44,7 @@ import matchuri.backend.domain.group.result.CreateGroupResult;
 import matchuri.backend.domain.group.result.CreateGroupRecommendationResult;
 import matchuri.backend.domain.group.result.CreateNicknameGroupInviteResult;
 import matchuri.backend.domain.group.result.DeleteGroupResult;
+import matchuri.backend.domain.group.result.FinalizeGroupRecommendationResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
 import matchuri.backend.domain.group.result.GroupRecommendationCandidateListResult;
@@ -264,6 +265,8 @@ public class GroupController implements GroupApi {
             @PathVariable Long groupId,
             @PathVariable Long sessionId
     ) {
-        return ApiResponse.success(FinalizeGroupRecommendationResponse.mockFinalized());
+        FinalizeGroupRecommendationResult result = groupService.finalizeGroupRecommendation(groupId, sessionId);
+
+        return ApiResponse.success(groupMapper.toFinalizeGroupRecommendationResponse(result));
     }
 }

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -15,6 +15,7 @@ import matchuri.backend.api.group.dto.response.CreateNicknameGroupInviteResponse
 import matchuri.backend.api.group.dto.response.CreateGroupResponse;
 import matchuri.backend.api.group.dto.response.CreateGroupRecommendationResponse;
 import matchuri.backend.api.group.dto.response.DeleteGroupResponse;
+import matchuri.backend.api.group.dto.response.FinalizeGroupRecommendationResponse;
 import matchuri.backend.api.group.dto.response.GroupDetailResponse;
 import matchuri.backend.api.group.dto.response.GroupInviteSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupMemberSummaryResponse;
@@ -44,6 +45,7 @@ import matchuri.backend.domain.group.result.CreateGroupResult;
 import matchuri.backend.domain.group.result.CreateGroupRecommendationResult;
 import matchuri.backend.domain.group.result.CreateNicknameGroupInviteResult;
 import matchuri.backend.domain.group.result.DeleteGroupResult;
+import matchuri.backend.domain.group.result.FinalizeGroupRecommendationResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
 import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
@@ -268,6 +270,17 @@ public class GroupMapper {
                 result.voteId(),
                 result.candidateId(),
                 result.votedAt()
+        );
+    }
+
+    public FinalizeGroupRecommendationResponse toFinalizeGroupRecommendationResponse(
+            FinalizeGroupRecommendationResult result
+    ) {
+        return new FinalizeGroupRecommendationResponse(
+                result.sessionId(),
+                result.status(),
+                toGroupRecommendationCandidateResponse(result.finalCandidate()),
+                result.finalizedAt()
         );
     }
 

--- a/src/main/java/matchuri/backend/api/group/dto/response/FinalizeGroupRecommendationResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/FinalizeGroupRecommendationResponse.java
@@ -17,12 +17,4 @@ public record FinalizeGroupRecommendationResponse(
         @Schema(description = "최종 확정 시각입니다.", example = "2026-05-06T12:25:00")
         LocalDateTime finalizedAt
 ) {
-    public static FinalizeGroupRecommendationResponse mockFinalized() {
-        return new FinalizeGroupRecommendationResponse(
-                5001L,
-                GroupRecommendationStatus.FINALIZED,
-                GroupRecommendationCandidateResponse.mockBibimbap(),
-                LocalDateTime.of(2026, 5, 6, 12, 25)
-        );
-    }
 }

--- a/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
@@ -38,7 +38,9 @@ public enum GroupErrorCode implements ErrorCode {
     RECOMMENDATION_NOT_OPEN(HttpStatus.CONFLICT, "열린 상태의 그룹 추천이 아닙니다. sessionId : {0}"),
     RECOMMENDATION_REROLL_FORBIDDEN(HttpStatus.FORBIDDEN, "그룹 추천 재요청 권한이 없습니다. groupId : {0}"),
     RECOMMENDATION_CANDIDATE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 그룹 추천 후보를 찾을 수 없습니다. candidateId : {0}"),
-    RECOMMENDATION_ALREADY_VOTED(HttpStatus.CONFLICT, "이미 해당 그룹 추천에 투표했습니다. sessionId : {0}, memberId : {1}");
+    RECOMMENDATION_ALREADY_VOTED(HttpStatus.CONFLICT, "이미 해당 그룹 추천에 투표했습니다. sessionId : {0}, memberId : {1}"),
+    RECOMMENDATION_FINALIZE_FORBIDDEN(HttpStatus.FORBIDDEN, "그룹 추천 최종 확정 권한이 없습니다. groupId : {0}"),
+    RECOMMENDATION_NO_CANDIDATES(HttpStatus.CONFLICT, "최종 확정할 그룹 추천 후보가 없습니다. sessionId : {0}");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/matchuri/backend/domain/group/result/FinalizeGroupRecommendationResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/FinalizeGroupRecommendationResult.java
@@ -1,0 +1,12 @@
+package matchuri.backend.domain.group.result;
+
+import java.time.LocalDateTime;
+import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
+
+public record FinalizeGroupRecommendationResult(
+        Long sessionId,
+        GroupRecommendationStatus status,
+        GroupRecommendationCandidateResult finalCandidate,
+        LocalDateTime finalizedAt
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/service/GroupService.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupService.java
@@ -16,6 +16,7 @@ import matchuri.backend.domain.group.result.CreateGroupResult;
 import matchuri.backend.domain.group.result.CreateGroupRecommendationResult;
 import matchuri.backend.domain.group.result.CreateNicknameGroupInviteResult;
 import matchuri.backend.domain.group.result.DeleteGroupResult;
+import matchuri.backend.domain.group.result.FinalizeGroupRecommendationResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
 import matchuri.backend.domain.group.result.GroupRecommendationCandidateListResult;
@@ -46,6 +47,8 @@ public interface GroupService {
     GroupRecommendationCandidateListResult getGroupRecommendationCandidates(Long groupId, Long sessionId);
 
     GroupVoteResult voteGroupRecommendation(Long groupId, Long sessionId, Long candidateId);
+
+    FinalizeGroupRecommendationResult finalizeGroupRecommendation(Long groupId, Long sessionId);
 
     CreateNicknameGroupInviteResult createNicknameInvite(CreateNicknameGroupInviteCommand command);
 

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -291,6 +291,45 @@ public class GroupServiceImpl implements GroupService {
     }
 
     @Override
+    public FinalizeGroupRecommendationResult finalizeGroupRecommendation(Long groupId, Long sessionId) {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        GroupRoomMember membership = validateActiveMembership(groupId, member.getId());
+
+        if (!membership.isOwner()) {
+            throw new BusinessException(GroupErrorCode.RECOMMENDATION_FINALIZE_FORBIDDEN, groupId);
+        }
+
+        GroupRecommendation recommendation = groupRecommendationRepository.findByIdAndRoomId(sessionId, groupId)
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_FOUND, sessionId));
+
+        if (recommendation.getStatus() != GroupRecommendationStatus.OPEN) {
+            throw new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_OPEN, sessionId);
+        }
+
+        List<GroupRecommendationCandidate> candidates = groupRecommendationCandidateRepository
+                .findAllByGroupRecommendationIdOrderByRankNoAsc(recommendation.getId());
+
+        if (candidates.isEmpty()) {
+            throw new BusinessException(GroupErrorCode.RECOMMENDATION_NO_CANDIDATES, sessionId);
+        }
+
+        Map<Long, Integer> voteCountsByCandidateId = countVotesByCandidateId(recommendation.getId());
+        GroupRecommendationCandidate selectedCandidate = selectFinalCandidate(candidates, voteCountsByCandidateId);
+        LocalDateTime finalizedAt = LocalDateTime.now();
+        recommendation.finalizeWith(selectedCandidate, finalizedAt);
+
+        return new FinalizeGroupRecommendationResult(
+                recommendation.getId(),
+                recommendation.getStatus(),
+                GroupRecommendationCandidateResult.from(
+                        selectedCandidate,
+                        voteCountsByCandidateId.getOrDefault(selectedCandidate.getId(), 0)
+                ),
+                finalizedAt
+        );
+    }
+
+    @Override
     public CreateNicknameGroupInviteResult createNicknameInvite(CreateNicknameGroupInviteCommand command) {
         Member requestMember = activeMemberReader.getCurrentAuthenticatedActiveMember();
         GroupRoom room = groupRoomRepository.findByIdAndStatusNot(command.groupId(), GroupRoomStatus.DELETED)
@@ -596,6 +635,26 @@ public class GroupServiceImpl implements GroupService {
                         GroupCandidateVoteCountProjection::getCandidateId,
                         projection -> projection.getVoteCount().intValue()
                 ));
+    }
+
+    private GroupRecommendationCandidate selectFinalCandidate(
+            List<GroupRecommendationCandidate> candidates,
+            Map<Long, Integer> voteCountsByCandidateId
+    ) {
+        return candidates.stream()
+                .max((left, right) -> {
+                    int voteComparison = Integer.compare(
+                            voteCountsByCandidateId.getOrDefault(left.getId(), 0),
+                            voteCountsByCandidateId.getOrDefault(right.getId(), 0)
+                    );
+
+                    if (voteComparison != 0) {
+                        return voteComparison;
+                    }
+
+                    return Integer.compare(right.getRankNo(), left.getRankNo());
+                })
+                .orElseThrow();
     }
 
     private GroupVoteProgressResult toVoteProgress(GroupRecommendation recommendation) {

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -70,6 +70,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -83,6 +84,9 @@ class GroupIntegrationTest {
 
     @Autowired
     private MatchuriProperties matchuriProperties;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
 
     @Autowired
     private MemberRepository memberRepository;
@@ -146,6 +150,7 @@ class GroupIntegrationTest {
     }
 
     private void clearData() {
+        jdbcTemplate.update("update group_recommendations set selected_candidate_id = null");
         groupMenuActionRepository.deleteAll();
         groupRecommendationVoteRepository.deleteAll();
         groupRecommendationCandidateRepository.deleteAll();
@@ -805,6 +810,245 @@ class GroupIntegrationTest {
                                 """.formatted(candidate.getId())))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.error.code").value("GROUP_ACCESS_DENIED"));
+
+        assertThat(groupRecommendationVoteRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("그룹 추천 최종 확정은 OWNER가 최다 득표 후보를 저장한다")
+    void finalizeGroupRecommendationSelectsMostVotedCandidateForOwner() throws Exception {
+        Member owner = saveMember("recommendation-finalize-owner", "확정방장");
+        Member member = saveMember("recommendation-finalize-member", "확정멤버");
+        Member anotherMember = saveMember("recommendation-finalize-another", "확정멤버둘");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "확정 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(groupRoom, member, GroupMemberRole.MEMBER, LocalDateTime.now()));
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                anotherMember,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        MenuItem bibimbap = saveMenu("finalize-bibimbap", "확정비빔밥");
+        MenuItem gimbap = saveMenu("finalize-gimbap", "확정김밥");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+        GroupRecommendationCandidate firstCandidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, bibimbap, 1, 70.0, "{}")
+        );
+        GroupRecommendationCandidate secondCandidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, gimbap, 2, 60.0, "{}")
+        );
+        groupRecommendationVoteRepository.save(new GroupRecommendationVote(recommendation, firstCandidate, owner));
+        groupRecommendationVoteRepository.save(new GroupRecommendationVote(recommendation, secondCandidate, member));
+        groupRecommendationVoteRepository.save(new GroupRecommendationVote(recommendation, secondCandidate,
+                anotherMember));
+
+        mockMvc.perform(patch("/api/v1/groups/{groupId}/recommendations/{sessionId}/finalize",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.sessionId").value(recommendation.getId()))
+                .andExpect(jsonPath("$.data.status").value(GroupRecommendationStatus.FINALIZED.name()))
+                .andExpect(jsonPath("$.data.finalCandidate.candidateId").value(secondCandidate.getId()))
+                .andExpect(jsonPath("$.data.finalCandidate.menuId").value(gimbap.getId()))
+                .andExpect(jsonPath("$.data.finalCandidate.rankNo").value(2))
+                .andExpect(jsonPath("$.data.finalCandidate.voteCount").value(2))
+                .andExpect(jsonPath("$.data.finalizedAt").isNotEmpty());
+
+        GroupRecommendation finalizedRecommendation =
+                groupRecommendationRepository.findById(recommendation.getId()).orElseThrow();
+        assertThat(finalizedRecommendation.getStatus()).isEqualTo(GroupRecommendationStatus.FINALIZED);
+        assertThat(finalizedRecommendation.getSelectedCandidate().getId()).isEqualTo(secondCandidate.getId());
+        assertThat(finalizedRecommendation.getEndedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("그룹 추천 최종 확정은 동률이면 추천 순위가 높은 후보를 저장한다")
+    void finalizeGroupRecommendationBreaksVoteTieByRankNo() throws Exception {
+        Member owner = saveMember("recommendation-finalize-tie-owner", "동률확정방장");
+        Member member = saveMember("recommendation-finalize-tie-member", "동률확정멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "동률 확정 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                member,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        MenuItem firstMenu = saveMenu("finalize-tie-first", "동률첫번째");
+        MenuItem secondMenu = saveMenu("finalize-tie-second", "동률두번째");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+        GroupRecommendationCandidate firstCandidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, firstMenu, 1, 70.0, "{}")
+        );
+        GroupRecommendationCandidate secondCandidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, secondMenu, 2, 70.0, "{}")
+        );
+        groupRecommendationVoteRepository.save(new GroupRecommendationVote(recommendation, firstCandidate, owner));
+        groupRecommendationVoteRepository.save(new GroupRecommendationVote(recommendation, secondCandidate, member));
+
+        mockMvc.perform(patch("/api/v1/groups/{groupId}/recommendations/{sessionId}/finalize",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.finalCandidate.candidateId").value(firstCandidate.getId()))
+                .andExpect(jsonPath("$.data.finalCandidate.rankNo").value(1))
+                .andExpect(jsonPath("$.data.finalCandidate.voteCount").value(1));
+    }
+
+    @Test
+    @DisplayName("그룹 추천 최종 확정은 투표가 없으면 1순위 후보를 저장한다")
+    void finalizeGroupRecommendationSelectsRankOneWhenNoVotes() throws Exception {
+        Member owner = saveMember("recommendation-finalize-no-vote-owner", "무투표확정방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "무투표 확정 그룹");
+        MenuItem firstMenu = saveMenu("finalize-no-vote-first", "무투표첫번째");
+        MenuItem secondMenu = saveMenu("finalize-no-vote-second", "무투표두번째");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+        GroupRecommendationCandidate firstCandidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, firstMenu, 1, 70.0, "{}")
+        );
+        groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, secondMenu, 2, 60.0, "{}")
+        );
+
+        mockMvc.perform(patch("/api/v1/groups/{groupId}/recommendations/{sessionId}/finalize",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.finalCandidate.candidateId").value(firstCandidate.getId()))
+                .andExpect(jsonPath("$.data.finalCandidate.voteCount").value(0));
+    }
+
+    @Test
+    @DisplayName("그룹 추천 최종 확정은 OWNER가 아닌 활성 멤버이면 거절한다")
+    void finalizeGroupRecommendationFailsForNonOwnerMember() throws Exception {
+        Member owner = saveMember("recommendation-finalize-forbidden-owner", "확정권한방장");
+        Member member = saveMember("recommendation-finalize-forbidden-member", "확정권한멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "확정 권한 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                member,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        MenuItem menuItem = saveMenu("finalize-forbidden-menu", "확정권한메뉴");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+        groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, menuItem, 1, 10.0, "{}")
+        );
+
+        mockMvc.perform(patch("/api/v1/groups/{groupId}/recommendations/{sessionId}/finalize",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_FINALIZE_FORBIDDEN"));
+
+        assertThat(groupRecommendationRepository.findById(recommendation.getId()).orElseThrow().getStatus())
+                .isEqualTo(GroupRecommendationStatus.OPEN);
+    }
+
+    @Test
+    @DisplayName("그룹 추천 최종 확정은 열린 상태가 아니면 거절한다")
+    void finalizeGroupRecommendationFailsForNotOpenRecommendation() throws Exception {
+        Member owner = saveMember("recommendation-finalize-closed-owner", "확정종료방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "확정 종료 그룹");
+        MenuItem menuItem = saveMenu("finalize-closed-menu", "확정종료메뉴");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+        GroupRecommendationCandidate candidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, menuItem, 1, 10.0, "{}")
+        );
+        recommendation.finalizeWith(candidate, LocalDateTime.now());
+        groupRecommendationRepository.save(recommendation);
+
+        mockMvc.perform(patch("/api/v1/groups/{groupId}/recommendations/{sessionId}/finalize",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_NOT_OPEN"));
+    }
+
+    @Test
+    @DisplayName("그룹 추천 최종 확정은 후보가 없으면 거절한다")
+    void finalizeGroupRecommendationFailsWhenNoCandidates() throws Exception {
+        Member owner = saveMember("recommendation-finalize-empty-owner", "후보없음방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "후보 없음 그룹");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+
+        mockMvc.perform(patch("/api/v1/groups/{groupId}/recommendations/{sessionId}/finalize",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_NO_CANDIDATES"));
+
+        assertThat(groupRecommendationRepository.findById(recommendation.getId()).orElseThrow().getStatus())
+                .isEqualTo(GroupRecommendationStatus.OPEN);
+    }
+
+    @Test
+    @DisplayName("확정된 그룹 추천에는 더 이상 투표할 수 없다")
+    void voteGroupRecommendationFailsAfterFinalized() throws Exception {
+        Member owner = saveMember("recommendation-vote-finalized-owner", "확정후투표방장");
+        Member member = saveMember("recommendation-vote-finalized-member", "확정후투표멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "확정 후 투표 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                member,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        MenuItem menuItem = saveMenu("vote-finalized-menu", "확정후투표메뉴");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+        GroupRecommendationCandidate candidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, menuItem, 1, 10.0, "{}")
+        );
+        recommendation.finalizeWith(candidate, LocalDateTime.now());
+        groupRecommendationRepository.save(recommendation);
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations/{sessionId}/votes",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "candidateId": %d
+                                }
+                                """.formatted(candidate.getId())))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_NOT_OPEN"));
 
         assertThat(groupRecommendationVoteRepository.count()).isZero();
     }


### PR DESCRIPTION
## 관련 이슈
Closes #241 

## 📝 작업 내용

- `PATCH /api/v1/groups/{groupId}/recommendations/{sessionId}/finalize` 구현
- `OWNER` 역할의 활성 그룹원만 최종 확정 가능
- 최다 득표 후보를 `selectedCandidate`로 저장하고 상태를 `FINALIZED`로 전환
- 동률이면 `rankNo`가 낮은 후보 우선
- 투표 0건이면 `rankNo=1` 후보 확정
- 후보 없음, 비OPEN 상태, 권한 없음 실패 케이스 추가
- 확정 후 투표 거절 테스트 추가
- 문서에서 최종 확정 API 상태를 real로 갱신

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
