### PR TITLE
[Feat] 그룹 메뉴 추천 리스트 조회 API

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -20,6 +20,7 @@ import matchuri.backend.api.group.dto.docs.GroupDetailApiResponse;
 import matchuri.backend.api.group.dto.docs.GroupInviteSummaryPageApiResponse;
 import matchuri.backend.api.group.dto.docs.GroupRecommendationCandidateListApiResponse;
 import matchuri.backend.api.group.dto.docs.GroupRecommendationSessionApiResponse;
+import matchuri.backend.api.group.dto.docs.GroupRecommendationSummaryPageApiResponse;
 import matchuri.backend.api.group.dto.docs.GroupSummaryPageApiResponse;
 import matchuri.backend.api.group.dto.docs.GroupVoteApiResponse;
 import matchuri.backend.api.group.dto.docs.JoinGroupApiResponse;
@@ -43,6 +44,7 @@ import matchuri.backend.api.group.dto.response.GroupDetailResponse;
 import matchuri.backend.api.group.dto.response.GroupInviteSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateListResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationSessionResponse;
+import matchuri.backend.api.group.dto.response.GroupRecommendationSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupVoteResponse;
 import matchuri.backend.api.group.dto.response.JoinGroupResponse;
@@ -400,6 +402,47 @@ public interface GroupApi {
     ApiResponse<CreateGroupRecommendationResponse> createRecommendation(
             Long groupId,
             @Valid CreateGroupRecommendationRequest request
+    );
+
+    @Operation(
+            summary = "그룹 추천 요청 리스트 조회",
+            description = """
+                    특정 그룹 방에서 생성된 그룹 추천 요청 목록을 조회합니다.
+
+                    구현 기준:
+                    - 로그인한 활성 회원만 사용할 수 있습니다.
+                    - 현재 회원이 해당 그룹의 `ACTIVE` 멤버일 때만 조회할 수 있습니다.
+                    - 삭제된 그룹은 조회할 수 없습니다.
+                    - 응답은 `sessionId`, `status`, `startedAt`, `endedAt`만 포함하는 얇은 summary입니다.
+                    - `finalCandidate`, `finalMenuName`, `voteProgress`, `status` 필터는 1차 범위에서 제외합니다.
+                    - 최신순(`startedAt DESC`, `id DESC`)으로 정렬합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = GroupRecommendationSummaryPageApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = GroupApiExamples.RECOMMENDATION_LIST_SUCCESS
+                            )
+                    )
+            )
+    })
+    ApiResponse<PageResponse<GroupRecommendationSummaryResponse>> getRecommendations(
+            Long groupId,
+
+            @Parameter(description = "0부터 시작하는 페이지 번호입니다.", example = "0")
+            @Min(0)
+            Integer page,
+
+            @Parameter(description = "페이지 크기입니다. 기본값은 20입니다.", example = "20")
+            @Min(1)
+            @Max(100)
+            Integer size
     );
 
     @Operation(

--- a/src/main/java/matchuri/backend/api/group/GroupController.java
+++ b/src/main/java/matchuri/backend/api/group/GroupController.java
@@ -22,6 +22,7 @@ import matchuri.backend.api.group.dto.response.GroupDetailResponse;
 import matchuri.backend.api.group.dto.response.GroupInviteSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateListResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationSessionResponse;
+import matchuri.backend.api.group.dto.response.GroupRecommendationSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupVoteResponse;
 import matchuri.backend.api.group.dto.response.JoinGroupResponse;
@@ -49,6 +50,7 @@ import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
 import matchuri.backend.domain.group.result.GroupRecommendationCandidateListResult;
 import matchuri.backend.domain.group.result.GroupRecommendationResult;
+import matchuri.backend.domain.group.result.GroupRecommendationSummaryResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.result.GroupVoteResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
@@ -203,6 +205,24 @@ public class GroupController implements GroupApi {
         CreateGroupRecommendationResult result = groupService.createGroupRecommendation(command);
 
         return ApiResponse.success(groupMapper.toCreateGroupRecommendationResponse(result));
+    }
+
+    @Override
+    @GetMapping("/{groupId}/recommendations")
+    public ApiResponse<PageResponse<GroupRecommendationSummaryResponse>> getRecommendations(
+            @PathVariable Long groupId,
+            @Min(0) @RequestParam(defaultValue = "0")
+            Integer page,
+
+            @Min(1) @Max(100) @RequestParam(defaultValue = "20")
+            Integer size
+    ) {
+        Page<GroupRecommendationSummaryResult> results =
+                groupService.getGroupRecommendations(groupId, page, size);
+        PageResponse<GroupRecommendationSummaryResponse> response =
+                PageResponse.of(results, groupMapper::toGroupRecommendationSummaryResponse);
+
+        return ApiResponse.success(response);
     }
 
     @Override

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -22,6 +22,7 @@ import matchuri.backend.api.group.dto.response.GroupMemberSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateListResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationSessionResponse;
+import matchuri.backend.api.group.dto.response.GroupRecommendationSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupVoteProgressResponse;
 import matchuri.backend.api.group.dto.response.GroupVoteResponse;
@@ -52,6 +53,7 @@ import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
 import matchuri.backend.domain.group.result.GroupRecommendationCandidateListResult;
 import matchuri.backend.domain.group.result.GroupRecommendationCandidateResult;
 import matchuri.backend.domain.group.result.GroupRecommendationResult;
+import matchuri.backend.domain.group.result.GroupRecommendationSummaryResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.result.GroupVoteProgressResult;
 import matchuri.backend.domain.group.result.GroupVoteResult;
@@ -262,6 +264,17 @@ public class GroupMapper {
                 result.candidates().stream()
                         .map(this::toGroupRecommendationCandidateResponse)
                         .toList()
+        );
+    }
+
+    public GroupRecommendationSummaryResponse toGroupRecommendationSummaryResponse(
+            GroupRecommendationSummaryResult result
+    ) {
+        return new GroupRecommendationSummaryResponse(
+                result.sessionId(),
+                result.status(),
+                result.startedAt(),
+                result.endedAt()
         );
     }
 

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -240,6 +240,39 @@ public final class GroupApiExamples {
             }
             """;
 
+    public static final String RECOMMENDATION_LIST_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "content": [
+                  {
+                    "sessionId": 5002,
+                    "status": "OPEN",
+                    "startedAt": "2026-05-26T12:20:00",
+                    "endedAt": null
+                  },
+                  {
+                    "sessionId": 5001,
+                    "status": "FINALIZED",
+                    "startedAt": "2026-05-26T12:00:00",
+                    "endedAt": "2026-05-26T12:15:00"
+                  }
+                ],
+                "pageInfo": {
+                  "page": 0,
+                  "size": 20,
+                  "totalElements": 2,
+                  "totalPages": 1,
+                  "first": true,
+                  "last": true,
+                  "hasNext": false,
+                  "hasPrevious": false
+                }
+              },
+              "error": null
+            }
+            """;
+
     public static final String RECOMMENDATION_SESSION_SUCCESS = """
             {
               "success": true,

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupRecommendationSummaryPageApiResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupRecommendationSummaryPageApiResponse.java
@@ -1,0 +1,12 @@
+package matchuri.backend.api.group.dto.docs;
+
+import matchuri.backend.api.group.dto.response.GroupRecommendationSummaryResponse;
+import matchuri.backend.global.api.ErrorResponse;
+import matchuri.backend.global.api.PageResponse;
+
+public record GroupRecommendationSummaryPageApiResponse(
+        boolean success,
+        PageResponse<GroupRecommendationSummaryResponse> data,
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationSummaryResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationSummaryResponse.java
@@ -1,0 +1,20 @@
+package matchuri.backend.api.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
+
+public record GroupRecommendationSummaryResponse(
+        @Schema(description = "그룹 추천 ID입니다. API 경로에서는 sessionId로 표현합니다.", example = "5001")
+        Long sessionId,
+
+        @Schema(description = "그룹 추천 상태입니다.", example = "FINALIZED")
+        GroupRecommendationStatus status,
+
+        @Schema(description = "추천 시작 시각입니다.", example = "2026-05-26T12:00:00")
+        LocalDateTime startedAt,
+
+        @Schema(description = "추천 종료 시각입니다. OPEN이면 null입니다.", example = "2026-05-26T12:15:00")
+        LocalDateTime endedAt
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationRepository.java
@@ -3,6 +3,8 @@ package matchuri.backend.domain.group.repository;
 import java.util.Optional;
 import matchuri.backend.domain.group.entity.GroupRecommendation;
 import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GroupRecommendationRepository extends JpaRepository<GroupRecommendation, Long> {
@@ -15,4 +17,6 @@ public interface GroupRecommendationRepository extends JpaRepository<GroupRecomm
             Long roomId,
             GroupRecommendationStatus status
     );
+
+    Page<GroupRecommendation> findByRoomIdOrderByStartedAtDescIdDesc(Long roomId, Pageable pageable);
 }

--- a/src/main/java/matchuri/backend/domain/group/result/GroupRecommendationSummaryResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupRecommendationSummaryResult.java
@@ -1,0 +1,21 @@
+package matchuri.backend.domain.group.result;
+
+import java.time.LocalDateTime;
+import matchuri.backend.domain.group.entity.GroupRecommendation;
+import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
+
+public record GroupRecommendationSummaryResult(
+        Long sessionId,
+        GroupRecommendationStatus status,
+        LocalDateTime startedAt,
+        LocalDateTime endedAt
+) {
+    public static GroupRecommendationSummaryResult from(GroupRecommendation recommendation) {
+        return new GroupRecommendationSummaryResult(
+                recommendation.getId(),
+                recommendation.getStatus(),
+                recommendation.getStartedAt(),
+                recommendation.getEndedAt()
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/domain/group/service/GroupService.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupService.java
@@ -21,6 +21,7 @@ import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
 import matchuri.backend.domain.group.result.GroupRecommendationCandidateListResult;
 import matchuri.backend.domain.group.result.GroupRecommendationResult;
+import matchuri.backend.domain.group.result.GroupRecommendationSummaryResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.result.GroupVoteResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
@@ -45,6 +46,8 @@ public interface GroupService {
     GroupRecommendationResult getGroupRecommendation(Long groupId, Long sessionId);
 
     GroupRecommendationCandidateListResult getGroupRecommendationCandidates(Long groupId, Long sessionId);
+
+    Page<GroupRecommendationSummaryResult> getGroupRecommendations(Long groupId, int page, int size);
 
     GroupVoteResult voteGroupRecommendation(Long groupId, Long sessionId, Long candidateId);
 

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -254,6 +254,18 @@ public class GroupServiceImpl implements GroupService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public Page<@NonNull GroupRecommendationSummaryResult> getGroupRecommendations(Long groupId, int page, int size) {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        GroupRoom room = getActiveGroupRoom(groupId);
+        validateActiveMembership(room.getId(), member.getId());
+
+        return groupRecommendationRepository
+                .findByRoomIdOrderByStartedAtDescIdDesc(room.getId(), PageRequest.of(page, size))
+                .map(GroupRecommendationSummaryResult::from);
+    }
+
+    @Override
     public GroupVoteResult voteGroupRecommendation(Long groupId, Long sessionId, Long candidateId) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
         validateActiveMembership(groupId, member.getId());

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -636,6 +636,104 @@ class GroupIntegrationTest {
     }
 
     @Test
+    @DisplayName("그룹 추천 요청 목록 조회는 그룹별 추천 summary를 최신순 페이지로 반환한다")
+    void getGroupRecommendationsReturnsSummariesByGroup() throws Exception {
+        Member owner = saveMember("recommendation-list-owner", "목록방장");
+        Member member = saveMember("recommendation-list-member", "목록멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "추천 목록 그룹");
+        GroupRoom otherGroupRoom = saveGroupOwnedBy(owner, "다른 추천 목록 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                member,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        GroupRecommendation oldRecommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.of(2026, 5, 26, 12, 0)
+        ));
+        oldRecommendation.rerollWithoutSkip(LocalDateTime.of(2026, 5, 26, 12, 15));
+        groupRecommendationRepository.save(oldRecommendation);
+        GroupRecommendation latestRecommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.of(2026, 5, 26, 12, 30)
+        ));
+        groupRecommendationRepository.save(new GroupRecommendation(
+                otherGroupRoom,
+                "{}",
+                LocalDateTime.of(2026, 5, 26, 13, 0)
+        ));
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}/recommendations", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member)))
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.content.length()").value(2))
+                .andExpect(jsonPath("$.data.content[0].sessionId").value(latestRecommendation.getId()))
+                .andExpect(jsonPath("$.data.content[0].status").value(GroupRecommendationStatus.OPEN.name()))
+                .andExpect(jsonPath("$.data.content[0].startedAt").value("2026-05-26T12:30:00"))
+                .andExpect(jsonPath("$.data.content[0].endedAt").value(nullValue()))
+                .andExpect(jsonPath("$.data.content[0].finalCandidate").doesNotExist())
+                .andExpect(jsonPath("$.data.content[0].finalMenuName").doesNotExist())
+                .andExpect(jsonPath("$.data.content[0].voteProgress").doesNotExist())
+                .andExpect(jsonPath("$.data.content[1].sessionId").value(oldRecommendation.getId()))
+                .andExpect(jsonPath("$.data.content[1].status")
+                        .value(GroupRecommendationStatus.REROLLED_WITHOUT_SKIP.name()))
+                .andExpect(jsonPath("$.data.content[1].endedAt").value("2026-05-26T12:15:00"))
+                .andExpect(jsonPath("$.data.pageInfo.totalElements").value(2))
+                .andExpect(jsonPath("$.data.pageInfo.totalPages").value(1));
+    }
+
+    @Test
+    @DisplayName("그룹 추천 요청 목록 조회는 비멤버이면 거절한다")
+    void getGroupRecommendationsFailsForNonMember() throws Exception {
+        Member owner = saveMember("recommendation-list-denied-owner", "목록거절방장");
+        Member other = saveMember("recommendation-list-denied-other", "목록거절비멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "목록 거절 그룹");
+        groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}/recommendations", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(other))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("GROUP_ACCESS_DENIED"));
+    }
+
+    @Test
+    @DisplayName("그룹 추천 요청 목록 조회는 삭제된 그룹이면 찾을 수 없음으로 처리한다")
+    void getGroupRecommendationsFailsForDeletedGroup() throws Exception {
+        Member owner = saveMember("recommendation-list-deleted-owner", "목록삭제방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "목록 삭제 그룹");
+        groupRoom.delete();
+        groupRoomRepository.save(groupRoom);
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}/recommendations", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("GROUP_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("그룹 추천 요청 목록 조회는 페이지 크기가 허용 범위를 넘으면 실패한다")
+    void getGroupRecommendationsFailsWithInvalidPageSize() throws Exception {
+        Member owner = saveMember("recommendation-list-invalid-page-owner", "목록페이지방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "목록 페이지 그룹");
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}/recommendations", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .param("size", "101"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
     @DisplayName("그룹 추천 투표는 활성 멤버의 후보 선택을 저장한다")
     void voteGroupRecommendationStoresMemberVote() throws Exception {
         Member owner = saveMember("recommendation-vote-owner", "투표방장");

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -392,6 +392,15 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/groups/{groupId}/recommendations'].post.responses['200'].content['application/json'].examples.success.value.data.candidates[0].candidateId")
                         .value(8001))
                 .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendations'].get.responses['200'].content['application/json'].examples.success.value.data.content[0].sessionId")
+                        .value(5002))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendations'].get.responses['200'].content['application/json'].examples.success.value.data.content[0].finalCandidate")
+                        .doesNotExist())
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendations'].get.responses['200'].content['application/json'].examples.success.value.data.content[0].voteProgress")
+                        .doesNotExist())
+                .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}'].get.responses['200'].content['application/json'].examples.success.value.data.finalCandidate")
                         .value((Object) null))
                 .andExpect(jsonPath(


### PR DESCRIPTION
## 관련 이슈
Closes #259 

## 📝 작업 내용

- `GET /api/v1/groups/{groupId}/recommendations` 추가
- 그룹별 추천 목록만 조회
- `status` 필터 없음
- 응답 필드: `sessionId`, `status`, `startedAt`, `endedAt`
- `finalCandidate`, `finalMenuName`, `voteProgress` 미포함
- 최신순 정렬: startedAt DESC, id DESC
- `ACTIVE` 그룹 멤버만 조회 가능

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
