### PR TITLE
[Refactor] 그룹 정보 수정시 응답값에 현재 open 상태의 요청 id를 반환

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -266,6 +266,9 @@ public interface GroupApi {
                     - 요청에는 최소 1개 이상의 지원 필드가 포함되어야 합니다.
                     - 현재 회원이 해당 그룹의 `ACTIVE` OWNER 멤버일 때만 수정할 수 있습니다.
                     - 그룹이 `ACTIVE` 상태일 때만 수정할 수 있습니다.
+                    - 수정 시점에 열린 그룹 추천이 있으면 `openGroupRecommendationId`를 함께 반환합니다.
+                    - `openGroupRecommendationId`가 있으면 위치 변경 등을 반영하기 위해 해당 추천 ID로 `INPUT_CHANGED` 재요청을 이어갈 수 있습니다.
+                    - 진행 중인 그룹 추천이 없으면 `openGroupRecommendationId`는 `null`입니다.
                     """
     )
     @ApiResponses({

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -199,7 +199,8 @@ public class GroupMapper {
                 result.latitude(),
                 result.longitude(),
                 result.status(),
-                result.updatedAt()
+                result.updatedAt(),
+                result.openGroupRecommendationId()
         );
     }
 

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -101,7 +101,8 @@ public final class GroupApiExamples {
                 "latitude": 37.498095,
                 "longitude": 127.027610,
                 "status": "ACTIVE",
-                "updatedAt": "2026-05-18T12:30:00"
+                "updatedAt": "2026-05-18T12:30:00",
+                "openGroupRecommendationId": 5001
               },
               "error": null
             }

--- a/src/main/java/matchuri/backend/api/group/dto/response/UpdateGroupResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/UpdateGroupResponse.java
@@ -22,6 +22,13 @@ public record UpdateGroupResponse(
         GroupRoomStatus status,
 
         @Schema(description = "수정 시각입니다.", example = "2026-05-18T12:30:00")
-        LocalDateTime updatedAt
+        LocalDateTime updatedAt,
+
+        @Schema(
+                description = "그룹 수정 시점에 INPUT_CHANGED 재요청으로 이어갈 수 있는 열린 그룹 추천 ID입니다. 없으면 null입니다.",
+                example = "5001",
+                nullable = true
+        )
+        Long openGroupRecommendationId
 ) {
 }

--- a/src/main/java/matchuri/backend/domain/group/result/UpdateGroupResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/UpdateGroupResult.java
@@ -10,6 +10,7 @@ public record UpdateGroupResult(
         BigDecimal latitude,
         BigDecimal longitude,
         GroupRoomStatus status,
-        LocalDateTime updatedAt
+        LocalDateTime updatedAt,
+        Long openGroupRecommendationId
 ) {
 }

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -485,13 +485,15 @@ public class GroupServiceImpl implements GroupService {
             room.updateName(command.name());
         }
 
-        if (command.latitude() != null) {
+        if (command.latitude() != null && command.longitude() != null) {
             room.updateLatitude(command.latitude());
-        }
-
-        if (command.longitude() != null) {
             room.updateLongitude(command.longitude());
         }
+
+        Long openGroupRecommendationId = groupRecommendationRepository
+                .findFirstByRoomIdAndStatusOrderByStartedAtDesc(room.getId(), GroupRecommendationStatus.OPEN)
+                .map(GroupRecommendation::getId)
+                .orElse(null);
 
         return new UpdateGroupResult(
                 room.getId(),
@@ -499,7 +501,8 @@ public class GroupServiceImpl implements GroupService {
                 room.getLatitude(),
                 room.getLongitude(),
                 room.getStatus(),
-                room.getUpdatedAt()
+                room.getUpdatedAt(),
+                openGroupRecommendationId
         );
     }
 

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -1360,10 +1360,36 @@ class GroupIntegrationTest {
                 .andExpect(jsonPath("$.data.latitude").value(nullValue()))
                 .andExpect(jsonPath("$.data.longitude").value(nullValue()))
                 .andExpect(jsonPath("$.data.status").value(GroupRoomStatus.ACTIVE.name()))
-                .andExpect(jsonPath("$.data.updatedAt").isNotEmpty());
+                .andExpect(jsonPath("$.data.updatedAt").isNotEmpty())
+                .andExpect(jsonPath("$.data.openGroupRecommendationId").value(nullValue()));
 
         assertThat(groupRoomRepository.findById(groupRoom.getId()).orElseThrow().getName())
                 .isEqualTo("수정 후 그룹");
+    }
+
+    @Test
+    @DisplayName("그룹 수정은 열린 그룹 추천이 있으면 재요청 가능한 추천 ID를 반환한다")
+    void updateGroupReturnsOpenGroupRecommendationId() throws Exception {
+        Member owner = saveMember("update-open-recommendation-owner", "열린추천수정방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "열린 추천 수정 그룹");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+
+        mockMvc.perform(patch("/api/v1/groups/{groupId}", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "latitude": 37.498095,
+                                  "longitude": 127.027610
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.groupId").value(groupRoom.getId()))
+                .andExpect(jsonPath("$.data.openGroupRecommendationId").value(recommendation.getId()));
     }
 
     @Test

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -389,6 +389,12 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/groups/{groupId}'].delete.responses['200'].content['application/json'].examples.success.value.data.status")
                         .value("DELETED"))
                 .andExpect(jsonPath(
+                        "$.components.schemas.UpdateGroupResponse.properties.openGroupRecommendationId.description")
+                        .value("그룹 수정 시점에 INPUT_CHANGED 재요청으로 이어갈 수 있는 열린 그룹 추천 ID입니다. 없으면 null입니다."))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}'].patch.responses['200'].content['application/json'].examples.success.value.data.openGroupRecommendationId")
+                        .value(5001))
+                .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}/recommendations'].post.responses['200'].content['application/json'].examples.success.value.data.candidates[0].candidateId")
                         .value(8001))
                 .andExpect(jsonPath(


### PR DESCRIPTION
## 관련 이슈
Closes #243 

## 📝 작업 내용

- `PATCH /api/v1/groups/{groupId}` 응답에 `openGroupRecommendationId` 추가
- 그룹 수정 성공 시 해당 그룹에 `OPEN` 그룹 추천이 있으면 그 ID 반환
- 없으면 `null`

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
