### PR TITLE
[Feat] 그룹원 준비 상태 추가 

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -377,14 +377,13 @@ public interface GroupApi {
     @Operation(
             summary = "그룹 추천 시작",
             description = """
-                    그룹 추천을 시작하고 후보 메뉴를 생성합니다.
+                    그룹 추천 준비 세션을 시작합니다.
 
                     - 로그인한 활성 회원만 사용할 수 있습니다.
                     - MVP에서는 해당 그룹의 `OWNER`만 시작할 수 있습니다.
-                    - 한 그룹에는 동시에 `OPEN` 그룹 추천을 1개만 허용합니다.
-                    - 그룹 활성 멤버의 취향 프로필을 모아 후보를 생성합니다.
-                    - 취향 프로필이 없는 멤버는 빈 취향으로 반영합니다.
-                    - 생성된 후보에는 추천 점수와 내부 메타데이터를 저장합니다.
+                    - 한 그룹에는 동시에 `PREPARING` 또는 `OPEN` 그룹 추천을 1개만 허용합니다.
+                    - 생성 직후 상태는 `PREPARING`이며, 후보는 아직 생성하지 않습니다.
+                    - 그룹원 준비 완료 API가 추가되면 모든 활성 멤버가 준비 완료한 시점에 후보를 생성하고 `OPEN`으로 전환합니다.
                     - API 경로는 사용자 흐름상 `recommendations`를 사용하며, 최신 저장 테이블은 `group_recommendations` 기준입니다.
                     """
     )
@@ -528,7 +527,7 @@ public interface GroupApi {
                             schema = @Schema(implementation = CreateGroupRecommendationApiResponse.class),
                             examples = @ExampleObject(
                                     name = "success",
-                                    value = GroupApiExamples.CREATE_RECOMMENDATION_SUCCESS
+                                    value = GroupApiExamples.REROLL_RECOMMENDATION_SUCCESS
                             )
                     )
             )

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -209,6 +209,18 @@ public final class GroupApiExamples {
               "success": true,
               "data": {
                 "sessionId": 5001,
+                "status": "PREPARING",
+                "candidates": []
+              },
+              "error": null
+            }
+            """;
+
+    public static final String REROLL_RECOMMENDATION_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "sessionId": 5001,
                 "status": "OPEN",
                 "candidates": [
                   {

--- a/src/main/java/matchuri/backend/api/group/dto/response/CreateGroupRecommendationResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/CreateGroupRecommendationResponse.java
@@ -8,10 +8,10 @@ public record CreateGroupRecommendationResponse(
         @Schema(description = "그룹 추천 ID입니다. API 경로에서는 sessionId로 표현합니다.", example = "5001")
         Long sessionId,
 
-        @Schema(description = "그룹 추천 상태입니다.", example = "OPEN")
+        @Schema(description = "그룹 추천 상태입니다.", example = "PREPARING")
         GroupRecommendationStatus status,
 
-        @Schema(description = "생성된 추천 후보 목록입니다.")
+        @Schema(description = "생성된 추천 후보 목록입니다. PREPARING 상태이면 빈 목록입니다.")
         List<GroupRecommendationCandidateResponse> candidates
 ) {
     public static CreateGroupRecommendationResponse mockOpen() {

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendation.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendation.java
@@ -59,6 +59,16 @@ public class GroupRecommendation extends BaseEntity {
         this.status = GroupRecommendationStatus.OPEN;
     }
 
+    public static GroupRecommendation preparing(GroupRoom room, String contextJson, LocalDateTime startedAt) {
+        GroupRecommendation recommendation = new GroupRecommendation(room, contextJson, startedAt);
+        recommendation.status = GroupRecommendationStatus.PREPARING;
+        return recommendation;
+    }
+
+    public void open() {
+        this.status = GroupRecommendationStatus.OPEN;
+    }
+
     public void finalizeWith(GroupRecommendationCandidate selectedCandidate, LocalDateTime endedAt) {
         this.status = GroupRecommendationStatus.FINALIZED;
         this.selectedCandidate = selectedCandidate;

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationReadiness.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationReadiness.java
@@ -1,0 +1,69 @@
+package matchuri.backend.domain.group.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import matchuri.backend.domain.common.BaseEntity;
+import matchuri.backend.domain.member.entity.Member;
+
+@Getter
+@Entity
+@Table(
+        name = "group_recommendation_readiness",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_group_recommendation_readiness_recommendation_member",
+                        columnNames = {"group_recommendation_id", "member_id"}
+                )
+        },
+        comment = "그룹 추천 준비 상태"
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GroupRecommendationReadiness extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(comment = "그룹 추천 준비 상태 ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "group_recommendation_id", nullable = false, comment = "그룹 추천 ID")
+    private GroupRecommendation groupRecommendation;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false, comment = "회원 ID")
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20, comment = "준비 상태")
+    private GroupRecommendationReadinessStatus status;
+
+    public GroupRecommendationReadiness(
+            GroupRecommendation groupRecommendation,
+            Member member
+    ) {
+        this.groupRecommendation = groupRecommendation;
+        this.member = member;
+        this.status = GroupRecommendationReadinessStatus.READY;
+    }
+
+    public void ready() {
+        this.status = GroupRecommendationReadinessStatus.READY;
+    }
+
+    public void cancel() {
+        this.status = GroupRecommendationReadinessStatus.CANCELED;
+    }
+}

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationReadinessStatus.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationReadinessStatus.java
@@ -1,0 +1,6 @@
+package matchuri.backend.domain.group.entity;
+
+public enum GroupRecommendationReadinessStatus {
+    READY,
+    CANCELED
+}

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationStatus.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationStatus.java
@@ -1,6 +1,7 @@
 package matchuri.backend.domain.group.entity;
 
 public enum GroupRecommendationStatus {
+    PREPARING,
     OPEN,
     FINALIZED,
     REROLLED_WITH_SKIP,

--- a/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
@@ -34,6 +34,7 @@ public enum GroupErrorCode implements ErrorCode {
     INVITE_CODE_GENERATION_FAILED(HttpStatus.CONFLICT, "그룹 고정 초대 코드 생성에 실패했습니다."),
     RECOMMENDATION_CREATE_FORBIDDEN(HttpStatus.FORBIDDEN, "그룹 추천 생성 권한이 없습니다. groupId : {0}"),
     RECOMMENDATION_OPEN_EXISTS(HttpStatus.CONFLICT, "이미 열린 그룹 추천이 있습니다. groupId : {0}"),
+    RECOMMENDATION_ACTIVE_EXISTS(HttpStatus.CONFLICT, "이미 진행 중인 그룹 추천이 있습니다. groupId : {0}"),
     RECOMMENDATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 그룹 추천을 찾을 수 없습니다. sessionId : {0}"),
     RECOMMENDATION_NOT_OPEN(HttpStatus.CONFLICT, "열린 상태의 그룹 추천이 아닙니다. sessionId : {0}"),
     RECOMMENDATION_REROLL_FORBIDDEN(HttpStatus.FORBIDDEN, "그룹 추천 재요청 권한이 없습니다. groupId : {0}"),

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationReadinessRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationReadinessRepository.java
@@ -1,0 +1,8 @@
+package matchuri.backend.domain.group.repository;
+
+import matchuri.backend.domain.group.entity.GroupRecommendationReadiness;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupRecommendationReadinessRepository
+        extends JpaRepository<GroupRecommendationReadiness, Long> {
+}

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationRepository.java
@@ -1,5 +1,6 @@
 package matchuri.backend.domain.group.repository;
 
+import java.util.Collection;
 import java.util.Optional;
 import matchuri.backend.domain.group.entity.GroupRecommendation;
 import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
@@ -10,6 +11,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface GroupRecommendationRepository extends JpaRepository<GroupRecommendation, Long> {
 
     boolean existsByRoomIdAndStatus(Long roomId, GroupRecommendationStatus status);
+
+    boolean existsByRoomIdAndStatusIn(Long roomId, Collection<GroupRecommendationStatus> statuses);
 
     Optional<GroupRecommendation> findByIdAndRoomId(Long id, Long roomId);
 

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -98,11 +98,21 @@ public class GroupServiceImpl implements GroupService {
             throw new BusinessException(GroupErrorCode.RECOMMENDATION_CREATE_FORBIDDEN, room.getId());
         }
 
-        if (groupRecommendationRepository.existsByRoomIdAndStatus(room.getId(), GroupRecommendationStatus.OPEN)) {
-            throw new BusinessException(GroupErrorCode.RECOMMENDATION_OPEN_EXISTS, room.getId());
+        if (hasActiveRecommendation(room.getId())) {
+            throw new BusinessException(GroupErrorCode.RECOMMENDATION_ACTIVE_EXISTS, room.getId());
         }
 
-        return createGroupRecommendation(room, command.contextJson(), recentlySkippedMenuIds(room.getId()));
+        GroupRecommendation recommendation = groupRecommendationRepository.save(GroupRecommendation.preparing(
+                room,
+                command.contextJson(),
+                LocalDateTime.now()
+        ));
+
+        return new CreateGroupRecommendationResult(
+                recommendation.getId(),
+                recommendation.getStatus(),
+                List.of()
+        );
     }
 
     @Override
@@ -138,10 +148,17 @@ public class GroupServiceImpl implements GroupService {
             throw new IllegalArgumentException("지원하지 않는 그룹 추천 재요청 타입입니다. rerollType=" + rerollType);
         }
 
-        return createGroupRecommendation(room, contextJson, recentlySkippedMenuIds(room.getId()));
+        return createOpenGroupRecommendation(room, contextJson, recentlySkippedMenuIds(room.getId()));
     }
 
-    private CreateGroupRecommendationResult createGroupRecommendation(
+    private boolean hasActiveRecommendation(Long roomId) {
+        return groupRecommendationRepository.existsByRoomIdAndStatusIn(
+                roomId,
+                List.of(GroupRecommendationStatus.PREPARING, GroupRecommendationStatus.OPEN)
+        );
+    }
+
+    private CreateGroupRecommendationResult createOpenGroupRecommendation(
             GroupRoom room,
             String contextJson,
             List<Long> excludedMenuIds

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -32,6 +32,7 @@ import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.repository.GroupInviteRepository;
 import matchuri.backend.domain.group.repository.GroupMenuActionRepository;
 import matchuri.backend.domain.group.repository.GroupRecommendationCandidateRepository;
+import matchuri.backend.domain.group.repository.GroupRecommendationReadinessRepository;
 import matchuri.backend.domain.group.repository.GroupRecommendationRepository;
 import matchuri.backend.domain.group.repository.GroupRecommendationVoteRepository;
 import matchuri.backend.domain.group.repository.GroupRoomMemberRepository;
@@ -110,6 +111,9 @@ class GroupIntegrationTest {
     private GroupRecommendationCandidateRepository groupRecommendationCandidateRepository;
 
     @Autowired
+    private GroupRecommendationReadinessRepository groupRecommendationReadinessRepository;
+
+    @Autowired
     private GroupRecommendationVoteRepository groupRecommendationVoteRepository;
 
     @Autowired
@@ -153,6 +157,7 @@ class GroupIntegrationTest {
         jdbcTemplate.update("update group_recommendations set selected_candidate_id = null");
         groupMenuActionRepository.deleteAll();
         groupRecommendationVoteRepository.deleteAll();
+        groupRecommendationReadinessRepository.deleteAll();
         groupRecommendationCandidateRepository.deleteAll();
         groupRecommendationRepository.deleteAll();
         groupInviteRepository.deleteAll();
@@ -234,15 +239,10 @@ class GroupIntegrationTest {
     }
 
     @Test
-    @DisplayName("그룹 추천 생성은 OWNER가 그룹 취향 기반 후보를 저장한다")
-    void createGroupRecommendationCreatesCandidatesForOwner() throws Exception {
+    @DisplayName("그룹 추천 생성은 OWNER가 준비 세션을 저장하고 후보는 아직 생성하지 않는다")
+    void createGroupRecommendationCreatesPreparingSessionForOwner() throws Exception {
         Member owner = saveMember("recommendation-owner", "추천방장");
         GroupRoom groupRoom = saveGroupOwnedBy(owner, "추천 그룹");
-        AttributeCategory spicy = saveCategory("spicy", "매콤한", 1);
-        MenuItem kimchiStew = saveMenu("kimchi-stew", "김치찌개", spicy);
-        saveMenu("salad", "샐러드");
-        saveMenu("gimbap", "김밥");
-        saveTasteProfile(owner, new AttributeCategory[]{spicy}, new Ingredient[]{}, new MenuItem[]{});
 
         mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations", groupRoom.getId())
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
@@ -257,27 +257,18 @@ class GroupIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.sessionId").isNumber())
-                .andExpect(jsonPath("$.data.status").value(GroupRecommendationStatus.OPEN.name()))
-                .andExpect(jsonPath("$.data.candidates.length()").value(3))
-                .andExpect(jsonPath("$.data.candidates[0].menuId").value(kimchiStew.getId()))
-                .andExpect(jsonPath("$.data.candidates[0].score").value(50.0))
-                .andExpect(jsonPath("$.data.candidates[0].voteCount").value(0));
+                .andExpect(jsonPath("$.data.status").value(GroupRecommendationStatus.PREPARING.name()))
+                .andExpect(jsonPath("$.data.candidates.length()").value(0));
 
         assertThat(groupRecommendationRepository.count()).isEqualTo(1);
-        assertThat(groupRecommendationCandidateRepository.count()).isEqualTo(3);
+        assertThat(groupRecommendationCandidateRepository.count()).isZero();
+        assertThat(groupRecommendationReadinessRepository.count()).isZero();
 
         GroupRecommendation savedRecommendation = groupRecommendationRepository.findAll().getFirst();
-        List<GroupRecommendationCandidate> candidates = groupRecommendationCandidateRepository.findAll();
 
         assertThat(savedRecommendation.getRoom().getId()).isEqualTo(groupRoom.getId());
-        assertThat(savedRecommendation.getStatus()).isEqualTo(GroupRecommendationStatus.OPEN);
+        assertThat(savedRecommendation.getStatus()).isEqualTo(GroupRecommendationStatus.PREPARING);
         assertThat(savedRecommendation.getContextJson()).contains("LUNCH");
-        assertThat(candidates)
-                .extracting(candidate -> candidate.getCandidateMetaJson())
-                .allSatisfy(candidateMetaJson -> {
-                    assertThat(candidateMetaJson).contains("GROUP");
-                    assertThat(candidateMetaJson).contains("scoreBreakdown");
-                });
     }
 
     @Test
@@ -308,10 +299,33 @@ class GroupIntegrationTest {
     }
 
     @Test
-    @DisplayName("그룹 추천 생성은 열린 그룹 추천이 있으면 거절한다")
-    void createGroupRecommendationFailsWhenOpenRecommendationExists() throws Exception {
+    @DisplayName("그룹 추천 생성은 진행 중인 그룹 추천이 있으면 거절한다")
+    void createGroupRecommendationFailsWhenActiveRecommendationExists() throws Exception {
         Member owner = saveMember("recommendation-open-owner", "열린추천방장");
         GroupRoom groupRoom = saveGroupOwnedBy(owner, "열린 추천 그룹");
+        groupRecommendationRepository.save(GroupRecommendation.preparing(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "contextJson": {}
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_ACTIVE_EXISTS"));
+    }
+
+    @Test
+    @DisplayName("그룹 추천 생성은 열린 그룹 추천이 있어도 진행 중으로 보고 거절한다")
+    void createGroupRecommendationFailsWhenOpenRecommendationExists() throws Exception {
+        Member owner = saveMember("recommendation-already-open-owner", "이미열린추천방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "이미 열린 추천 그룹");
         groupRecommendationRepository.save(new GroupRecommendation(
                 groupRoom,
                 "{}",
@@ -327,12 +341,12 @@ class GroupIntegrationTest {
                                 }
                                 """))
                 .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_OPEN_EXISTS"));
+                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_ACTIVE_EXISTS"));
     }
 
     @Test
-    @DisplayName("그룹 추천 생성은 한 명이라도 제한한 재료가 포함된 메뉴를 제외한다")
-    void createGroupRecommendationExcludesAnyRestrictedIngredient() throws Exception {
+    @DisplayName("그룹 추천 생성은 준비 세션만 만들기 때문에 제한 재료 후보 필터링을 아직 수행하지 않는다")
+    void createGroupRecommendationDoesNotGenerateCandidatesDuringPreparing() throws Exception {
         Member owner = saveMember("recommendation-restriction-owner", "제한방장");
         Member member = saveMember("recommendation-restriction-member", "제한멤버");
         GroupRoom groupRoom = saveGroupOwnedBy(owner, "제한 추천 그룹");
@@ -357,12 +371,13 @@ class GroupIntegrationTest {
                                 }
                                 """))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.candidates.length()").value(1))
-                .andExpect(jsonPath("$.data.candidates[0].menuId").value(bibimbap.getId()));
+                .andExpect(jsonPath("$.data.status").value(GroupRecommendationStatus.PREPARING.name()))
+                .andExpect(jsonPath("$.data.candidates.length()").value(0));
 
-        assertThat(groupRecommendationCandidateRepository.findAll())
-                .extracting(candidate -> candidate.getMenuItem().getId())
-                .doesNotContain(porkCutlet.getId());
+        assertThat(groupRecommendationCandidateRepository.findAll()).isEmpty();
+        assertThat(menuItemRepository.findAll())
+                .extracting(MenuItem::getId)
+                .contains(porkCutlet.getId(), bibimbap.getId());
     }
 
     @Test

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -396,7 +396,10 @@ class OpenApiDocumentationIntegrationTest {
                         .value(5001))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}/recommendations'].post.responses['200'].content['application/json'].examples.success.value.data.candidates[0].candidateId")
-                        .value(8001))
+                        .doesNotExist())
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendations'].post.responses['200'].content['application/json'].examples.success.value.data.status")
+                        .value("PREPARING"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}/recommendations'].get.responses['200'].content['application/json'].examples.success.value.data.content[0].sessionId")
                         .value(5002))


### PR DESCRIPTION
## 관련 이슈
Closes #262 

## 📝 작업 내용
- `GroupRecommendationStatus.PREPARING` 추가
- `GroupRecommendationReadiness` 엔티티 추가
- `POST /api/v1/groups/{groupId}/recommendations` 변경
    - 기존: 즉시 후보 생성 후 `OPEN`
    - 변경: `PREPARING` 세션 생성
- 같은 그룹에 `PREPARING` 또는 `OPEN` 세션이 있으면 `GROUP_RECOMMENDATION_ACTIVE_EXISTS`
- `reroll`은 기존처럼 새 `OPEN` 추천과 후보를 생성하도록 분리 유지


## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [x] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
