### PR TITLE
[Feat] 그룹 추천 준비 완료 API

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -25,6 +25,7 @@ import matchuri.backend.api.group.dto.docs.GroupSummaryPageApiResponse;
 import matchuri.backend.api.group.dto.docs.GroupVoteApiResponse;
 import matchuri.backend.api.group.dto.docs.JoinGroupApiResponse;
 import matchuri.backend.api.group.dto.docs.LeaveGroupApiResponse;
+import matchuri.backend.api.group.dto.docs.ReadyGroupRecommendationApiResponse;
 import matchuri.backend.api.group.dto.docs.RespondGroupInviteApiResponse;
 import matchuri.backend.api.group.dto.docs.UpdateGroupApiResponse;
 import matchuri.backend.api.group.dto.request.CreateGroupRecommendationRequest;
@@ -49,6 +50,7 @@ import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupVoteResponse;
 import matchuri.backend.api.group.dto.response.JoinGroupResponse;
 import matchuri.backend.api.group.dto.response.LeaveGroupResponse;
+import matchuri.backend.api.group.dto.response.ReadyGroupRecommendationResponse;
 import matchuri.backend.api.group.dto.response.RespondGroupInviteResponse;
 import matchuri.backend.api.group.dto.response.UpdateGroupResponse;
 import matchuri.backend.domain.group.entity.GroupInviteStatus;
@@ -503,6 +505,36 @@ public interface GroupApi {
             )
     })
     ApiResponse<GroupRecommendationCandidateListResponse> getRecommendationCandidates(Long groupId, Long sessionId);
+
+    @Operation(
+            summary = "그룹 추천 준비 완료",
+            description = """
+                    현재 회원이 그룹 추천 준비 세션에서 준비 완료 상태가 됩니다.
+
+                    구현 기준:
+                    - 로그인한 활성 회원만 사용할 수 있습니다.
+                    - 현재 회원이 해당 그룹의 `ACTIVE` 멤버일 때만 준비 완료할 수 있습니다.
+                    - source 그룹 추천은 해당 그룹에 속하고 `PREPARING` 상태여야 합니다.
+                    - 같은 회원의 중복 호출은 idempotent하게 `READY` 상태를 유지합니다.
+                    - 모든 현재 `ACTIVE` 그룹 멤버가 준비 완료하면 후보를 생성하고 세션을 `OPEN`으로 전환합니다.
+                    - 응답은 준비 진행률과, `OPEN` 전환 시 생성된 후보 목록을 함께 반환합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "준비 완료 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ReadyGroupRecommendationApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = GroupApiExamples.READY_RECOMMENDATION_SUCCESS
+                            )
+                    )
+            )
+    })
+    ApiResponse<ReadyGroupRecommendationResponse> readyRecommendation(Long groupId, Long sessionId);
 
     @Operation(
             summary = "그룹 추천 재요청",

--- a/src/main/java/matchuri/backend/api/group/GroupController.java
+++ b/src/main/java/matchuri/backend/api/group/GroupController.java
@@ -27,6 +27,7 @@ import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupVoteResponse;
 import matchuri.backend.api.group.dto.response.JoinGroupResponse;
 import matchuri.backend.api.group.dto.response.LeaveGroupResponse;
+import matchuri.backend.api.group.dto.response.ReadyGroupRecommendationResponse;
 import matchuri.backend.api.group.dto.response.RespondGroupInviteResponse;
 import matchuri.backend.api.group.dto.response.UpdateGroupResponse;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
@@ -55,6 +56,7 @@ import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.result.GroupVoteResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
 import matchuri.backend.domain.group.result.LeaveGroupResult;
+import matchuri.backend.domain.group.result.ReadyGroupRecommendationResult;
 import matchuri.backend.domain.group.result.RespondGroupInviteResult;
 import matchuri.backend.domain.group.result.UpdateGroupResult;
 import matchuri.backend.domain.group.service.GroupService;
@@ -246,6 +248,17 @@ public class GroupController implements GroupApi {
                 groupService.getGroupRecommendationCandidates(groupId, sessionId);
 
         return ApiResponse.success(groupMapper.toGroupRecommendationCandidateListResponse(result));
+    }
+
+    @Override
+    @PostMapping("/{groupId}/recommendations/{sessionId}/ready")
+    public ApiResponse<ReadyGroupRecommendationResponse> readyRecommendation(
+            @PathVariable Long groupId,
+            @PathVariable Long sessionId
+    ) {
+        ReadyGroupRecommendationResult result = groupService.readyGroupRecommendation(groupId, sessionId);
+
+        return ApiResponse.success(groupMapper.toReadyGroupRecommendationResponse(result));
     }
 
     @Override

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -23,12 +23,14 @@ import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateListR
 import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationSessionResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationSummaryResponse;
+import matchuri.backend.api.group.dto.response.GroupRecommendationReadinessProgressResponse;
 import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupVoteProgressResponse;
 import matchuri.backend.api.group.dto.response.GroupVoteResponse;
 import matchuri.backend.api.group.dto.response.JoinGroupResponse;
 import matchuri.backend.api.group.dto.response.LeaveGroupResponse;
 import matchuri.backend.api.group.dto.response.RespondGroupInviteResponse;
+import matchuri.backend.api.group.dto.response.ReadyGroupRecommendationResponse;
 import matchuri.backend.api.group.dto.response.UpdateGroupResponse;
 import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.CreateGroupRecommendationCommand;
@@ -54,12 +56,14 @@ import matchuri.backend.domain.group.result.GroupRecommendationCandidateListResu
 import matchuri.backend.domain.group.result.GroupRecommendationCandidateResult;
 import matchuri.backend.domain.group.result.GroupRecommendationResult;
 import matchuri.backend.domain.group.result.GroupRecommendationSummaryResult;
+import matchuri.backend.domain.group.result.GroupRecommendationReadinessProgressResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
 import matchuri.backend.domain.group.result.GroupVoteProgressResult;
 import matchuri.backend.domain.group.result.GroupVoteResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
 import matchuri.backend.domain.group.result.LeaveGroupResult;
 import matchuri.backend.domain.group.result.RespondGroupInviteResult;
+import matchuri.backend.domain.group.result.ReadyGroupRecommendationResult;
 import matchuri.backend.domain.group.result.UpdateGroupResult;
 import org.springframework.stereotype.Component;
 
@@ -279,6 +283,19 @@ public class GroupMapper {
         );
     }
 
+    public ReadyGroupRecommendationResponse toReadyGroupRecommendationResponse(
+            ReadyGroupRecommendationResult result
+    ) {
+        return new ReadyGroupRecommendationResponse(
+                result.sessionId(),
+                result.status(),
+                toGroupRecommendationReadinessProgressResponse(result.readiness()),
+                result.candidates().stream()
+                        .map(this::toGroupRecommendationCandidateResponse)
+                        .toList()
+        );
+    }
+
     public GroupVoteResponse toGroupVoteResponse(GroupVoteResult result) {
         return new GroupVoteResponse(
                 result.voteId(),
@@ -338,6 +355,16 @@ public class GroupMapper {
         return new GroupVoteProgressResponse(
                 result.totalMemberCount(),
                 result.votedMemberCount()
+        );
+    }
+
+    private GroupRecommendationReadinessProgressResponse toGroupRecommendationReadinessProgressResponse(
+            GroupRecommendationReadinessProgressResult result
+    ) {
+        return new GroupRecommendationReadinessProgressResponse(
+                result.totalMemberCount(),
+                result.readyMemberCount(),
+                result.allReady()
         );
     }
 

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -365,6 +365,23 @@ public final class GroupApiExamples {
             }
             """;
 
+    public static final String READY_RECOMMENDATION_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "sessionId": 5001,
+                "status": "PREPARING",
+                "readiness": {
+                  "totalMemberCount": 4,
+                  "readyMemberCount": 3,
+                  "allReady": false
+                },
+                "candidates": []
+              },
+              "error": null
+            }
+            """;
+
     public static final String VOTE_SUCCESS = """
             {
               "success": true,

--- a/src/main/java/matchuri/backend/api/group/dto/docs/ReadyGroupRecommendationApiResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/ReadyGroupRecommendationApiResponse.java
@@ -1,0 +1,11 @@
+package matchuri.backend.api.group.dto.docs;
+
+import matchuri.backend.api.group.dto.response.ReadyGroupRecommendationResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+public record ReadyGroupRecommendationApiResponse(
+        boolean success,
+        ReadyGroupRecommendationResponse data,
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationReadinessProgressResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationReadinessProgressResponse.java
@@ -1,0 +1,15 @@
+package matchuri.backend.api.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GroupRecommendationReadinessProgressResponse(
+        @Schema(description = "현재 준비 대상인 활성 그룹 멤버 수입니다.", example = "4")
+        int totalMemberCount,
+
+        @Schema(description = "준비 완료 상태인 활성 그룹 멤버 수입니다.", example = "3")
+        int readyMemberCount,
+
+        @Schema(description = "모든 현재 활성 그룹 멤버가 준비 완료했는지 여부입니다.", example = "false")
+        boolean allReady
+) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/response/ReadyGroupRecommendationResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/ReadyGroupRecommendationResponse.java
@@ -1,0 +1,20 @@
+package matchuri.backend.api.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
+
+public record ReadyGroupRecommendationResponse(
+        @Schema(description = "그룹 추천 ID입니다. API 경로에서는 sessionId로 표현합니다.", example = "5001")
+        Long sessionId,
+
+        @Schema(description = "그룹 추천 상태입니다. 전원 준비 완료 전에는 PREPARING, 전원 준비 완료 후에는 OPEN입니다.", example = "PREPARING")
+        GroupRecommendationStatus status,
+
+        @Schema(description = "그룹 추천 준비 진행 상태입니다.")
+        GroupRecommendationReadinessProgressResponse readiness,
+
+        @Schema(description = "전원 준비 완료로 OPEN 전환된 경우 생성된 추천 후보 목록입니다. 아직 PREPARING이면 빈 목록입니다.")
+        List<GroupRecommendationCandidateResponse> candidates
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
@@ -37,6 +37,7 @@ public enum GroupErrorCode implements ErrorCode {
     RECOMMENDATION_ACTIVE_EXISTS(HttpStatus.CONFLICT, "이미 진행 중인 그룹 추천이 있습니다. groupId : {0}"),
     RECOMMENDATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 그룹 추천을 찾을 수 없습니다. sessionId : {0}"),
     RECOMMENDATION_NOT_OPEN(HttpStatus.CONFLICT, "열린 상태의 그룹 추천이 아닙니다. sessionId : {0}"),
+    RECOMMENDATION_NOT_PREPARING(HttpStatus.CONFLICT, "준비 중인 그룹 추천이 아닙니다. sessionId : {0}"),
     RECOMMENDATION_REROLL_FORBIDDEN(HttpStatus.FORBIDDEN, "그룹 추천 재요청 권한이 없습니다. groupId : {0}"),
     RECOMMENDATION_CANDIDATE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 그룹 추천 후보를 찾을 수 없습니다. candidateId : {0}"),
     RECOMMENDATION_ALREADY_VOTED(HttpStatus.CONFLICT, "이미 해당 그룹 추천에 투표했습니다. sessionId : {0}, memberId : {1}"),

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationReadinessRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationReadinessRepository.java
@@ -1,8 +1,33 @@
 package matchuri.backend.domain.group.repository;
 
+import java.util.Optional;
 import matchuri.backend.domain.group.entity.GroupRecommendationReadiness;
+import matchuri.backend.domain.group.entity.GroupRecommendationReadinessStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface GroupRecommendationReadinessRepository
         extends JpaRepository<GroupRecommendationReadiness, Long> {
+
+    Optional<GroupRecommendationReadiness> findByGroupRecommendationIdAndMemberId(
+            Long groupRecommendationId,
+            Long memberId
+    );
+
+    @Query("""
+            select count(readiness)
+            from GroupRecommendationReadiness readiness
+            join GroupRoomMember groupMember
+              on groupMember.member.id = readiness.member.id
+             and groupMember.room.id = :roomId
+             and groupMember.status = matchuri.backend.domain.group.entity.GroupMemberStatus.ACTIVE
+            where readiness.groupRecommendation.id = :groupRecommendationId
+              and readiness.status = :status
+            """)
+    long countActiveMemberReadinessByRecommendationIdAndStatus(
+            @Param("groupRecommendationId") Long groupRecommendationId,
+            @Param("roomId") Long roomId,
+            @Param("status") GroupRecommendationReadinessStatus status
+    );
 }

--- a/src/main/java/matchuri/backend/domain/group/result/GroupRecommendationReadinessProgressResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupRecommendationReadinessProgressResult.java
@@ -1,0 +1,15 @@
+package matchuri.backend.domain.group.result;
+
+public record GroupRecommendationReadinessProgressResult(
+        int totalMemberCount,
+        int readyMemberCount,
+        boolean allReady
+) {
+    public static GroupRecommendationReadinessProgressResult of(int totalMemberCount, int readyMemberCount) {
+        return new GroupRecommendationReadinessProgressResult(
+                totalMemberCount,
+                readyMemberCount,
+                totalMemberCount > 0 && totalMemberCount == readyMemberCount
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/domain/group/result/ReadyGroupRecommendationResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/ReadyGroupRecommendationResult.java
@@ -1,0 +1,12 @@
+package matchuri.backend.domain.group.result;
+
+import java.util.List;
+import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
+
+public record ReadyGroupRecommendationResult(
+        Long sessionId,
+        GroupRecommendationStatus status,
+        GroupRecommendationReadinessProgressResult readiness,
+        List<GroupRecommendationCandidateResult> candidates
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/service/GroupService.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupService.java
@@ -27,6 +27,7 @@ import matchuri.backend.domain.group.result.GroupVoteResult;
 import matchuri.backend.domain.group.result.JoinGroupResult;
 import matchuri.backend.domain.group.result.LeaveGroupResult;
 import matchuri.backend.domain.group.result.RespondGroupInviteResult;
+import matchuri.backend.domain.group.result.ReadyGroupRecommendationResult;
 import matchuri.backend.domain.group.result.UpdateGroupResult;
 import org.springframework.data.domain.Page;
 
@@ -48,6 +49,8 @@ public interface GroupService {
     GroupRecommendationCandidateListResult getGroupRecommendationCandidates(Long groupId, Long sessionId);
 
     Page<GroupRecommendationSummaryResult> getGroupRecommendations(Long groupId, int page, int size);
+
+    ReadyGroupRecommendationResult readyGroupRecommendation(Long groupId, Long sessionId);
 
     GroupVoteResult voteGroupRecommendation(Long groupId, Long sessionId, Long candidateId);
 

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -61,6 +61,7 @@ public class GroupServiceImpl implements GroupService {
     private final GroupMenuActionRepository groupMenuActionRepository;
     private final GroupRecommendationRepository groupRecommendationRepository;
     private final GroupRecommendationCandidateRepository groupRecommendationCandidateRepository;
+    private final GroupRecommendationReadinessRepository groupRecommendationReadinessRepository;
     private final GroupRecommendationVoteRepository groupRecommendationVoteRepository;
     private final MenuItemRepository menuItemRepository;
     private final MenuIngredientRepository menuIngredientRepository;
@@ -148,7 +149,25 @@ public class GroupServiceImpl implements GroupService {
             throw new IllegalArgumentException("지원하지 않는 그룹 추천 재요청 타입입니다. rerollType=" + rerollType);
         }
 
-        return createOpenGroupRecommendation(room, contextJson, recentlySkippedMenuIds(room.getId()));
+        GroupRecommendation newRecommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                room,
+                contextJson,
+                LocalDateTime.now()
+        ));
+        List<GroupRecommendationCandidate> candidates = generateCandidatesForRecommendation(
+                room,
+                newRecommendation,
+                contextJson,
+                recentlySkippedMenuIds(room.getId())
+        );
+
+        return new CreateGroupRecommendationResult(
+                newRecommendation.getId(),
+                newRecommendation.getStatus(),
+                candidates.stream()
+                        .map(candidate -> GroupRecommendationCandidateResult.from(candidate, 0))
+                        .toList()
+        );
     }
 
     private boolean hasActiveRecommendation(Long roomId) {
@@ -158,8 +177,9 @@ public class GroupServiceImpl implements GroupService {
         );
     }
 
-    private CreateGroupRecommendationResult createOpenGroupRecommendation(
+    private List<GroupRecommendationCandidate> generateCandidatesForRecommendation(
             GroupRoom room,
+            GroupRecommendation recommendation,
             String contextJson,
             List<Long> excludedMenuIds
     ) {
@@ -182,24 +202,14 @@ public class GroupServiceImpl implements GroupService {
                 Map.of()
         ));
 
-        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
-                room,
-                contextJson,
-                LocalDateTime.now()
-        ));
         List<GroupRecommendationCandidate> candidates = saveGroupRecommendationCandidates(
                 recommendation,
                 recommendationResult,
                 menuItemById
         );
+        recommendation.open();
 
-        return new CreateGroupRecommendationResult(
-                recommendation.getId(),
-                recommendation.getStatus(),
-                candidates.stream()
-                        .map(candidate -> GroupRecommendationCandidateResult.from(candidate, 0))
-                        .toList()
-        );
+        return candidates;
     }
 
     private GroupRoom getActiveGroupRoom(Long groupId) {
@@ -280,6 +290,60 @@ public class GroupServiceImpl implements GroupService {
         return groupRecommendationRepository
                 .findByRoomIdOrderByStartedAtDescIdDesc(room.getId(), PageRequest.of(page, size))
                 .map(GroupRecommendationSummaryResult::from);
+    }
+
+    @Override
+    public ReadyGroupRecommendationResult readyGroupRecommendation(Long groupId, Long sessionId) {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        GroupRoom room = getActiveGroupRoom(groupId);
+        validateActiveMembership(room.getId(), member.getId());
+
+        GroupRecommendation recommendation = groupRecommendationRepository.findByIdAndRoomId(sessionId, room.getId())
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_FOUND, sessionId));
+
+        if (recommendation.getStatus() != GroupRecommendationStatus.PREPARING) {
+            throw new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_PREPARING, sessionId);
+        }
+
+        groupRecommendationReadinessRepository
+                .findByGroupRecommendationIdAndMemberId(recommendation.getId(), member.getId())
+                .ifPresentOrElse(
+                        GroupRecommendationReadiness::ready,
+                        () -> groupRecommendationReadinessRepository.save(new GroupRecommendationReadiness(
+                                recommendation,
+                                member
+                        ))
+                );
+
+        List<GroupRoomMember> activeMembers = groupRoomMemberRepository.findActiveMembersByRoomId(room.getId());
+        int totalMemberCount = activeMembers.size();
+        int readyMemberCount = Math.toIntExact(groupRecommendationReadinessRepository
+                .countActiveMemberReadinessByRecommendationIdAndStatus(
+                        recommendation.getId(),
+                        room.getId(),
+                        GroupRecommendationReadinessStatus.READY
+                ));
+        GroupRecommendationReadinessProgressResult readiness =
+                GroupRecommendationReadinessProgressResult.of(totalMemberCount, readyMemberCount);
+
+        List<GroupRecommendationCandidate> candidates = List.of();
+        if (readiness.allReady()) {
+            candidates = generateCandidatesForRecommendation(
+                    room,
+                    recommendation,
+                    recommendation.getContextJson(),
+                    recentlySkippedMenuIds(room.getId())
+            );
+        }
+
+        return new ReadyGroupRecommendationResult(
+                recommendation.getId(),
+                recommendation.getStatus(),
+                readiness,
+                candidates.stream()
+                        .map(candidate -> GroupRecommendationCandidateResult.from(candidate, 0))
+                        .toList()
+        );
     }
 
     @Override

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -19,6 +19,8 @@ import java.util.List;
 import javax.crypto.SecretKey;
 import matchuri.backend.domain.group.entity.GroupRecommendation;
 import matchuri.backend.domain.group.entity.GroupRecommendationCandidate;
+import matchuri.backend.domain.group.entity.GroupRecommendationReadiness;
+import matchuri.backend.domain.group.entity.GroupRecommendationReadinessStatus;
 import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
 import matchuri.backend.domain.group.entity.GroupRecommendationVote;
 import matchuri.backend.domain.group.entity.GroupInvite;
@@ -378,6 +380,166 @@ class GroupIntegrationTest {
         assertThat(menuItemRepository.findAll())
                 .extracting(MenuItem::getId)
                 .contains(porkCutlet.getId(), bibimbap.getId());
+    }
+
+    @Test
+    @DisplayName("그룹 추천 준비 완료는 현재 회원을 READY로 저장하고 아직 전원이 아니면 PREPARING을 유지한다")
+    void readyGroupRecommendationMarksMemberReadyBeforeAllMembersReady() throws Exception {
+        Member owner = saveMember("ready-owner", "준비방장");
+        Member member = saveMember("ready-member", "준비멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "준비 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                member,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        GroupRecommendation recommendation = groupRecommendationRepository.save(GroupRecommendation.preparing(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations/{sessionId}/ready",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.sessionId").value(recommendation.getId()))
+                .andExpect(jsonPath("$.data.status").value(GroupRecommendationStatus.PREPARING.name()))
+                .andExpect(jsonPath("$.data.readiness.totalMemberCount").value(2))
+                .andExpect(jsonPath("$.data.readiness.readyMemberCount").value(1))
+                .andExpect(jsonPath("$.data.readiness.allReady").value(false))
+                .andExpect(jsonPath("$.data.candidates.length()").value(0));
+
+        List<GroupRecommendationReadiness> readinesses = groupRecommendationReadinessRepository.findAll();
+        assertThat(readinesses).hasSize(1);
+        assertThat(readinesses.getFirst().getMember().getId()).isEqualTo(member.getId());
+        assertThat(readinesses.getFirst().getStatus()).isEqualTo(GroupRecommendationReadinessStatus.READY);
+        assertThat(groupRecommendationRepository.findById(recommendation.getId()).orElseThrow().getStatus())
+                .isEqualTo(GroupRecommendationStatus.PREPARING);
+    }
+
+    @Test
+    @DisplayName("그룹 추천 준비 완료는 중복 호출되어도 READY 상태를 유지한다")
+    void readyGroupRecommendationIsIdempotentForSameMember() throws Exception {
+        Member owner = saveMember("ready-idempotent-owner", "준비중복방장");
+        Member member = saveMember("ready-idempotent-member", "준비중복멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "준비 중복 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                member,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        GroupRecommendation recommendation = groupRecommendationRepository.save(GroupRecommendation.preparing(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations/{sessionId}/ready",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value(GroupRecommendationStatus.PREPARING.name()))
+                .andExpect(jsonPath("$.data.readiness.readyMemberCount").value(1));
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations/{sessionId}/ready",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value(GroupRecommendationStatus.PREPARING.name()))
+                .andExpect(jsonPath("$.data.readiness.readyMemberCount").value(1));
+
+        assertThat(groupRecommendationReadinessRepository.findAll()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("마지막 그룹원이 준비 완료하면 후보를 생성하고 그룹 추천을 OPEN으로 전환한다")
+    void readyGroupRecommendationOpensAndCreatesCandidatesWhenAllMembersReady() throws Exception {
+        Member owner = saveMember("ready-open-owner", "준비오픈방장");
+        Member member = saveMember("ready-open-member", "준비오픈멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "준비 오픈 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                member,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        saveMenu("ready-open-first", "준비오픈첫번째");
+        saveMenu("ready-open-second", "준비오픈두번째");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(GroupRecommendation.preparing(
+                groupRoom,
+                "{\"mealTime\":\"LUNCH\"}",
+                LocalDateTime.now()
+        ));
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations/{sessionId}/ready",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value(GroupRecommendationStatus.PREPARING.name()));
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations/{sessionId}/ready",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value(GroupRecommendationStatus.OPEN.name()))
+                .andExpect(jsonPath("$.data.readiness.totalMemberCount").value(2))
+                .andExpect(jsonPath("$.data.readiness.readyMemberCount").value(2))
+                .andExpect(jsonPath("$.data.readiness.allReady").value(true))
+                .andExpect(jsonPath("$.data.candidates.length()").value(2));
+
+        GroupRecommendation openedRecommendation =
+                groupRecommendationRepository.findById(recommendation.getId()).orElseThrow();
+        assertThat(openedRecommendation.getStatus()).isEqualTo(GroupRecommendationStatus.OPEN);
+        assertThat(groupRecommendationCandidateRepository
+                .findAllByGroupRecommendationIdOrderByRankNoAsc(recommendation.getId()))
+                .hasSize(2);
+    }
+
+    @Test
+    @DisplayName("그룹 추천 준비 완료는 PREPARING 상태가 아니면 실패한다")
+    void readyGroupRecommendationFailsWhenRecommendationIsNotPreparing() throws Exception {
+        Member owner = saveMember("ready-not-preparing-owner", "준비상태아님방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "준비 상태 아님 그룹");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations/{sessionId}/ready",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_NOT_PREPARING"));
+    }
+
+    @Test
+    @DisplayName("그룹 추천 준비 완료는 비멤버이면 거절한다")
+    void readyGroupRecommendationFailsForNonMember() throws Exception {
+        Member owner = saveMember("ready-access-owner", "준비접근방장");
+        Member other = saveMember("ready-access-other", "준비접근없음");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "준비 접근 그룹");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(GroupRecommendation.preparing(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations/{sessionId}/ready",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(other))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("GROUP_ACCESS_DENIED"));
     }
 
     @Test

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -418,6 +418,11 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/candidates'].get.responses['200'].content['application/json'].examples.success.value.data.candidates[1].menuName")
                         .value("돈까스"))
+                .andExpect(jsonPath("$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/ready'].post.summary")
+                        .value("그룹 추천 준비 완료"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/ready'].post.responses['200'].content['application/json'].examples.success.value.data.readiness.readyMemberCount")
+                        .value(3))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/votes'].post.responses['200'].content['application/json'].examples.success.value.data.candidateId")
                         .value(8001))


### PR DESCRIPTION
## 관련 이슈
Closes #242 

## 📝 작업 내용

- `POST /api/v1/groups/{groupId}/recommendations/{sessionId}/ready` 추가
- 현재 회원을 `group_recommendation_readiness.status=READY`로 저장
- 같은 회원의 중복 호출은 세션이 계속 `PREPARING`이면 idempotent하게 READY 유지
- 현재 `ACTIVE` 그룹 멤버 전원이 `READY`가 되면:
- 기존 `PREPARING` 세션에 후보 생성
- 세션 상태를 `OPEN`으로 전환
- 응답에 생성된 `candidates` 반환

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
