### PR TITLE
[Feat] 그룹 추천 준비 상태 조회 API

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -19,6 +19,7 @@ import matchuri.backend.api.group.dto.docs.GroupApiExamples;
 import matchuri.backend.api.group.dto.docs.GroupDetailApiResponse;
 import matchuri.backend.api.group.dto.docs.GroupInviteSummaryPageApiResponse;
 import matchuri.backend.api.group.dto.docs.GroupRecommendationCandidateListApiResponse;
+import matchuri.backend.api.group.dto.docs.GroupRecommendationReadinessApiResponse;
 import matchuri.backend.api.group.dto.docs.GroupRecommendationSessionApiResponse;
 import matchuri.backend.api.group.dto.docs.GroupRecommendationSummaryPageApiResponse;
 import matchuri.backend.api.group.dto.docs.GroupSummaryPageApiResponse;
@@ -44,6 +45,7 @@ import matchuri.backend.api.group.dto.response.FinalizeGroupRecommendationRespon
 import matchuri.backend.api.group.dto.response.GroupDetailResponse;
 import matchuri.backend.api.group.dto.response.GroupInviteSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateListResponse;
+import matchuri.backend.api.group.dto.response.GroupRecommendationReadinessResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationSessionResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
@@ -505,6 +507,36 @@ public interface GroupApi {
             )
     })
     ApiResponse<GroupRecommendationCandidateListResponse> getRecommendationCandidates(Long groupId, Long sessionId);
+
+    @Operation(
+            summary = "그룹 추천 준비 상태 조회",
+            description = """
+                    그룹 추천 준비 세션의 준비 진행률과 현재 활성 멤버별 준비 상태를 조회합니다.
+
+                    구현 기준:
+                    - 로그인한 활성 회원만 사용할 수 있습니다.
+                    - 현재 회원이 해당 그룹의 `ACTIVE` 멤버일 때만 조회할 수 있습니다.
+                    - `sessionId`는 해당 그룹에 속한 그룹 추천이어야 합니다.
+                    - 분모는 현재 `ACTIVE` 그룹 멤버 기준입니다.
+                    - `status=READY`인 현재 활성 멤버만 준비 완료로 계산합니다.
+                    - 아직 준비 액션이 없거나 `CANCELED` 상태인 멤버는 준비 미완료로 계산합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = GroupRecommendationReadinessApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "success",
+                                    value = GroupApiExamples.RECOMMENDATION_READINESS_SUCCESS
+                            )
+                    )
+            )
+    })
+    ApiResponse<GroupRecommendationReadinessResponse> getRecommendationReadiness(Long groupId, Long sessionId);
 
     @Operation(
             summary = "그룹 추천 준비 완료",

--- a/src/main/java/matchuri/backend/api/group/GroupController.java
+++ b/src/main/java/matchuri/backend/api/group/GroupController.java
@@ -21,6 +21,7 @@ import matchuri.backend.api.group.dto.response.FinalizeGroupRecommendationRespon
 import matchuri.backend.api.group.dto.response.GroupDetailResponse;
 import matchuri.backend.api.group.dto.response.GroupInviteSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateListResponse;
+import matchuri.backend.api.group.dto.response.GroupRecommendationReadinessResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationSessionResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupSummaryResponse;
@@ -50,6 +51,7 @@ import matchuri.backend.domain.group.result.FinalizeGroupRecommendationResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
 import matchuri.backend.domain.group.result.GroupRecommendationCandidateListResult;
+import matchuri.backend.domain.group.result.GroupRecommendationReadinessResult;
 import matchuri.backend.domain.group.result.GroupRecommendationResult;
 import matchuri.backend.domain.group.result.GroupRecommendationSummaryResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
@@ -248,6 +250,18 @@ public class GroupController implements GroupApi {
                 groupService.getGroupRecommendationCandidates(groupId, sessionId);
 
         return ApiResponse.success(groupMapper.toGroupRecommendationCandidateListResponse(result));
+    }
+
+    @Override
+    @GetMapping("/{groupId}/recommendations/{sessionId}/readiness")
+    public ApiResponse<GroupRecommendationReadinessResponse> getRecommendationReadiness(
+            @PathVariable Long groupId,
+            @PathVariable Long sessionId
+    ) {
+        GroupRecommendationReadinessResult result =
+                groupService.getGroupRecommendationReadiness(groupId, sessionId);
+
+        return ApiResponse.success(groupMapper.toGroupRecommendationReadinessResponse(result));
     }
 
     @Override

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -21,6 +21,8 @@ import matchuri.backend.api.group.dto.response.GroupInviteSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupMemberSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateListResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationCandidateResponse;
+import matchuri.backend.api.group.dto.response.GroupRecommendationReadinessMemberResponse;
+import matchuri.backend.api.group.dto.response.GroupRecommendationReadinessResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationSessionResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationSummaryResponse;
 import matchuri.backend.api.group.dto.response.GroupRecommendationReadinessProgressResponse;
@@ -54,6 +56,8 @@ import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
 import matchuri.backend.domain.group.result.GroupMemberSummaryResult;
 import matchuri.backend.domain.group.result.GroupRecommendationCandidateListResult;
 import matchuri.backend.domain.group.result.GroupRecommendationCandidateResult;
+import matchuri.backend.domain.group.result.GroupRecommendationReadinessMemberResult;
+import matchuri.backend.domain.group.result.GroupRecommendationReadinessResult;
 import matchuri.backend.domain.group.result.GroupRecommendationResult;
 import matchuri.backend.domain.group.result.GroupRecommendationSummaryResult;
 import matchuri.backend.domain.group.result.GroupRecommendationReadinessProgressResult;
@@ -283,6 +287,19 @@ public class GroupMapper {
         );
     }
 
+    public GroupRecommendationReadinessResponse toGroupRecommendationReadinessResponse(
+            GroupRecommendationReadinessResult result
+    ) {
+        return new GroupRecommendationReadinessResponse(
+                result.sessionId(),
+                result.status(),
+                toGroupRecommendationReadinessProgressResponse(result.progress()),
+                result.members().stream()
+                        .map(this::toGroupRecommendationReadinessMemberResponse)
+                        .toList()
+        );
+    }
+
     public ReadyGroupRecommendationResponse toReadyGroupRecommendationResponse(
             ReadyGroupRecommendationResult result
     ) {
@@ -355,6 +372,19 @@ public class GroupMapper {
         return new GroupVoteProgressResponse(
                 result.totalMemberCount(),
                 result.votedMemberCount()
+        );
+    }
+
+    private GroupRecommendationReadinessMemberResponse toGroupRecommendationReadinessMemberResponse(
+            GroupRecommendationReadinessMemberResult result
+    ) {
+        return new GroupRecommendationReadinessMemberResponse(
+                result.memberId(),
+                result.nickname(),
+                result.role(),
+                result.ready(),
+                result.readinessStatus(),
+                result.readinessUpdatedAt()
         );
     }
 

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -365,6 +365,40 @@ public final class GroupApiExamples {
             }
             """;
 
+    public static final String RECOMMENDATION_READINESS_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "sessionId": 5001,
+                "status": "PREPARING",
+                "progress": {
+                  "totalMemberCount": 4,
+                  "readyMemberCount": 2,
+                  "allReady": false
+                },
+                "members": [
+                  {
+                    "memberId": 1,
+                    "nickname": "김철수",
+                    "role": "OWNER",
+                    "ready": true,
+                    "readinessStatus": "READY",
+                    "readinessUpdatedAt": "2026-05-26T12:05:00"
+                  },
+                  {
+                    "memberId": 2,
+                    "nickname": "김덕배",
+                    "role": "MEMBER",
+                    "ready": false,
+                    "readinessStatus": null,
+                    "readinessUpdatedAt": null
+                  }
+                ]
+              },
+              "error": null
+            }
+            """;
+
     public static final String READY_RECOMMENDATION_SUCCESS = """
             {
               "success": true,

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupRecommendationReadinessApiResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupRecommendationReadinessApiResponse.java
@@ -1,0 +1,11 @@
+package matchuri.backend.api.group.dto.docs;
+
+import matchuri.backend.api.group.dto.response.GroupRecommendationReadinessResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+public record GroupRecommendationReadinessApiResponse(
+        boolean success,
+        GroupRecommendationReadinessResponse data,
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationReadinessMemberResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationReadinessMemberResponse.java
@@ -1,0 +1,27 @@
+package matchuri.backend.api.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import matchuri.backend.domain.group.entity.GroupMemberRole;
+import matchuri.backend.domain.group.entity.GroupRecommendationReadinessStatus;
+
+public record GroupRecommendationReadinessMemberResponse(
+        @Schema(description = "회원 ID입니다.", example = "1")
+        Long memberId,
+
+        @Schema(description = "회원 닉네임입니다.", example = "점심탐험가")
+        String nickname,
+
+        @Schema(description = "그룹 내 역할입니다.", example = "OWNER")
+        GroupMemberRole role,
+
+        @Schema(description = "현재 준비 완료 여부입니다.", example = "true")
+        boolean ready,
+
+        @Schema(description = "준비 상태입니다. 아직 액션이 없으면 null입니다.", example = "READY", nullable = true)
+        GroupRecommendationReadinessStatus readinessStatus,
+
+        @Schema(description = "준비 상태가 마지막으로 변경된 시각입니다. 아직 액션이 없으면 null입니다.", example = "2026-05-26T12:05:00", nullable = true)
+        LocalDateTime readinessUpdatedAt
+) {
+}

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationReadinessResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationReadinessResponse.java
@@ -1,0 +1,20 @@
+package matchuri.backend.api.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
+
+public record GroupRecommendationReadinessResponse(
+        @Schema(description = "그룹 추천 ID입니다. API 경로에서는 sessionId로 표현합니다.", example = "5001")
+        Long sessionId,
+
+        @Schema(description = "그룹 추천 상태입니다.", example = "PREPARING")
+        GroupRecommendationStatus status,
+
+        @Schema(description = "그룹 추천 준비 진행 상태입니다.")
+        GroupRecommendationReadinessProgressResponse progress,
+
+        @Schema(description = "현재 활성 그룹 멤버별 준비 상태입니다.")
+        List<GroupRecommendationReadinessMemberResponse> members
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationReadinessRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationReadinessRepository.java
@@ -1,5 +1,6 @@
 package matchuri.backend.domain.group.repository;
 
+import java.util.List;
 import java.util.Optional;
 import matchuri.backend.domain.group.entity.GroupRecommendationReadiness;
 import matchuri.backend.domain.group.entity.GroupRecommendationReadinessStatus;
@@ -14,6 +15,8 @@ public interface GroupRecommendationReadinessRepository
             Long groupRecommendationId,
             Long memberId
     );
+
+    List<GroupRecommendationReadiness> findAllByGroupRecommendationId(Long groupRecommendationId);
 
     @Query("""
             select count(readiness)

--- a/src/main/java/matchuri/backend/domain/group/result/GroupRecommendationReadinessMemberResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupRecommendationReadinessMemberResult.java
@@ -1,0 +1,15 @@
+package matchuri.backend.domain.group.result;
+
+import java.time.LocalDateTime;
+import matchuri.backend.domain.group.entity.GroupMemberRole;
+import matchuri.backend.domain.group.entity.GroupRecommendationReadinessStatus;
+
+public record GroupRecommendationReadinessMemberResult(
+        Long memberId,
+        String nickname,
+        GroupMemberRole role,
+        boolean ready,
+        GroupRecommendationReadinessStatus readinessStatus,
+        LocalDateTime readinessUpdatedAt
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/result/GroupRecommendationReadinessResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupRecommendationReadinessResult.java
@@ -1,0 +1,12 @@
+package matchuri.backend.domain.group.result;
+
+import java.util.List;
+import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
+
+public record GroupRecommendationReadinessResult(
+        Long sessionId,
+        GroupRecommendationStatus status,
+        GroupRecommendationReadinessProgressResult progress,
+        List<GroupRecommendationReadinessMemberResult> members
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/service/GroupService.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupService.java
@@ -20,6 +20,7 @@ import matchuri.backend.domain.group.result.FinalizeGroupRecommendationResult;
 import matchuri.backend.domain.group.result.GroupDetailResult;
 import matchuri.backend.domain.group.result.GroupInviteSummaryResult;
 import matchuri.backend.domain.group.result.GroupRecommendationCandidateListResult;
+import matchuri.backend.domain.group.result.GroupRecommendationReadinessResult;
 import matchuri.backend.domain.group.result.GroupRecommendationResult;
 import matchuri.backend.domain.group.result.GroupRecommendationSummaryResult;
 import matchuri.backend.domain.group.result.GroupSummaryResult;
@@ -49,6 +50,8 @@ public interface GroupService {
     GroupRecommendationCandidateListResult getGroupRecommendationCandidates(Long groupId, Long sessionId);
 
     Page<GroupRecommendationSummaryResult> getGroupRecommendations(Long groupId, int page, int size);
+
+    GroupRecommendationReadinessResult getGroupRecommendationReadiness(Long groupId, Long sessionId);
 
     ReadyGroupRecommendationResult readyGroupRecommendation(Long groupId, Long sessionId);
 

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -293,6 +293,43 @@ public class GroupServiceImpl implements GroupService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public GroupRecommendationReadinessResult getGroupRecommendationReadiness(Long groupId, Long sessionId) {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        GroupRoom room = getActiveGroupRoom(groupId);
+        validateActiveMembership(room.getId(), member.getId());
+
+        GroupRecommendation recommendation = groupRecommendationRepository.findByIdAndRoomId(sessionId, room.getId())
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_FOUND, sessionId));
+
+        List<GroupRoomMember> activeMembers = groupRoomMemberRepository.findActiveMembersByRoomId(room.getId());
+        Map<Long, GroupRecommendationReadiness> readinessByMemberId = groupRecommendationReadinessRepository
+                .findAllByGroupRecommendationId(recommendation.getId())
+                .stream()
+                .collect(Collectors.toMap(
+                        readiness -> readiness.getMember().getId(),
+                        Function.identity()
+                ));
+
+        GroupRecommendationReadinessProgressResult progress = readinessProgress(
+                recommendation.getId(),
+                room.getId(),
+                activeMembers.size()
+        );
+
+        List<GroupRecommendationReadinessMemberResult> recommendationReadinessMemberResults = activeMembers.stream()
+                .map(groupMember -> toReadinessMemberResult(groupMember, readinessByMemberId))
+                .toList();
+
+        return new GroupRecommendationReadinessResult(
+                recommendation.getId(),
+                recommendation.getStatus(),
+                progress,
+                recommendationReadinessMemberResults
+        );
+    }
+
+    @Override
     public ReadyGroupRecommendationResult readyGroupRecommendation(Long groupId, Long sessionId) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
         GroupRoom room = getActiveGroupRoom(groupId);
@@ -315,16 +352,12 @@ public class GroupServiceImpl implements GroupService {
                         ))
                 );
 
-        List<GroupRoomMember> activeMembers = groupRoomMemberRepository.findActiveMembersByRoomId(room.getId());
-        int totalMemberCount = activeMembers.size();
-        int readyMemberCount = Math.toIntExact(groupRecommendationReadinessRepository
-                .countActiveMemberReadinessByRecommendationIdAndStatus(
-                        recommendation.getId(),
-                        room.getId(),
-                        GroupRecommendationReadinessStatus.READY
-                ));
-        GroupRecommendationReadinessProgressResult readiness =
-                GroupRecommendationReadinessProgressResult.of(totalMemberCount, readyMemberCount);
+        int totalMemberCount = groupRoomMemberRepository.findActiveMembersByRoomId(room.getId()).size();
+        GroupRecommendationReadinessProgressResult readiness = readinessProgress(
+                recommendation.getId(),
+                room.getId(),
+                totalMemberCount
+        );
 
         List<GroupRecommendationCandidate> candidates = List.of();
         if (readiness.allReady()) {
@@ -343,6 +376,39 @@ public class GroupServiceImpl implements GroupService {
                 candidates.stream()
                         .map(candidate -> GroupRecommendationCandidateResult.from(candidate, 0))
                         .toList()
+        );
+    }
+
+    private GroupRecommendationReadinessProgressResult readinessProgress(
+            Long recommendationId,
+            Long roomId,
+            int totalMemberCount
+    ) {
+        int readyMemberCount = Math.toIntExact(groupRecommendationReadinessRepository
+                .countActiveMemberReadinessByRecommendationIdAndStatus(
+                        recommendationId,
+                        roomId,
+                        GroupRecommendationReadinessStatus.READY
+                ));
+
+        return GroupRecommendationReadinessProgressResult.of(totalMemberCount, readyMemberCount);
+    }
+
+    private GroupRecommendationReadinessMemberResult toReadinessMemberResult(
+            GroupRoomMember groupMember,
+            Map<Long, GroupRecommendationReadiness> readinessByMemberId
+    ) {
+        Member member = groupMember.getMember();
+        GroupRecommendationReadiness readiness = readinessByMemberId.get(member.getId());
+        GroupRecommendationReadinessStatus readinessStatus = readiness == null ? null : readiness.getStatus();
+
+        return new GroupRecommendationReadinessMemberResult(
+                member.getId(),
+                member.getNickname(),
+                groupMember.getRole(),
+                readinessStatus == GroupRecommendationReadinessStatus.READY,
+                readinessStatus,
+                readiness == null ? null : readiness.getUpdatedAt()
         );
     }
 

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -383,6 +383,102 @@ class GroupIntegrationTest {
     }
 
     @Test
+    @DisplayName("그룹 추천 준비 상태 조회는 현재 활성 멤버별 READY 상태와 진행률을 반환한다")
+    void getGroupRecommendationReadinessReturnsActiveMemberReadiness() throws Exception {
+        Member owner = saveMember("readiness-owner", "준비조회방장");
+        Member member = saveMember("readiness-member", "준비조회멤버");
+        Member waitingMember = saveMember("readiness-waiting", "준비조회대기");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "준비 조회 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                member,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                waitingMember,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        GroupRecommendation recommendation = groupRecommendationRepository.save(GroupRecommendation.preparing(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+        groupRecommendationReadinessRepository.save(new GroupRecommendationReadiness(recommendation, owner));
+        GroupRecommendationReadiness canceledReadiness =
+                new GroupRecommendationReadiness(recommendation, member);
+        canceledReadiness.cancel();
+        groupRecommendationReadinessRepository.save(canceledReadiness);
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}/recommendations/{sessionId}/readiness",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.sessionId").value(recommendation.getId()))
+                .andExpect(jsonPath("$.data.status").value(GroupRecommendationStatus.PREPARING.name()))
+                .andExpect(jsonPath("$.data.progress.totalMemberCount").value(3))
+                .andExpect(jsonPath("$.data.progress.readyMemberCount").value(1))
+                .andExpect(jsonPath("$.data.progress.allReady").value(false))
+                .andExpect(jsonPath("$.data.members.length()").value(3))
+                .andExpect(jsonPath("$.data.members[0].memberId").value(owner.getId()))
+                .andExpect(jsonPath("$.data.members[0].ready").value(true))
+                .andExpect(jsonPath("$.data.members[0].readinessStatus")
+                        .value(GroupRecommendationReadinessStatus.READY.name()))
+                .andExpect(jsonPath("$.data.members[0].readinessUpdatedAt").isNotEmpty())
+                .andExpect(jsonPath("$.data.members[1].memberId").value(member.getId()))
+                .andExpect(jsonPath("$.data.members[1].ready").value(false))
+                .andExpect(jsonPath("$.data.members[1].readinessStatus")
+                        .value(GroupRecommendationReadinessStatus.CANCELED.name()))
+                .andExpect(jsonPath("$.data.members[2].memberId").value(waitingMember.getId()))
+                .andExpect(jsonPath("$.data.members[2].ready").value(false))
+                .andExpect(jsonPath("$.data.members[2].readinessStatus").value(nullValue()))
+                .andExpect(jsonPath("$.data.members[2].readinessUpdatedAt").value(nullValue()));
+    }
+
+    @Test
+    @DisplayName("그룹 추천 준비 상태 조회는 비멤버이면 거절한다")
+    void getGroupRecommendationReadinessFailsForNonMember() throws Exception {
+        Member owner = saveMember("readiness-access-owner", "준비조회접근방장");
+        Member other = saveMember("readiness-access-other", "준비조회접근없음");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "준비 조회 접근 그룹");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(GroupRecommendation.preparing(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}/recommendations/{sessionId}/readiness",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(other))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("GROUP_ACCESS_DENIED"));
+    }
+
+    @Test
+    @DisplayName("그룹 추천 준비 상태 조회는 다른 그룹 추천이면 찾을 수 없음으로 처리한다")
+    void getGroupRecommendationReadinessFailsWhenRecommendationDoesNotBelongToGroup() throws Exception {
+        Member owner = saveMember("readiness-other-owner", "준비조회다른방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "준비 조회 대상 그룹");
+        GroupRoom otherGroupRoom = saveGroupOwnedBy(owner, "준비 조회 다른 그룹");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(GroupRecommendation.preparing(
+                otherGroupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}/recommendations/{sessionId}/readiness",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_NOT_FOUND"));
+    }
+
+    @Test
     @DisplayName("그룹 추천 준비 완료는 현재 회원을 READY로 저장하고 아직 전원이 아니면 PREPARING을 유지한다")
     void readyGroupRecommendationMarksMemberReadyBeforeAllMembersReady() throws Exception {
         Member owner = saveMember("ready-owner", "준비방장");

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -418,6 +418,11 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/candidates'].get.responses['200'].content['application/json'].examples.success.value.data.candidates[1].menuName")
                         .value("돈까스"))
+                .andExpect(jsonPath("$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/readiness'].get.summary")
+                        .value("그룹 추천 준비 상태 조회"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/readiness'].get.responses['200'].content['application/json'].examples.success.value.data.progress.readyMemberCount")
+                        .value(2))
                 .andExpect(jsonPath("$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/ready'].post.summary")
                         .value("그룹 추천 준비 완료"))
                 .andExpect(jsonPath(


### PR DESCRIPTION
## 관련 이슈
Closes #239 

## 📝 작업 내용
- `GET /api/v1/groups/{groupId}/recommendations/{sessionId}/readiness` 추가

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- `progress`에서 현재 상태를 확인합니다.
- `members`에서 각 회원들의 준비 상태를 확인합니다.
- 추후 SSE 방식으로 준비 상태를 최신화 합니다.
