### PR TITLE
[Refactor] 그룹 및 그룹 세션 상세조회 API 응답에 준비 상태값 반환

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -150,10 +150,18 @@ public interface GroupApi {
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = GroupDetailApiResponse.class),
-                            examples = @ExampleObject(
-                                    name = "success",
-                                    value = GroupApiExamples.GROUP_DETAIL_SUCCESS
-                            )
+                            examples = {
+                                    @ExampleObject(
+                                            name = "preparing",
+                                            summary = "준비 중인 그룹 추천 포함",
+                                            value = GroupApiExamples.GROUP_DETAIL_SUCCESS
+                                    ),
+                                    @ExampleObject(
+                                            name = "open",
+                                            summary = "열린 그룹 추천 포함",
+                                            value = GroupApiExamples.GROUP_DETAIL_OPEN_RECOMMENDATION_SUCCESS
+                                    )
+                            }
                     )
             )
     })

--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -98,7 +98,8 @@ public interface GroupApi {
                     - 로그인한 활성 회원만 사용할 수 있습니다.
                     - 현재 회원이 `ACTIVE` 멤버로 속한 그룹만 반환합니다.
                     - 삭제된 그룹은 목록에서 제외합니다.
-                    - 그룹 추천 구현 전까지 `latestRecommendationStatus`는 null일 수 있습니다.
+                    - 최신 그룹 추천이 있으면 `latestRecommendationStatus`로 상태를 반환합니다.
+                    - 아직 그룹 추천이 없으면 `latestRecommendationStatus`는 null입니다.
                     """
     )
     @ApiResponses({
@@ -138,7 +139,8 @@ public interface GroupApi {
                     - 현재 회원이 해당 그룹의 `ACTIVE` 멤버일 때만 조회할 수 있습니다.
                     - 그룹의 모든 `ACTIVE` 멤버에게 고정 초대 코드를 함께 반환합니다.
                     - 삭제된 그룹은 조회할 수 없습니다.
-                    - 열린 그룹 추천이 있으면 `activeRecommendation`을 함께 반환합니다.
+                    - `PREPARING` 또는 `OPEN` 추천 세션이 있으면 `activeRecommendation`을 함께 반환합니다.
+                    - `PREPARING`이면 readiness 진행률을, `OPEN`이면 후보와 투표 진행률을 포함합니다.
                     """
     )
     @ApiResponses({
@@ -419,6 +421,7 @@ public interface GroupApi {
                     - 로그인한 활성 회원만 사용할 수 있습니다.
                     - 현재 회원이 해당 그룹의 `ACTIVE` 멤버일 때만 조회할 수 있습니다.
                     - 삭제된 그룹은 조회할 수 없습니다.
+                    - `PREPARING` 세션도 목록에 포함합니다.
                     - 응답은 `sessionId`, `status`, `startedAt`, `endedAt`만 포함하는 얇은 summary입니다.
                     - `finalCandidate`, `finalMenuName`, `voteProgress`, `status` 필터는 1차 범위에서 제외합니다.
                     - 최신순(`startedAt DESC`, `id DESC`)으로 정렬합니다.
@@ -454,13 +457,14 @@ public interface GroupApi {
     @Operation(
             summary = "그룹 추천 세션 상세 조회",
             description = """
-                    그룹 추천 상태, 후보, 투표 진행률, 최종 후보를 조회합니다.
+                    그룹 추천 상태, 준비 진행률, 후보, 투표 진행률, 최종 후보를 조회합니다.
 
                     구현 기준:
                     - 로그인한 활성 회원만 사용할 수 있습니다.
                     - 현재 회원이 해당 그룹의 `ACTIVE` 멤버일 때만 조회할 수 있습니다.
                     - `sessionId`는 API 표현 이름이며 저장 모델은 `group_recommendations.id`로 해석합니다.
-                    - 후보별 현재 투표 수와 전체 투표 진행률을 함께 반환합니다.
+                    - `PREPARING` 세션이면 후보는 빈 배열, 투표 진행률은 null, readiness 진행률은 값으로 반환합니다.
+                    - `OPEN` 세션이면 후보별 현재 투표 수와 전체 투표 진행률을 함께 반환하고 readiness는 null입니다.
                     """
     )
     @ApiResponses({

--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -563,10 +563,18 @@ public interface GroupApi {
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ReadyGroupRecommendationApiResponse.class),
-                            examples = @ExampleObject(
-                                    name = "success",
-                                    value = GroupApiExamples.READY_RECOMMENDATION_SUCCESS
-                            )
+                            examples = {
+                                    @ExampleObject(
+                                            name = "preparing",
+                                            summary = "아직 전원 준비 전",
+                                            value = GroupApiExamples.READY_RECOMMENDATION_SUCCESS
+                                    ),
+                                    @ExampleObject(
+                                            name = "opened",
+                                            summary = "마지막 인원 준비 완료로 후보 생성",
+                                            value = GroupApiExamples.READY_RECOMMENDATION_OPEN_SUCCESS
+                                    )
+                            }
                     )
             )
     })

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -254,10 +254,15 @@ public class GroupMapper {
         return new GroupRecommendationSessionResponse(
                 result.sessionId(),
                 result.status(),
+                result.readiness() == null
+                        ? null
+                        : toGroupRecommendationReadinessProgressResponse(result.readiness()),
                 result.candidates().stream()
                         .map(this::toGroupRecommendationCandidateResponse)
                         .toList(),
-                toGroupVoteProgressResponse(result.voteProgress()),
+                result.voteProgress() == null
+                        ? null
+                        : toGroupVoteProgressResponse(result.voteProgress()),
                 result.finalCandidate() == null
                         ? null
                         : toGroupRecommendationCandidateResponse(result.finalCandidate()),

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -27,7 +27,7 @@ public final class GroupApiExamples {
                     "name": "오늘 점심 메뉴 회의",
                     "status": "ACTIVE",
                     "memberCount": 4,
-                    "latestRecommendationStatus": null,
+                    "latestRecommendationStatus": "PREPARING",
                     "createdAt": "2026-05-06T12:00:00"
                   }
                 ],
@@ -86,7 +86,19 @@ public final class GroupApiExamples {
                     "joinedAt": "2026-05-06T12:02:00"
                   }
                 ],
-                "activeRecommendation": null
+                "activeRecommendation": {
+                  "sessionId": 5001,
+                  "status": "PREPARING",
+                  "readiness": {
+                    "totalMemberCount": 4,
+                    "readyMemberCount": 2,
+                    "allReady": false
+                  },
+                  "candidates": [],
+                  "voteProgress": null,
+                  "finalCandidate": null,
+                  "createdAt": "2026-05-06T12:05:00"
+                }
               },
               "error": null
             }
@@ -260,7 +272,7 @@ public final class GroupApiExamples {
                 "content": [
                   {
                     "sessionId": 5002,
-                    "status": "OPEN",
+                    "status": "PREPARING",
                     "startedAt": "2026-05-26T12:20:00",
                     "endedAt": null
                   },
@@ -292,6 +304,7 @@ public final class GroupApiExamples {
               "data": {
                 "sessionId": 5001,
                 "status": "OPEN",
+                "readiness": null,
                 "candidates": [
                   {
                     "candidateId": 8001,

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -104,6 +104,74 @@ public final class GroupApiExamples {
             }
             """;
 
+    public static final String GROUP_DETAIL_OPEN_RECOMMENDATION_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "id": 3001,
+                "name": "오늘 점심 메뉴 회의",
+                "inviteCode": "LUNCH42",
+                "latitude": 37.498095,
+                "longitude": 127.027610,
+                "status": "ACTIVE",
+                "members": [
+                  {
+                    "memberId": 1,
+                    "nickname": "점심탐험가",
+                    "role": "OWNER",
+                    "status": "ACTIVE",
+                    "joinedAt": "2026-05-06T12:01:00"
+                  },
+                  {
+                    "memberId": 2,
+                    "nickname": "든든한한끼",
+                    "role": "MEMBER",
+                    "status": "ACTIVE",
+                    "joinedAt": "2026-05-06T12:02:00"
+                  }
+                ],
+                "activeRecommendation": {
+                  "sessionId": 5001,
+                  "status": "OPEN",
+                  "readiness": null,
+                  "candidates": [
+                    {
+                      "candidateId": 8001,
+                      "menuId": 1001,
+                      "menuName": "비빔밥",
+                      "rankNo": 1,
+                      "score": 91.5,
+                      "voteCount": 3
+                    },
+                    {
+                      "candidateId": 8002,
+                      "menuId": 1002,
+                      "menuName": "돈까스",
+                      "rankNo": 2,
+                      "score": 84.0,
+                      "voteCount": 1
+                    },
+                    {
+                      "candidateId": 8003,
+                      "menuId": 1003,
+                      "menuName": "쌀국수",
+                      "rankNo": 3,
+                      "score": 79.5,
+                      "voteCount": 0
+                    }
+                  ],
+                  "voteProgress": {
+                    "totalMemberCount": 4,
+                    "votedMemberCount": 3
+                  },
+                  "finalCandidate": null,
+                  "createdAt": "2026-05-06T12:05:00"
+                }
+              },
+              "error": null
+            }
+            """;
+
     public static final String UPDATE_GROUP_SUCCESS = """
             {
               "success": true,

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -429,6 +429,48 @@ public final class GroupApiExamples {
             }
             """;
 
+    public static final String READY_RECOMMENDATION_OPEN_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "sessionId": 5001,
+                "status": "OPEN",
+                "readiness": {
+                  "totalMemberCount": 4,
+                  "readyMemberCount": 4,
+                  "allReady": true
+                },
+                "candidates": [
+                  {
+                    "candidateId": 8001,
+                    "menuId": 1001,
+                    "menuName": "비빔밥",
+                    "rankNo": 1,
+                    "score": 91.5,
+                    "voteCount": 0
+                  },
+                  {
+                    "candidateId": 8002,
+                    "menuId": 1002,
+                    "menuName": "돈까스",
+                    "rankNo": 2,
+                    "score": 84.0,
+                    "voteCount": 0
+                  },
+                  {
+                    "candidateId": 8003,
+                    "menuId": 1003,
+                    "menuName": "쌀국수",
+                    "rankNo": 3,
+                    "score": 79.5,
+                    "voteCount": 0
+                  }
+                ]
+              },
+              "error": null
+            }
+            """;
+
     public static final String VOTE_SUCCESS = """
             {
               "success": true,

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationSessionResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationSessionResponse.java
@@ -12,10 +12,13 @@ public record GroupRecommendationSessionResponse(
         @Schema(description = "그룹 추천 상태입니다.", example = "OPEN")
         GroupRecommendationStatus status,
 
+        @Schema(description = "준비 단계 진행률입니다. PREPARING 상태가 아니면 null입니다.", nullable = true)
+        GroupRecommendationReadinessProgressResponse readiness,
+
         @Schema(description = "추천 후보 목록입니다.")
         List<GroupRecommendationCandidateResponse> candidates,
 
-        @Schema(description = "투표 진행률입니다.")
+        @Schema(description = "투표 진행률입니다. PREPARING 상태이면 null입니다.", nullable = true)
         GroupVoteProgressResponse voteProgress,
 
         @Schema(description = "최종 확정 후보입니다. 확정 전에는 null입니다.")
@@ -28,6 +31,7 @@ public record GroupRecommendationSessionResponse(
         return new GroupRecommendationSessionResponse(
                 5001L,
                 GroupRecommendationStatus.OPEN,
+                null,
                 GroupMocks.candidates(),
                 GroupVoteProgressResponse.mockInProgress(),
                 null,

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationRepository.java
@@ -21,5 +21,12 @@ public interface GroupRecommendationRepository extends JpaRepository<GroupRecomm
             GroupRecommendationStatus status
     );
 
+    Optional<GroupRecommendation> findFirstByRoomIdAndStatusInOrderByStartedAtDescIdDesc(
+            Long roomId,
+            Collection<GroupRecommendationStatus> statuses
+    );
+
+    Optional<GroupRecommendation> findFirstByRoomIdOrderByStartedAtDescIdDesc(Long roomId);
+
     Page<GroupRecommendation> findByRoomIdOrderByStartedAtDescIdDesc(Long roomId, Pageable pageable);
 }

--- a/src/main/java/matchuri/backend/domain/group/result/GroupRecommendationResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupRecommendationResult.java
@@ -7,6 +7,7 @@ import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
 public record GroupRecommendationResult(
         Long sessionId,
         GroupRecommendationStatus status,
+        GroupRecommendationReadinessProgressResult readiness,
         List<GroupRecommendationCandidateResult> candidates,
         GroupVoteProgressResult voteProgress,
         GroupRecommendationCandidateResult finalCandidate,

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -733,7 +733,10 @@ public class GroupServiceImpl implements GroupService {
                 .map(this::toMemberSummaryResult)
                 .toList();
         GroupRecommendationResult activeRecommendation = groupRecommendationRepository
-                .findFirstByRoomIdAndStatusOrderByStartedAtDesc(groupId, GroupRecommendationStatus.OPEN)
+                .findFirstByRoomIdAndStatusInOrderByStartedAtDescIdDesc(
+                        groupId,
+                        List.of(GroupRecommendationStatus.PREPARING, GroupRecommendationStatus.OPEN)
+                )
                 .map(this::toGroupRecommendationResult)
                 .orElse(null);
 
@@ -755,7 +758,8 @@ public class GroupServiceImpl implements GroupService {
     }
 
     private GroupRecommendationResult toGroupRecommendationResult(GroupRecommendation recommendation) {
-        List<GroupRecommendationCandidateResult> candidates = toCandidateResults(recommendation);
+        boolean preparing = recommendation.getStatus() == GroupRecommendationStatus.PREPARING;
+        List<GroupRecommendationCandidateResult> candidates = preparing ? List.of() : toCandidateResults(recommendation);
         GroupRecommendationCandidateResult finalCandidate = recommendation.getSelectedCandidate() == null
                 ? null
                 : candidates.stream()
@@ -770,8 +774,16 @@ public class GroupServiceImpl implements GroupService {
         return new GroupRecommendationResult(
                 recommendation.getId(),
                 recommendation.getStatus(),
+                preparing
+                        ? readinessProgress(
+                                recommendation.getId(),
+                                recommendation.getRoom().getId(),
+                                groupRoomMemberRepository.findActiveMembersByRoomId(recommendation.getRoom().getId())
+                                        .size()
+                        )
+                        : null,
                 candidates,
-                toVoteProgress(recommendation),
+                preparing ? null : toVoteProgress(recommendation),
                 finalCandidate,
                 recommendation.getCreatedAt()
         );
@@ -947,7 +959,9 @@ public class GroupServiceImpl implements GroupService {
                 room.getName(),
                 room.getStatus(),
                 activeMemberCounts.getOrDefault(room.getId(), 0L).intValue(),
-                null,
+                groupRecommendationRepository.findFirstByRoomIdOrderByStartedAtDescIdDesc(room.getId())
+                        .map(GroupRecommendation::getStatus)
+                        .orElse(null),
                 room.getCreatedAt()
         );
     }

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -852,6 +852,7 @@ class GroupIntegrationTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.sessionId").value(recommendation.getId()))
                 .andExpect(jsonPath("$.data.status").value(GroupRecommendationStatus.OPEN.name()))
+                .andExpect(jsonPath("$.data.readiness").value(nullValue()))
                 .andExpect(jsonPath("$.data.candidates.length()").value(2))
                 .andExpect(jsonPath("$.data.candidates[0].candidateId").value(firstCandidate.getId()))
                 .andExpect(jsonPath("$.data.candidates[0].menuId").value(bibimbap.getId()))
@@ -865,6 +866,40 @@ class GroupIntegrationTest {
                 .andExpect(jsonPath("$.data.voteProgress.votedMemberCount").value(1))
                 .andExpect(jsonPath("$.data.finalCandidate").value(nullValue()))
                 .andExpect(jsonPath("$.data.createdAt").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("그룹 추천 상세 조회는 준비 세션이면 readiness 진행률을 반환하고 투표 진행률은 반환하지 않는다")
+    void getGroupRecommendationReturnsReadinessForPreparingSession() throws Exception {
+        Member owner = saveMember("recommendation-preparing-view-owner", "준비상세방장");
+        Member member = saveMember("recommendation-preparing-view-member", "준비상세멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "준비 상세 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                member,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        GroupRecommendation recommendation = groupRecommendationRepository.save(GroupRecommendation.preparing(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+        groupRecommendationReadinessRepository.save(new GroupRecommendationReadiness(recommendation, owner));
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}/recommendations/{sessionId}",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.sessionId").value(recommendation.getId()))
+                .andExpect(jsonPath("$.data.status").value(GroupRecommendationStatus.PREPARING.name()))
+                .andExpect(jsonPath("$.data.readiness.totalMemberCount").value(2))
+                .andExpect(jsonPath("$.data.readiness.readyMemberCount").value(1))
+                .andExpect(jsonPath("$.data.readiness.allReady").value(false))
+                .andExpect(jsonPath("$.data.candidates.length()").value(0))
+                .andExpect(jsonPath("$.data.voteProgress").value(nullValue()))
+                .andExpect(jsonPath("$.data.finalCandidate").value(nullValue()));
     }
 
     @Test
@@ -928,7 +963,7 @@ class GroupIntegrationTest {
         ));
         oldRecommendation.rerollWithoutSkip(LocalDateTime.of(2026, 5, 26, 12, 15));
         groupRecommendationRepository.save(oldRecommendation);
-        GroupRecommendation latestRecommendation = groupRecommendationRepository.save(new GroupRecommendation(
+        GroupRecommendation latestRecommendation = groupRecommendationRepository.save(GroupRecommendation.preparing(
                 groupRoom,
                 "{}",
                 LocalDateTime.of(2026, 5, 26, 12, 30)
@@ -947,7 +982,7 @@ class GroupIntegrationTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.content.length()").value(2))
                 .andExpect(jsonPath("$.data.content[0].sessionId").value(latestRecommendation.getId()))
-                .andExpect(jsonPath("$.data.content[0].status").value(GroupRecommendationStatus.OPEN.name()))
+                .andExpect(jsonPath("$.data.content[0].status").value(GroupRecommendationStatus.PREPARING.name()))
                 .andExpect(jsonPath("$.data.content[0].startedAt").value("2026-05-26T12:30:00"))
                 .andExpect(jsonPath("$.data.content[0].endedAt").value(nullValue()))
                 .andExpect(jsonPath("$.data.content[0].finalCandidate").doesNotExist())
@@ -1484,9 +1519,69 @@ class GroupIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.activeRecommendation.sessionId").value(recommendation.getId()))
                 .andExpect(jsonPath("$.data.activeRecommendation.status").value(GroupRecommendationStatus.OPEN.name()))
+                .andExpect(jsonPath("$.data.activeRecommendation.readiness").value(nullValue()))
                 .andExpect(jsonPath("$.data.activeRecommendation.candidates[0].candidateId").value(candidate.getId()))
                 .andExpect(jsonPath("$.data.activeRecommendation.voteProgress.totalMemberCount").value(1))
                 .andExpect(jsonPath("$.data.activeRecommendation.voteProgress.votedMemberCount").value(0));
+    }
+
+    @Test
+    @DisplayName("그룹 상세 조회는 준비 중인 그룹 추천도 activeRecommendation으로 반환한다")
+    void getGroupReturnsPreparingActiveRecommendation() throws Exception {
+        Member owner = saveMember("group-preparing-recommendation-owner", "준비추천방장");
+        Member member = saveMember("group-preparing-recommendation-member", "준비추천멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "준비 추천 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                member,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        GroupRecommendation recommendation = groupRecommendationRepository.save(GroupRecommendation.preparing(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+        groupRecommendationReadinessRepository.save(new GroupRecommendationReadiness(recommendation, owner));
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.activeRecommendation.sessionId").value(recommendation.getId()))
+                .andExpect(jsonPath("$.data.activeRecommendation.status")
+                        .value(GroupRecommendationStatus.PREPARING.name()))
+                .andExpect(jsonPath("$.data.activeRecommendation.readiness.totalMemberCount").value(2))
+                .andExpect(jsonPath("$.data.activeRecommendation.readiness.readyMemberCount").value(1))
+                .andExpect(jsonPath("$.data.activeRecommendation.candidates.length()").value(0))
+                .andExpect(jsonPath("$.data.activeRecommendation.voteProgress").value(nullValue()));
+    }
+
+    @Test
+    @DisplayName("내 그룹 목록은 최신 그룹 추천 상태를 반환한다")
+    void getMyGroupsReturnsLatestRecommendationStatus() throws Exception {
+        Member owner = saveMember("group-list-recommendation-owner", "목록추천방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "목록 추천 그룹");
+        GroupRecommendation oldRecommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.of(2026, 5, 26, 12, 0)
+        ));
+        oldRecommendation.rerollWithoutSkip(LocalDateTime.of(2026, 5, 26, 12, 10));
+        groupRecommendationRepository.save(GroupRecommendation.preparing(
+                groupRoom,
+                "{}",
+                LocalDateTime.of(2026, 5, 26, 12, 30)
+        ));
+
+        mockMvc.perform(get("/api/v1/groups")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content.length()").value(1))
+                .andExpect(jsonPath("$.data.content[0].id").value(groupRoom.getId()))
+                .andExpect(jsonPath("$.data.content[0].latestRecommendationStatus")
+                        .value(GroupRecommendationStatus.PREPARING.name()));
     }
 
     @Test

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -346,13 +346,22 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/groups'].get.responses['200'].content['application/json'].examples.success.value.data.content[0].latestRecommendationStatus")
                         .value("PREPARING"))
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/groups/{groupId}'].get.responses['200'].content['application/json'].examples.success.value.data.activeRecommendation.status")
+                        "$.paths['/api/v1/groups/{groupId}'].get.responses['200'].content['application/json'].examples.preparing.value.data.activeRecommendation.status")
                         .value("PREPARING"))
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/groups/{groupId}'].get.responses['200'].content['application/json'].examples.success.value.data.activeRecommendation.readiness.readyMemberCount")
+                        "$.paths['/api/v1/groups/{groupId}'].get.responses['200'].content['application/json'].examples.preparing.value.data.activeRecommendation.readiness.readyMemberCount")
                         .value(2))
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/groups/{groupId}'].get.responses['200'].content['application/json'].examples.success.value.data.inviteCode")
+                        "$.paths['/api/v1/groups/{groupId}'].get.responses['200'].content['application/json'].examples.open.value.data.activeRecommendation.status")
+                        .value("OPEN"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}'].get.responses['200'].content['application/json'].examples.open.value.data.activeRecommendation.candidates[0].menuName")
+                        .value("비빔밥"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}'].get.responses['200'].content['application/json'].examples.open.value.data.activeRecommendation.voteProgress.votedMemberCount")
+                        .value(3))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}'].get.responses['200'].content['application/json'].examples.preparing.value.data.inviteCode")
                         .value("LUNCH42"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}'].patch.responses['200'].content['application/json'].examples.success.value.data.name")

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -344,10 +344,13 @@ class OpenApiDocumentationIntegrationTest {
                         .value("내 그룹 목록 조회"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups'].get.responses['200'].content['application/json'].examples.success.value.data.content[0].latestRecommendationStatus")
-                        .value(nullValue()))
+                        .value("PREPARING"))
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/groups/{groupId}'].get.responses['200'].content['application/json'].examples.success.value.data.activeRecommendation")
-                        .value(nullValue()))
+                        "$.paths['/api/v1/groups/{groupId}'].get.responses['200'].content['application/json'].examples.success.value.data.activeRecommendation.status")
+                        .value("PREPARING"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}'].get.responses['200'].content['application/json'].examples.success.value.data.activeRecommendation.readiness.readyMemberCount")
+                        .value(2))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}'].get.responses['200'].content['application/json'].examples.success.value.data.inviteCode")
                         .value("LUNCH42"))
@@ -411,6 +414,9 @@ class OpenApiDocumentationIntegrationTest {
                         .doesNotExist())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}'].get.responses['200'].content['application/json'].examples.success.value.data.finalCandidate")
+                        .value((Object) null))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}'].get.responses['200'].content['application/json'].examples.success.value.data.readiness")
                         .value((Object) null))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}'].get.responses['200'].content['application/json'].examples.success.value.data.resultJson")

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -432,8 +432,14 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath("$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/ready'].post.summary")
                         .value("그룹 추천 준비 완료"))
                 .andExpect(jsonPath(
-                        "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/ready'].post.responses['200'].content['application/json'].examples.success.value.data.readiness.readyMemberCount")
+                        "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/ready'].post.responses['200'].content['application/json'].examples.preparing.value.data.readiness.readyMemberCount")
                         .value(3))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/ready'].post.responses['200'].content['application/json'].examples.opened.value.data.status")
+                        .value("OPEN"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/ready'].post.responses['200'].content['application/json'].examples.opened.value.data.candidates[0].menuName")
+                        .value("비빔밥"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/votes'].post.responses['200'].content['application/json'].examples.success.value.data.candidateId")
                         .value(8001))


### PR DESCRIPTION
## 관련 이슈
Closes #267 

## 📝 작업 내용

- `GET /api/v1/groups/{groupId}`의 `activeRecommendation`이 이제 `OPEN`뿐 아니라 `PREPARING` 세션도 반환
- `GET /api/v1/groups/{groupId}/recommendations/{sessionId}`는 `PREPARING`이면 `readiness` 진행률을 반환하고, `candidates=[]`, `voteProgress=null`로 응답
- `GET /api/v1/groups`의 `latestRecommendationStatus`가 최신 추천 상태를 실제로 반환
- `POST /api/v1/groups/{groupId}/recommendations/{sessionId}/ready`의 200 예시를 2개로 분리
- `GET /api/v1/groups/{groupId}` 200 예시를 2개로 분리

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 그룹 API 응답 경량화 작업 필요 (중복 데이터 존재)
