### PR TITLE
[Docs] API에 고유 넘버링 추가 및 정렬

### DIFF
--- a/src/main/java/matchuri/backend/global/config/OpenApiConfig.java
+++ b/src/main/java/matchuri/backend/global/config/OpenApiConfig.java
@@ -10,11 +10,17 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.Paths;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.tags.Tag;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -22,6 +28,17 @@ import org.springframework.context.annotation.Configuration;
 public class OpenApiConfig {
 
     private static final String BEARER_SCHEME = "bearerAuth";
+    private static final Pattern API_ID_PREFIX_PATTERN = Pattern.compile("^\\[[A-Z0-9]+\\.\\d{3}\\.\\d{3}]\\s*");
+    private static final List<Tag> API_FLOW_TAGS = List.of(
+            tag("00 Ops", "공통/운영 API"),
+            tag("01 Auth", "인증/가입 플로우 API"),
+            tag("02 Onboarding", "온보딩/내 정보 플로우 API"),
+            tag("03 Menu Reference", "메뉴/취향 참조 플로우 API"),
+            tag("04 Recommendation", "개인 추천 플로우 API"),
+            tag("05 Group", "그룹 생성/참여 플로우 API"),
+            tag("06 Group Recommendation", "그룹 추천/투표 플로우 API"),
+            tag("09 Admin", "관리자 데이터 운영 API"));
+    private static final Map<ApiOperationKey, ApiOperationMetadata> API_OPERATION_METADATA = apiOperationMetadata();
 
     @Bean
     public OpenAPI matchuriOpenApi() {
@@ -40,7 +57,7 @@ public class OpenApiConfig {
                 .addSecurityItem(new SecurityRequirement().addList(BEARER_SCHEME))
                 .path("/api/v1/health", new PathItem().get(
                         new Operation()
-                                .tags(List.of("Ops"))
+                                .tags(List.of("00 Ops"))
                                 .summary("헬스 체크")
                                 .description("""
                                         백엔드 서비스의 기본 가용 상태를 확인합니다.
@@ -66,5 +83,211 @@ public class OpenApiConfig {
                                                                                   "status": "UP"
                                                                                 }
                                                                                 """))))))));
+    }
+
+    @Bean
+    public OpenApiCustomizer apiFlowMetadataCustomizer() {
+        return openApi -> {
+            openApi.setTags(API_FLOW_TAGS);
+            API_OPERATION_METADATA.forEach((key, metadata) -> applyApiMetadata(openApi, key, metadata));
+        };
+    }
+
+    private static void applyApiMetadata(OpenAPI openApi, ApiOperationKey key, ApiOperationMetadata metadata) {
+        Paths paths = openApi.getPaths();
+        if (paths == null || !paths.containsKey(key.path())) {
+            return;
+        }
+
+        Operation operation = paths.get(key.path()).readOperationsMap().get(key.method());
+        if (operation == null) {
+            return;
+        }
+
+        operation.setTags(List.of(metadata.tagName()));
+        operation.addExtension("x-api-id", metadata.apiId());
+        operation.setSummary(withApiIdPrefix(metadata.apiId(), operation.getSummary()));
+    }
+
+    private static String withApiIdPrefix(String apiId, String summary) {
+        String normalizedSummary = summary == null ? "" : API_ID_PREFIX_PATTERN.matcher(summary).replaceFirst("");
+        return "[" + apiId + "] " + normalizedSummary;
+    }
+
+    private static Tag tag(String name, String description) {
+        return new Tag().name(name).description(description);
+    }
+
+    private static Map<ApiOperationKey, ApiOperationMetadata> apiOperationMetadata() {
+        Map<ApiOperationKey, ApiOperationMetadata> metadata = new LinkedHashMap<>();
+
+        metadata.put(key("/api/v1/health", PathItem.HttpMethod.GET), meta("OPS.010.000", "00 Ops"));
+
+        metadata.put(key("/api/v1/auth/email", PathItem.HttpMethod.POST), meta("AUTH.010.000", "01 Auth"));
+        metadata.put(key("/api/v1/auth/email/confirm", PathItem.HttpMethod.POST), meta("AUTH.020.000", "01 Auth"));
+        metadata.put(key("/api/v1/members/exists/{loginId}", PathItem.HttpMethod.GET), meta("AUTH.030.000", "01 Auth"));
+        metadata.put(
+                key("/api/v1/members/exists/nickname/{nickname}", PathItem.HttpMethod.GET),
+                meta("AUTH.040.000", "01 Auth"));
+        metadata.put(key("/api/v1/members/signup", PathItem.HttpMethod.POST), meta("AUTH.050.000", "01 Auth"));
+        metadata.put(key("/api/v1/auth/oauth2/{provider}", PathItem.HttpMethod.GET), meta("AUTH.060.000", "01 Auth"));
+        metadata.put(
+                key("/api/v1/auth/oauth2/exchange", PathItem.HttpMethod.POST),
+                meta("AUTH.070.000", "01 Auth"));
+        metadata.put(key("/api/v1/auth/login", PathItem.HttpMethod.POST), meta("AUTH.080.000", "01 Auth"));
+        metadata.put(key("/api/v1/auth/refresh", PathItem.HttpMethod.POST), meta("AUTH.090.000", "01 Auth"));
+        metadata.put(key("/api/v1/auth/logout", PathItem.HttpMethod.POST), meta("AUTH.100.000", "01 Auth"));
+        metadata.put(
+                key("/api/v1/auth/recovery/login-id", PathItem.HttpMethod.POST),
+                meta("AUTH.110.000", "01 Auth"));
+        metadata.put(
+                key("/api/v1/auth/recovery/password", PathItem.HttpMethod.POST),
+                meta("AUTH.120.000", "01 Auth"));
+        metadata.put(key("/api/v1/members", PathItem.HttpMethod.POST), meta("AUTH.900.000", "01 Auth"));
+
+        metadata.put(
+                key("/api/v1/member-agreements/required-status", PathItem.HttpMethod.GET),
+                meta("ONB.010.000", "02 Onboarding"));
+        metadata.put(
+                key("/api/v1/member-agreements/consents", PathItem.HttpMethod.POST),
+                meta("ONB.020.000", "02 Onboarding"));
+        metadata.put(key("/api/v1/members/me", PathItem.HttpMethod.GET), meta("ONB.030.000", "02 Onboarding"));
+        metadata.put(key("/api/v1/members/me", PathItem.HttpMethod.PATCH), meta("ONB.040.000", "02 Onboarding"));
+        metadata.put(
+                key("/api/v1/members/me/password", PathItem.HttpMethod.PATCH),
+                meta("ONB.050.000", "02 Onboarding"));
+        metadata.put(
+                key("/api/v1/members/me/taste-profile", PathItem.HttpMethod.GET),
+                meta("ONB.060.000", "02 Onboarding"));
+        metadata.put(
+                key("/api/v1/members/me/taste-profile", PathItem.HttpMethod.PATCH),
+                meta("ONB.070.000", "02 Onboarding"));
+        metadata.put(key("/api/v1/members/me", PathItem.HttpMethod.DELETE), meta("ONB.080.000", "02 Onboarding"));
+
+        metadata.put(
+                key("/api/v1/attribute-categories", PathItem.HttpMethod.GET),
+                meta("REF.010.000", "03 Menu Reference"));
+        metadata.put(
+                key("/api/v1/restriction-ingredients", PathItem.HttpMethod.GET),
+                meta("REF.020.000", "03 Menu Reference"));
+        metadata.put(key("/api/v1/menu-items", PathItem.HttpMethod.GET), meta("REF.030.000", "03 Menu Reference"));
+        metadata.put(
+                key("/api/v1/menu-items/{menuItemId}", PathItem.HttpMethod.GET),
+                meta("REF.040.000", "03 Menu Reference"));
+
+        metadata.put(
+                key("/api/v1/guest/recommendations", PathItem.HttpMethod.POST),
+                meta("REC.010.000", "04 Recommendation"));
+        metadata.put(
+                key("/api/v1/personal/recommendations", PathItem.HttpMethod.GET),
+                meta("REC.020.000", "04 Recommendation"));
+        metadata.put(
+                key("/api/v1/personal/recommendations", PathItem.HttpMethod.POST),
+                meta("REC.030.000", "04 Recommendation"));
+        metadata.put(
+                key("/api/v1/personal/recommendations/{requestId}/reroll", PathItem.HttpMethod.POST),
+                meta("REC.040.000", "04 Recommendation"));
+        metadata.put(
+                key("/api/v1/personal/recommendations/{requestId}", PathItem.HttpMethod.GET),
+                meta("REC.050.000", "04 Recommendation"));
+        metadata.put(
+                key("/api/v1/personal/recommendations/{requestId}/candidates", PathItem.HttpMethod.GET),
+                meta("REC.060.000", "04 Recommendation"));
+        metadata.put(
+                key("/api/v1/personal/recommendations/{requestId}", PathItem.HttpMethod.PATCH),
+                meta("REC.070.000", "04 Recommendation"));
+
+        metadata.put(key("/api/v1/groups", PathItem.HttpMethod.POST), meta("GROUP.010.000", "05 Group"));
+        metadata.put(key("/api/v1/groups", PathItem.HttpMethod.GET), meta("GROUP.020.000", "05 Group"));
+        metadata.put(key("/api/v1/groups/{groupId}", PathItem.HttpMethod.GET), meta("GROUP.030.000", "05 Group"));
+        metadata.put(
+                key("/api/v1/groups/{groupId}", PathItem.HttpMethod.PATCH),
+                meta("GROUP.040.000", "05 Group"));
+        metadata.put(
+                key("/api/v1/groups/invites/nickname", PathItem.HttpMethod.POST),
+                meta("GROUP.050.000", "05 Group"));
+        metadata.put(
+                key("/api/v1/groups/invites/me", PathItem.HttpMethod.GET),
+                meta("GROUP.060.000", "05 Group"));
+        metadata.put(
+                key("/api/v1/groups/invites/{inviteId}/response", PathItem.HttpMethod.POST),
+                meta("GROUP.070.000", "05 Group"));
+        metadata.put(key("/api/v1/groups/join", PathItem.HttpMethod.POST), meta("GROUP.080.000", "05 Group"));
+        metadata.put(
+                key("/api/v1/groups/{groupId}/leave", PathItem.HttpMethod.POST),
+                meta("GROUP.090.000", "05 Group"));
+        metadata.put(key("/api/v1/groups/{groupId}", PathItem.HttpMethod.DELETE), meta("GROUP.100.000", "05 Group"));
+
+        metadata.put(
+                key("/api/v1/groups/{groupId}/recommendations", PathItem.HttpMethod.POST),
+                meta("GREC.010.000", "06 Group Recommendation"));
+        metadata.put(
+                key("/api/v1/groups/{groupId}/recommendations/{sessionId}/readiness", PathItem.HttpMethod.GET),
+                meta("GREC.020.000", "06 Group Recommendation"));
+        metadata.put(
+                key("/api/v1/groups/{groupId}/recommendations/{sessionId}/ready", PathItem.HttpMethod.POST),
+                meta("GREC.030.000", "06 Group Recommendation"));
+        metadata.put(
+                key("/api/v1/groups/{groupId}/recommendations", PathItem.HttpMethod.GET),
+                meta("GREC.040.000", "06 Group Recommendation"));
+        metadata.put(
+                key("/api/v1/groups/{groupId}/recommendations/{sessionId}", PathItem.HttpMethod.GET),
+                meta("GREC.050.000", "06 Group Recommendation"));
+        metadata.put(
+                key("/api/v1/groups/{groupId}/recommendations/{sessionId}/candidates", PathItem.HttpMethod.GET),
+                meta("GREC.060.000", "06 Group Recommendation"));
+        metadata.put(
+                key("/api/v1/groups/{groupId}/recommendations/{sessionId}/reroll", PathItem.HttpMethod.POST),
+                meta("GREC.070.000", "06 Group Recommendation"));
+        metadata.put(
+                key("/api/v1/groups/{groupId}/recommendations/{sessionId}/votes", PathItem.HttpMethod.POST),
+                meta("GREC.080.000", "06 Group Recommendation"));
+        metadata.put(
+                key("/api/v1/groups/{groupId}/recommendations/{sessionId}/finalize", PathItem.HttpMethod.PATCH),
+                meta("GREC.090.000", "06 Group Recommendation"));
+
+        metadata.put(
+                key("/api/v1/admin/attribute-categories", PathItem.HttpMethod.GET),
+                meta("ADMIN.010.000", "09 Admin"));
+        metadata.put(
+                key("/api/v1/admin/attribute-categories", PathItem.HttpMethod.POST),
+                meta("ADMIN.020.000", "09 Admin"));
+        metadata.put(
+                key("/api/v1/admin/attribute-categories/{attributeCategoryId}", PathItem.HttpMethod.PATCH),
+                meta("ADMIN.030.000", "09 Admin"));
+        metadata.put(
+                key("/api/v1/admin/attribute-categories/{attributeCategoryId}", PathItem.HttpMethod.DELETE),
+                meta("ADMIN.040.000", "09 Admin"));
+        metadata.put(key("/api/v1/admin/ingredients", PathItem.HttpMethod.GET), meta("ADMIN.050.000", "09 Admin"));
+        metadata.put(key("/api/v1/admin/ingredients", PathItem.HttpMethod.POST), meta("ADMIN.060.000", "09 Admin"));
+        metadata.put(
+                key("/api/v1/admin/ingredients/{ingredientId}", PathItem.HttpMethod.PATCH),
+                meta("ADMIN.070.000", "09 Admin"));
+        metadata.put(
+                key("/api/v1/admin/ingredients/{ingredientId}", PathItem.HttpMethod.DELETE),
+                meta("ADMIN.080.000", "09 Admin"));
+        metadata.put(key("/api/v1/admin/menu-items", PathItem.HttpMethod.GET), meta("ADMIN.090.000", "09 Admin"));
+        metadata.put(
+                key("/api/v1/admin/menu-items/{menuItemId}", PathItem.HttpMethod.PATCH),
+                meta("ADMIN.100.000", "09 Admin"));
+        metadata.put(
+                key("/api/v1/admin/menu-items/{menuItemId}", PathItem.HttpMethod.DELETE),
+                meta("ADMIN.110.000", "09 Admin"));
+
+        return metadata;
+    }
+
+    private static ApiOperationKey key(String path, PathItem.HttpMethod method) {
+        return new ApiOperationKey(path, method);
+    }
+
+    private static ApiOperationMetadata meta(String apiId, String tagName) {
+        return new ApiOperationMetadata(apiId, tagName);
+    }
+
+    private record ApiOperationKey(String path, PathItem.HttpMethod method) {
+    }
+
+    private record ApiOperationMetadata(String apiId, String tagName) {
     }
 }

--- a/src/main/java/matchuri/backend/global/config/OpenApiConfig.java
+++ b/src/main/java/matchuri/backend/global/config/OpenApiConfig.java
@@ -90,6 +90,7 @@ public class OpenApiConfig {
         return openApi -> {
             openApi.setTags(API_FLOW_TAGS);
             API_OPERATION_METADATA.forEach((key, metadata) -> applyApiMetadata(openApi, key, metadata));
+            sortPathsByApiOperationMetadata(openApi);
         };
     }
 
@@ -107,6 +108,27 @@ public class OpenApiConfig {
         operation.setTags(List.of(metadata.tagName()));
         operation.addExtension("x-api-id", metadata.apiId());
         operation.setSummary(withApiIdPrefix(metadata.apiId(), operation.getSummary()));
+    }
+
+    private static void sortPathsByApiOperationMetadata(OpenAPI openApi) {
+        Paths paths = openApi.getPaths();
+        if (paths == null) {
+            return;
+        }
+
+        Paths sortedPaths = new Paths();
+        API_OPERATION_METADATA.keySet().forEach(key -> {
+            if (paths.containsKey(key.path()) && !sortedPaths.containsKey(key.path())) {
+                sortedPaths.addPathItem(key.path(), paths.get(key.path()));
+            }
+        });
+        paths.forEach((path, pathItem) -> {
+            if (!sortedPaths.containsKey(path)) {
+                sortedPaths.addPathItem(path, pathItem);
+            }
+        });
+
+        openApi.setPaths(sortedPaths);
     }
 
     private static String withApiIdPrefix(String apiId, String summary) {

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -29,7 +29,11 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith("application/json"))
                 .andExpect(jsonPath("$.paths['/api/v1/members/exists/{loginId}'].get.summary")
-                        .value("로그인 ID 중복 확인"))
+                        .value("[AUTH.030.000] 로그인 ID 중복 확인"))
+                .andExpect(jsonPath("$.paths['/api/v1/members/exists/{loginId}'].get['x-api-id']")
+                        .value("AUTH.030.000"))
+                .andExpect(jsonPath("$.paths['/api/v1/members/exists/{loginId}'].get.tags[0]")
+                        .value("01 Auth"))
                 .andExpect(jsonPath("$.paths['/api/v1/members/exists/{loginId}'].get.description")
                         .value(org.hamcrest.Matchers.containsString("인증 없이 호출할 수 있습니다.")))
                 .andExpect(jsonPath("$.paths['/api/v1/members/exists/{loginId}'].get.parameters[0].description")
@@ -50,7 +54,11 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith("application/json"))
                 .andExpect(jsonPath("$.paths['/api/v1/auth/login'].post.summary")
-                        .value("로컬 로그인"))
+                        .value("[AUTH.080.000] 로컬 로그인"))
+                .andExpect(jsonPath("$.paths['/api/v1/auth/login'].post['x-api-id']")
+                        .value("AUTH.080.000"))
+                .andExpect(jsonPath("$.paths['/api/v1/auth/login'].post.tags[0]")
+                        .value("01 Auth"))
                 .andExpect(jsonPath("$.paths['/api/v1/auth/login'].post.security").isEmpty())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/auth/login'].post.responses['200'].content['application/json'].schema.$ref")
@@ -66,14 +74,14 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/auth/refresh'].post.responses['403'].content['application/json'].examples.inactiveMember.value.error.code")
                         .value("MEMBER_INACTIVE_MEMBER"))
                 .andExpect(jsonPath("$.paths['/api/v1/auth/oauth2/{provider}'].get.summary")
-                        .value("소셜 OAuth2 로그인 시작"))
+                        .value("[AUTH.060.000] 소셜 OAuth2 로그인 시작"))
                 .andExpect(jsonPath("$.paths['/api/v1/auth/oauth2/{provider}'].get.security").isEmpty())
                 .andExpect(jsonPath("$.paths['/api/v1/auth/oauth2/exchange'].post.security").isEmpty())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/auth/oauth2/exchange'].post.responses['200'].content['application/json'].schema.$ref")
                         .value("#/components/schemas/LoginApiResponse"))
                 .andExpect(jsonPath("$.paths['/api/v1/auth/email'].post.summary")
-                        .value("이메일 인증 코드 발송"))
+                        .value("[AUTH.010.000] 이메일 인증 코드 발송"))
                 .andExpect(jsonPath("$.paths['/api/v1/auth/email'].post.security").isEmpty())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/auth/email'].post.responses['200'].content['application/json'].schema.$ref")
@@ -82,7 +90,7 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/auth/email'].post.responses['502'].content['application/json'].examples.sendFailed.value.error.code")
                         .value("AUTH_EMAIL_SEND_FAILED"))
                 .andExpect(jsonPath("$.paths['/api/v1/auth/email/confirm'].post.summary")
-                        .value("이메일 인증 코드 확인"))
+                        .value("[AUTH.020.000] 이메일 인증 코드 확인"))
                 .andExpect(jsonPath("$.paths['/api/v1/auth/email/confirm'].post.security").isEmpty())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/auth/email/confirm'].post.responses['200'].content['application/json'].schema.$ref")
@@ -91,7 +99,7 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/auth/email/confirm'].post.responses['401'].content['application/json'].examples.verificationFailed.value.error.code")
                         .value("AUTH_EMAIL_VERIFICATION_FAILED"))
                 .andExpect(jsonPath("$.paths['/api/v1/auth/recovery/login-id'].post.summary")
-                        .value("로그인 ID 찾기"))
+                        .value("[AUTH.110.000] 로그인 ID 찾기"))
                 .andExpect(jsonPath("$.paths['/api/v1/auth/recovery/login-id'].post.security").isEmpty())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/auth/recovery/login-id'].post.responses['200'].content['application/json'].schema.$ref")
@@ -100,7 +108,7 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/auth/recovery/login-id'].post.responses['401'].content['application/json'].examples.emailVerificationFailed.value.error.code")
                         .value("AUTH_EMAIL_VERIFICATION_FAILED"))
                 .andExpect(jsonPath("$.paths['/api/v1/auth/recovery/password'].post.summary")
-                        .value("비밀번호 재설정"))
+                        .value("[AUTH.120.000] 비밀번호 재설정"))
                 .andExpect(jsonPath("$.paths['/api/v1/auth/recovery/password'].post.security").isEmpty())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/auth/recovery/password'].post.responses['200'].content['application/json'].schema.$ref")
@@ -228,7 +236,11 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith("application/json"))
                 .andExpect(jsonPath("$.paths['/api/v1/guest/recommendations'].post.summary")
-                        .value("비회원 개인 추천 요청"))
+                        .value("[REC.010.000] 비회원 개인 추천 요청"))
+                .andExpect(jsonPath("$.paths['/api/v1/guest/recommendations'].post['x-api-id']")
+                        .value("REC.010.000"))
+                .andExpect(jsonPath("$.paths['/api/v1/guest/recommendations'].post.tags[0]")
+                        .value("04 Recommendation"))
                 .andExpect(jsonPath("$.paths['/api/v1/guest/recommendations'].post.security").isEmpty())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/guest/recommendations'].post.responses['200'].content['application/json'].schema.$ref")
@@ -258,7 +270,7 @@ class OpenApiDocumentationIntegrationTest {
                         "$.components.schemas.CreateGuestPersonalRecommendationRequest.properties.attributeCategoryIds.description")
                         .value(org.hamcrest.Matchers.containsString("attribute category ID 목록")))
                 .andExpect(jsonPath("$.paths['/api/v1/personal/recommendations'].get.summary")
-                        .value("내 개인 추천 이력 목록 조회"))
+                        .value("[REC.020.000] 내 개인 추천 이력 목록 조회"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/personal/recommendations'].get.responses['200'].content['application/json'].examples.success.value.data.content[0].id")
                         .value(9001))
@@ -266,7 +278,7 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/personal/recommendations'].get.responses['200'].content['application/json'].examples.success.value.data.content[0].closedAt")
                         .value(nullValue()))
                 .andExpect(jsonPath("$.paths['/api/v1/personal/recommendations'].post.summary")
-                        .value("개인 추천 요청 생성"))
+                        .value("[REC.030.000] 개인 추천 요청 생성"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/personal/recommendations'].post.responses['200'].content['application/json'].examples.success.value.data.candidates[0].menuName")
                         .value("비빔밥"))
@@ -283,7 +295,7 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/personal/recommendations'].post.responses['409'].content['application/json'].examples.openExists.value.error.code")
                         .value("PERSONAL_RECOMMENDATION_OPEN_EXISTS"))
                 .andExpect(jsonPath("$.paths['/api/v1/personal/recommendations/{requestId}/reroll'].post.summary")
-                        .value("개인 추천 재요청"))
+                        .value("[REC.040.000] 개인 추천 재요청"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/personal/recommendations/{requestId}/reroll'].post.responses['200'].content['application/json'].examples.success.value.data.candidates[0].menuName")
                         .value("김치찌개"))
@@ -333,7 +345,11 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/personal/recommendations/{requestId}'].patch.responses['409'].content['application/json'].examples.expired.value.error.code")
                         .value("PERSONAL_RECOMMENDATION_EXPIRED"))
                 .andExpect(jsonPath("$.paths['/api/v1/groups'].post.summary")
-                        .value("그룹 생성"))
+                        .value("[GROUP.010.000] 그룹 생성"))
+                .andExpect(jsonPath("$.paths['/api/v1/groups'].post['x-api-id']")
+                        .value("GROUP.010.000"))
+                .andExpect(jsonPath("$.paths['/api/v1/groups'].post.tags[0]")
+                        .value("05 Group"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups'].post.responses['200'].content['application/json'].examples.success.value.data.groupId")
                         .value(3001))
@@ -341,7 +357,7 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/groups'].post.responses['200'].content['application/json'].examples.success.value.data.inviteCode")
                         .value("LUNCH42"))
                 .andExpect(jsonPath("$.paths['/api/v1/groups'].get.summary")
-                        .value("내 그룹 목록 조회"))
+                        .value("[GROUP.020.000] 내 그룹 목록 조회"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups'].get.responses['200'].content['application/json'].examples.success.value.data.content[0].latestRecommendationStatus")
                         .value("PREPARING"))
@@ -370,7 +386,7 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/groups/{groupId}'].patch.responses['200'].content['application/json'].examples.success.value.data.latitude")
                         .value(37.498095))
                 .andExpect(jsonPath("$.paths['/api/v1/groups/invites/nickname'].post.summary")
-                        .value("닉네임 기반 그룹 초대 생성"))
+                        .value("[GROUP.050.000] 닉네임 기반 그룹 초대 생성"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/invites/nickname'].post.responses['200'].content['application/json'].examples.success.value.data.status")
                         .value("PENDING"))
@@ -378,12 +394,12 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/groups/invites/nickname'].post.responses['200'].content['application/json'].examples.success.value.data.targetNickname")
                         .value("점심탐험가"))
                 .andExpect(jsonPath("$.paths['/api/v1/groups/invites/me'].get.summary")
-                        .value("내 그룹 초대 목록 조회"))
+                        .value("[GROUP.060.000] 내 그룹 초대 목록 조회"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/invites/me'].get.responses['200'].content['application/json'].examples.success.value.data.content[0].status")
                         .value("PENDING"))
                 .andExpect(jsonPath("$.paths['/api/v1/groups/invites/{inviteId}/response'].post.summary")
-                        .value("그룹 초대 응답"))
+                        .value("[GROUP.070.000] 그룹 초대 응답"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/invites/{inviteId}/response'].post.responses['200'].content['application/json'].examples.success.value.data.inviteStatus")
                         .value("ACCEPTED"))
@@ -434,12 +450,16 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/candidates'].get.responses['200'].content['application/json'].examples.success.value.data.candidates[1].menuName")
                         .value("돈까스"))
                 .andExpect(jsonPath("$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/readiness'].get.summary")
-                        .value("그룹 추천 준비 상태 조회"))
+                        .value("[GREC.020.000] 그룹 추천 준비 상태 조회"))
+                .andExpect(jsonPath("$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/readiness'].get['x-api-id']")
+                        .value("GREC.020.000"))
+                .andExpect(jsonPath("$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/readiness'].get.tags[0]")
+                        .value("06 Group Recommendation"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/readiness'].get.responses['200'].content['application/json'].examples.success.value.data.progress.readyMemberCount")
                         .value(2))
                 .andExpect(jsonPath("$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/ready'].post.summary")
-                        .value("그룹 추천 준비 완료"))
+                        .value("[GREC.030.000] 그룹 추천 준비 완료"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/ready'].post.responses['200'].content['application/json'].examples.preparing.value.data.readiness.readyMemberCount")
                         .value(3))
@@ -467,25 +487,29 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith("application/json"))
                 .andExpect(jsonPath("$.paths['/api/v1/attribute-categories'].get.summary")
-                        .value("attribute category 목록 조회"))
+                        .value("[REF.010.000] attribute category 목록 조회"))
+                .andExpect(jsonPath("$.paths['/api/v1/attribute-categories'].get['x-api-id']")
+                        .value("REF.010.000"))
+                .andExpect(jsonPath("$.paths['/api/v1/attribute-categories'].get.tags[0]")
+                        .value("03 Menu Reference"))
                 .andExpect(jsonPath("$.paths['/api/v1/attribute-categories'].get.security").isEmpty())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/attribute-categories'].get.responses['200'].content['application/json'].schema.$ref")
                         .value("#/components/schemas/AttributeCategoryListApiResponse"))
                 .andExpect(jsonPath("$.paths['/api/v1/restriction-ingredients'].get.summary")
-                        .value("restriction ingredient 목록 조회"))
+                        .value("[REF.020.000] restriction ingredient 목록 조회"))
                 .andExpect(jsonPath("$.paths['/api/v1/restriction-ingredients'].get.security").isEmpty())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/restriction-ingredients'].get.responses['200'].content['application/json'].schema.$ref")
                         .value("#/components/schemas/RestrictionIngredientListApiResponse"))
                 .andExpect(jsonPath("$.paths['/api/v1/menu-items'].get.summary")
-                        .value("메뉴 목록 조회"))
+                        .value("[REF.030.000] 메뉴 목록 조회"))
                 .andExpect(jsonPath("$.paths['/api/v1/menu-items'].get.security").isEmpty())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/menu-items'].get.responses['200'].content['application/json'].schema.$ref")
                         .value("#/components/schemas/MenuItemSummaryListApiResponse"))
                 .andExpect(jsonPath("$.paths['/api/v1/menu-items/{menuItemId}'].get.summary")
-                        .value("메뉴 상세 조회"))
+                        .value("[REF.040.000] 메뉴 상세 조회"))
                 .andExpect(jsonPath("$.paths['/api/v1/menu-items/{menuItemId}'].get.security").isEmpty())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/menu-items/{menuItemId}'].get.responses['200'].content['application/json'].schema.$ref")
@@ -512,7 +536,11 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith("application/json"))
                 .andExpect(jsonPath("$.paths['/api/v1/admin/attribute-categories'].get.summary")
-                        .value("관리자 attribute category 목록 조회"))
+                        .value("[ADMIN.010.000] 관리자 attribute category 목록 조회"))
+                .andExpect(jsonPath("$.paths['/api/v1/admin/attribute-categories'].get['x-api-id']")
+                        .value("ADMIN.010.000"))
+                .andExpect(jsonPath("$.paths['/api/v1/admin/attribute-categories'].get.tags[0]")
+                        .value("09 Admin"))
                 .andExpect(
                         jsonPath("$.paths['/api/v1/admin/attribute-categories'].get.security[0].bearerAuth").exists())
                 .andExpect(jsonPath(
@@ -525,7 +553,7 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/admin/attribute-categories'].get.responses['403'].content['application/json'].examples.forbidden.value.error.code")
                         .value("AUTH_FORBIDDEN"))
                 .andExpect(jsonPath("$.paths['/api/v1/admin/ingredients'].get.summary")
-                        .value("관리자 ingredient 목록 조회"))
+                        .value("[ADMIN.050.000] 관리자 ingredient 목록 조회"))
                 .andExpect(jsonPath("$.paths['/api/v1/admin/ingredients'].get.security[0].bearerAuth").exists())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/admin/ingredients'].get.responses['200'].content['application/json'].schema.$ref")
@@ -537,7 +565,7 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/admin/ingredients'].get.responses['403'].content['application/json'].examples.forbidden.value.error.code")
                         .value("AUTH_FORBIDDEN"))
                 .andExpect(jsonPath("$.paths['/api/v1/admin/menu-items'].get.summary")
-                        .value("관리자 메뉴 목록 조회"))
+                        .value("[ADMIN.090.000] 관리자 메뉴 목록 조회"))
                 .andExpect(jsonPath("$.paths['/api/v1/admin/menu-items'].get.security[0].bearerAuth").exists())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/admin/menu-items'].get.responses['200'].content['application/json'].schema.$ref")
@@ -549,7 +577,7 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/admin/menu-items'].get.responses['403'].content['application/json'].examples.forbidden.value.error.code")
                         .value("AUTH_FORBIDDEN"))
                 .andExpect(jsonPath("$.paths['/api/v1/admin/menu-items/{menuItemId}'].patch.summary")
-                        .value("관리자 메뉴 수정"))
+                        .value("[ADMIN.100.000] 관리자 메뉴 수정"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/admin/menu-items/{menuItemId}'].patch.security[0].bearerAuth").exists())
                 .andExpect(jsonPath(
@@ -559,7 +587,7 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/admin/menu-items/{menuItemId}'].patch.responses['404'].content['application/json'].examples.notFound.value.error.code")
                         .value("MENU_NOT_FOUND"))
                 .andExpect(jsonPath("$.paths['/api/v1/admin/menu-items/{menuItemId}'].delete.summary")
-                        .value("관리자 메뉴 비활성화"))
+                        .value("[ADMIN.110.000] 관리자 메뉴 비활성화"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/admin/menu-items/{menuItemId}'].delete.security[0].bearerAuth").exists())
                 .andExpect(jsonPath(
@@ -569,7 +597,7 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/admin/menu-items/{menuItemId}'].delete.responses['404'].content['application/json'].examples.notFound.value.error.code")
                         .value("MENU_NOT_FOUND"))
                 .andExpect(jsonPath("$.paths['/api/v1/admin/ingredients'].post.summary")
-                        .value("관리자 ingredient 생성"))
+                        .value("[ADMIN.060.000] 관리자 ingredient 생성"))
                 .andExpect(jsonPath("$.paths['/api/v1/admin/ingredients'].post.security[0].bearerAuth").exists())
                 .andExpect(jsonPath("$.paths['/api/v1/admin/ingredients'].post.requestBody.required")
                         .value(true))
@@ -577,21 +605,21 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/admin/ingredients'].post.responses['200'].content['application/json'].schema.$ref")
                         .value("#/components/schemas/AdminIngredientApiResponse"))
                 .andExpect(jsonPath("$.paths['/api/v1/admin/ingredients/{ingredientId}'].patch.summary")
-                        .value("관리자 ingredient 수정"))
+                        .value("[ADMIN.070.000] 관리자 ingredient 수정"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/admin/ingredients/{ingredientId}'].patch.security[0].bearerAuth").exists())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/admin/ingredients/{ingredientId}'].patch.responses['200'].content['application/json'].schema.$ref")
                         .value("#/components/schemas/AdminIngredientApiResponse"))
                 .andExpect(jsonPath("$.paths['/api/v1/admin/ingredients/{ingredientId}'].delete.summary")
-                        .value("관리자 ingredient 비활성화"))
+                        .value("[ADMIN.080.000] 관리자 ingredient 비활성화"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/admin/ingredients/{ingredientId}'].delete.security[0].bearerAuth").exists())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/admin/ingredients/{ingredientId}'].delete.responses['200'].content['application/json'].schema.$ref")
                         .value("#/components/schemas/AdminIngredientApiResponse"))
                 .andExpect(jsonPath("$.paths['/api/v1/admin/attribute-categories'].post.summary")
-                        .value("관리자 attribute category 생성"))
+                        .value("[ADMIN.020.000] 관리자 attribute category 생성"))
                 .andExpect(
                         jsonPath("$.paths['/api/v1/admin/attribute-categories'].post.security[0].bearerAuth").exists())
                 .andExpect(jsonPath("$.paths['/api/v1/admin/attribute-categories'].post.requestBody.required")
@@ -600,7 +628,7 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/admin/attribute-categories'].post.responses['200'].content['application/json'].schema.$ref")
                         .value("#/components/schemas/AdminAttributeCategoryApiResponse"))
                 .andExpect(jsonPath("$.paths['/api/v1/admin/attribute-categories/{attributeCategoryId}'].patch.summary")
-                        .value("관리자 attribute category 수정"))
+                        .value("[ADMIN.030.000] 관리자 attribute category 수정"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/admin/attribute-categories/{attributeCategoryId}'].patch.security[0].bearerAuth").exists())
                 .andExpect(jsonPath(
@@ -608,7 +636,7 @@ class OpenApiDocumentationIntegrationTest {
                         .value("#/components/schemas/AdminAttributeCategoryApiResponse"))
                 .andExpect(
                         jsonPath("$.paths['/api/v1/admin/attribute-categories/{attributeCategoryId}'].delete.summary")
-                                .value("관리자 attribute category 비활성화"))
+                                .value("[ADMIN.040.000] 관리자 attribute category 비활성화"))
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/admin/attribute-categories/{attributeCategoryId}'].delete.security[0].bearerAuth").exists())
                 .andExpect(jsonPath(

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -1,5 +1,6 @@
 package matchuri.backend.global.docs;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -21,6 +22,32 @@ class OpenApiDocumentationIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("OpenAPI 문서의 path 산출 순서가 API ID 순서를 따른다")
+    void sortsOpenApiPathsByApiIdOrder() throws Exception {
+        String openApiJson = mockMvc.perform(get("/docs/openapi"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("application/json"))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        assertAppearsInOrder(openApiJson,
+                "\"/api/v1/auth/email\":",
+                "\"/api/v1/auth/email/confirm\":",
+                "\"/api/v1/members/exists/{loginId}\":",
+                "\"/api/v1/members/exists/nickname/{nickname}\":",
+                "\"/api/v1/members/signup\":",
+                "\"/api/v1/auth/oauth2/{provider}\":",
+                "\"/api/v1/auth/oauth2/exchange\":",
+                "\"/api/v1/auth/login\":",
+                "\"/api/v1/auth/refresh\":",
+                "\"/api/v1/auth/logout\":",
+                "\"/api/v1/auth/recovery/login-id\":",
+                "\"/api/v1/auth/recovery/password\":",
+                "\"/api/v1/members\":");
+    }
 
     @Test
     @DisplayName("OpenAPI 문서에 loginId 중복 확인 API의 요약과 제약 설명이 노출된다")
@@ -695,5 +722,19 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath(
                         "$.components.schemas.SubmitRequiredAgreementsResponse.properties.accessToken.description")
                         .value(org.hamcrest.Matchers.containsString("새 access token")));
+    }
+
+    private static void assertAppearsInOrder(String content, String... fragments) {
+        int previousIndex = -1;
+        for (String fragment : fragments) {
+            int currentIndex = content.indexOf(fragment);
+            assertThat(currentIndex)
+                    .as("Expected OpenAPI content to contain %s", fragment)
+                    .isNotNegative();
+            assertThat(currentIndex)
+                    .as("Expected %s to appear after the previous API path", fragment)
+                    .isGreaterThan(previousIndex);
+            previousIndex = currentIndex;
+        }
     }
 }


### PR DESCRIPTION
## 관련 이슈
Closes #181 

## 📝 작업 내용
- API에 고유 넘버링 추가
- 고유 넘버링은 유저 플로우 기반
- 플로우가 추가됐을때 정렬에 유리한 버저닝 구조
- `OpenApiConfig.java`에서 중앙 관리 (구현 단순성)

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
실시간 소켓 및 SSE 기능을 제외한 API가 정의 및 구현 됐기에 고유 넘버링을 추가했습니다.

- 버저닝이 적절한지
- 도메인 구분이 적절한지
