### PR TITLE
[Refactor] 투표 API가 내부적으로 재투표 또한 호출하도록 로직 수정

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -630,9 +630,11 @@ public interface GroupApi {
                     정책:
                     - 활성 그룹 멤버만 투표할 수 있습니다.
                     - 열린 그룹 추천(`OPEN`)에만 투표할 수 있습니다.
-                    - 회원은 추천 세션당 한 번만 투표할 수 있습니다.
+                    - 회원은 추천 세션당 하나의 투표 row를 가지며, 다시 투표하면 기존 투표 후보를 변경합니다.
+                    - 같은 후보로 다시 투표하면 idempotent하게 기존 투표 정보를 반환합니다.
                     - `voteValue`는 사용하지 않고 후보 선택 여부만 저장합니다.
                     - 실제 저장 테이블은 `group_recommendation_votes` 기준입니다.
+                    - 응답의 `votedAt`은 최초 투표 또는 재투표로 마지막 반영된 시각입니다.
                     """
     )
     @ApiResponses({
@@ -642,10 +644,18 @@ public interface GroupApi {
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = GroupVoteApiResponse.class),
-                            examples = @ExampleObject(
-                                    name = "success",
-                                    value = GroupApiExamples.VOTE_SUCCESS
-                            )
+                            examples = {
+                                    @ExampleObject(
+                                            name = "success",
+                                            summary = "최초 투표",
+                                            value = GroupApiExamples.VOTE_SUCCESS
+                                    ),
+                                    @ExampleObject(
+                                            name = "revote",
+                                            summary = "기존 투표 후보 변경",
+                                            value = GroupApiExamples.REVOTE_SUCCESS
+                                    )
+                            }
                     )
             )
     })

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -551,6 +551,18 @@ public final class GroupApiExamples {
             }
             """;
 
+    public static final String REVOTE_SUCCESS = """
+            {
+              "success": true,
+              "data": {
+                "voteId": 91001,
+                "candidateId": 8002,
+                "votedAt": "2026-05-06T12:23:00"
+              },
+              "error": null
+            }
+            """;
+
     public static final String FINALIZE_RECOMMENDATION_SUCCESS = """
             {
               "success": true,

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationVote.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationVote.java
@@ -13,7 +13,7 @@ import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import matchuri.backend.domain.common.CreatedAtEntity;
+import matchuri.backend.domain.common.BaseEntity;
 import matchuri.backend.domain.member.entity.Member;
 
 @Getter
@@ -29,7 +29,7 @@ import matchuri.backend.domain.member.entity.Member;
         }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class GroupRecommendationVote extends CreatedAtEntity {
+public class GroupRecommendationVote extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -56,5 +56,13 @@ public class GroupRecommendationVote extends CreatedAtEntity {
         this.groupRecommendation = groupRecommendation;
         this.candidate = candidate;
         this.member = member;
+    }
+
+    public boolean hasCandidate(Long candidateId) {
+        return candidate.getId().equals(candidateId);
+    }
+
+    public void changeCandidate(GroupRecommendationCandidate candidate) {
+        this.candidate = candidate;
     }
 }

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationVoteRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationVoteRepository.java
@@ -1,6 +1,7 @@
 package matchuri.backend.domain.group.repository;
 
 import java.util.List;
+import java.util.Optional;
 import matchuri.backend.domain.group.entity.GroupRecommendationVote;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -21,4 +22,6 @@ public interface GroupRecommendationVoteRepository extends JpaRepository<GroupRe
     long countByGroupRecommendationId(Long recommendationId);
 
     boolean existsByGroupRecommendationIdAndMemberId(Long recommendationId, Long memberId);
+
+    Optional<GroupRecommendationVote> findByGroupRecommendationIdAndMemberId(Long recommendationId, Long memberId);
 }

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -413,6 +413,7 @@ public class GroupServiceImpl implements GroupService {
     }
 
     @Override
+    @Transactional
     public GroupVoteResult voteGroupRecommendation(Long groupId, Long sessionId, Long candidateId) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
         validateActiveMembership(groupId, member.getId());
@@ -429,23 +430,26 @@ public class GroupServiceImpl implements GroupService {
                 .orElseThrow(() -> new BusinessException(GroupErrorCode.RECOMMENDATION_CANDIDATE_NOT_FOUND,
                         candidateId));
 
-        if (groupRecommendationVoteRepository.existsByGroupRecommendationIdAndMemberId(
-                recommendation.getId(),
-                member.getId()
-        )) {
-            throw new BusinessException(GroupErrorCode.RECOMMENDATION_ALREADY_VOTED, sessionId, member.getId());
-        }
+        GroupRecommendationVote vote = groupRecommendationVoteRepository
+                .findByGroupRecommendationIdAndMemberId(recommendation.getId(), member.getId())
+                .map(existingVote -> {
+                    if (!existingVote.hasCandidate(candidate.getId())) {
+                        existingVote.changeCandidate(candidate);
+                    }
 
-        GroupRecommendationVote vote = groupRecommendationVoteRepository.save(new GroupRecommendationVote(
-                recommendation,
-                candidate,
-                member
-        ));
+                    return existingVote;
+                })
+                .orElseGet(() -> new GroupRecommendationVote(
+                        recommendation,
+                        candidate,
+                        member
+                ));
+        GroupRecommendationVote savedVote = groupRecommendationVoteRepository.saveAndFlush(vote);
 
         return new GroupVoteResult(
-                vote.getId(),
+                savedVote.getId(),
                 candidate.getId(),
-                vote.getCreatedAt()
+                savedVote.getUpdatedAt()
         );
     }
 

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -1088,11 +1088,56 @@ class GroupIntegrationTest {
     }
 
     @Test
-    @DisplayName("그룹 추천 투표는 같은 회원의 중복 투표를 거절한다")
-    void voteGroupRecommendationFailsForDuplicateVote() throws Exception {
-        Member owner = saveMember("recommendation-dup-vote-owner", "중복투표방장");
-        GroupRoom groupRoom = saveGroupOwnedBy(owner, "중복 투표 그룹");
-        MenuItem menuItem = saveMenu("dup-vote-menu", "중복투표메뉴");
+    @DisplayName("그룹 추천 투표는 같은 회원의 기존 투표 후보를 변경한다")
+    void voteGroupRecommendationChangesExistingMemberVote() throws Exception {
+        Member owner = saveMember("recommendation-revote-owner", "재투표방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "재투표 그룹");
+        MenuItem firstMenuItem = saveMenu("revote-first-menu", "재투표첫메뉴");
+        MenuItem secondMenuItem = saveMenu("revote-second-menu", "재투표둘째메뉴");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+        GroupRecommendationCandidate firstCandidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, firstMenuItem, 1, 10.0, "{}")
+        );
+        GroupRecommendationCandidate secondCandidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, secondMenuItem, 2, 9.0, "{}")
+        );
+        GroupRecommendationVote existingVote = groupRecommendationVoteRepository.save(new GroupRecommendationVote(
+                recommendation,
+                firstCandidate,
+                owner
+        ));
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations/{sessionId}/votes",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "candidateId": %d
+                                }
+                                """.formatted(secondCandidate.getId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.voteId").value(existingVote.getId()))
+                .andExpect(jsonPath("$.data.candidateId").value(secondCandidate.getId()))
+                .andExpect(jsonPath("$.data.votedAt").isNotEmpty());
+
+        assertThat(groupRecommendationVoteRepository.count()).isEqualTo(1);
+        GroupRecommendationVote updatedVote = groupRecommendationVoteRepository.findAll().getFirst();
+        assertThat(updatedVote.getId()).isEqualTo(existingVote.getId());
+        assertThat(updatedVote.getCandidate().getId()).isEqualTo(secondCandidate.getId());
+    }
+
+    @Test
+    @DisplayName("그룹 추천 투표는 같은 후보 재투표를 성공으로 처리한다")
+    void voteGroupRecommendationIsIdempotentForSameCandidate() throws Exception {
+        Member owner = saveMember("recommendation-idempotent-vote-owner", "재투표동일방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "동일 후보 재투표 그룹");
+        MenuItem menuItem = saveMenu("idempotent-vote-menu", "동일재투표메뉴");
         GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
                 groupRoom,
                 "{}",
@@ -1101,7 +1146,11 @@ class GroupIntegrationTest {
         GroupRecommendationCandidate candidate = groupRecommendationCandidateRepository.save(
                 new GroupRecommendationCandidate(recommendation, menuItem, 1, 10.0, "{}")
         );
-        groupRecommendationVoteRepository.save(new GroupRecommendationVote(recommendation, candidate, owner));
+        GroupRecommendationVote existingVote = groupRecommendationVoteRepository.save(new GroupRecommendationVote(
+                recommendation,
+                candidate,
+                owner
+        ));
 
         mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations/{sessionId}/votes",
                         groupRoom.getId(),
@@ -1113,10 +1162,14 @@ class GroupIntegrationTest {
                                   "candidateId": %d
                                 }
                                 """.formatted(candidate.getId())))
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_ALREADY_VOTED"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.voteId").value(existingVote.getId()))
+                .andExpect(jsonPath("$.data.candidateId").value(candidate.getId()))
+                .andExpect(jsonPath("$.data.votedAt").isNotEmpty());
 
         assertThat(groupRecommendationVoteRepository.count()).isEqualTo(1);
+        assertThat(groupRecommendationVoteRepository.findAll().getFirst().getCandidate().getId())
+                .isEqualTo(candidate.getId());
     }
 
     @Test

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -500,6 +500,9 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/votes'].post.responses['200'].content['application/json'].examples.success.value.data.candidateId")
                         .value(8001))
                 .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/votes'].post.responses['200'].content['application/json'].examples.revote.value.data.candidateId")
+                        .value(8002))
+                .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/votes'].post.responses['200'].content['application/json'].examples.success.value.data.voteValue")
                         .doesNotExist())
                 .andExpect(jsonPath(


### PR DESCRIPTION
## 관련 이슈
Closes #269 

## 📝 작업 내용
- `POST api/v1/groups/1/recommendations/1/votes` 수정
- upsert 형식의 API로 구현

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 별개의 API로 분리하지 않고 기존의 API를 수정했습니다.
- 내부 로직만 수정됐을 뿐 요구사항은 변하지 않았습니다.
