### PR TITLE
[Refactor] 그룹 추천 재요청 API를 deprecated 

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -597,8 +597,9 @@ public interface GroupApi {
                     Deprecated:
                     - 그룹 추천 재요청은 MVP 8단계 클라이언트 연동 범위에서 제외되었습니다.
                     - 엔드포인트와 도메인 구현은 MVP 이후 재도입 검토를 위해 호환 목적으로 보존합니다.
+                    - API 호출 시 `410 Gone`과 `GROUP_RECOMMENDATION_REROLL_DISABLED`를 반환합니다.
 
-                    구현 기준:
+                    보존된 구현 기준:
                     - 로그인한 활성 회원만 사용할 수 있습니다.
                     - 해당 그룹의 `ACTIVE` OWNER 멤버만 재요청할 수 있습니다.
                     - source 그룹 추천은 해당 그룹에 속하고 `OPEN` 상태여야 합니다.
@@ -609,14 +610,13 @@ public interface GroupApi {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "그룹 추천 재요청 성공",
+                    responseCode = "410",
+                    description = "그룹 추천 재요청은 MVP 클라이언트 계약에서 제외됨",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = CreateGroupRecommendationApiResponse.class),
                             examples = @ExampleObject(
-                                    name = "success",
-                                    value = GroupApiExamples.REROLL_RECOMMENDATION_SUCCESS
+                                    name = "disabled",
+                                    value = GroupApiExamples.REROLL_RECOMMENDATION_DISABLED
                             )
                     )
             )

--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -590,12 +590,17 @@ public interface GroupApi {
 
     @Operation(
             summary = "그룹 추천 재요청",
+            deprecated = true,
             description = """
                     열린 그룹 추천을 종료하고 새 그룹 추천을 생성합니다.
 
+                    Deprecated:
+                    - 그룹 추천 재요청은 MVP 8단계 클라이언트 연동 범위에서 제외되었습니다.
+                    - 엔드포인트와 도메인 구현은 MVP 이후 재도입 검토를 위해 호환 목적으로 보존합니다.
+
                     구현 기준:
                     - 로그인한 활성 회원만 사용할 수 있습니다.
-                    - MVP에서는 해당 그룹의 `ACTIVE` OWNER 멤버만 재요청할 수 있습니다.
+                    - 해당 그룹의 `ACTIVE` OWNER 멤버만 재요청할 수 있습니다.
                     - source 그룹 추천은 해당 그룹에 속하고 `OPEN` 상태여야 합니다.
                     - `NOT_SATISFIED`는 source 후보 전체를 `group_menu_actions.SKIP`으로 저장한 뒤 source를 `REROLLED_WITH_SKIP`으로 종료합니다.
                     - `INPUT_CHANGED`는 `SKIP` 로그 없이 source를 `REROLLED_WITHOUT_SKIP`으로 종료합니다.

--- a/src/main/java/matchuri/backend/api/group/GroupController.java
+++ b/src/main/java/matchuri/backend/api/group/GroupController.java
@@ -43,6 +43,7 @@ import matchuri.backend.domain.group.command.RespondGroupInviteCommand;
 import matchuri.backend.domain.group.command.UpdateGroupCommand;
 import matchuri.backend.domain.group.entity.GroupInviteStatus;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
+import matchuri.backend.domain.group.exception.GroupErrorCode;
 import matchuri.backend.domain.group.result.CreateGroupResult;
 import matchuri.backend.domain.group.result.CreateGroupRecommendationResult;
 import matchuri.backend.domain.group.result.CreateNicknameGroupInviteResult;
@@ -64,6 +65,7 @@ import matchuri.backend.domain.group.result.UpdateGroupResult;
 import matchuri.backend.domain.group.service.GroupService;
 import matchuri.backend.global.api.ApiResponse;
 import matchuri.backend.global.api.PageResponse;
+import matchuri.backend.global.exception.BusinessException;
 import org.springframework.data.domain.Page;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -282,15 +284,7 @@ public class GroupController implements GroupApi {
             @PathVariable Long sessionId,
             @Valid @RequestBody RerollGroupRecommendationRequest request
     ) {
-        CreateGroupRecommendationCommand command = groupMapper.toCreateGroupRecommendationCommand(groupId, request);
-        CreateGroupRecommendationResult result = groupService.rerollGroupRecommendation(
-                command.groupId(),
-                sessionId,
-                request.rerollType(),
-                command.contextJson()
-        );
-
-        return ApiResponse.success(groupMapper.toCreateGroupRecommendationResponse(result));
+        throw new BusinessException(GroupErrorCode.RECOMMENDATION_REROLL_DISABLED);
     }
 
     @Override

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -188,6 +188,18 @@ public final class GroupApiExamples {
             }
             """;
 
+    public static final String REROLL_RECOMMENDATION_DISABLED = """
+            {
+              "success": false,
+              "data": null,
+              "error": {
+                "status": 410,
+                "code": "GROUP_RECOMMENDATION_REROLL_DISABLED",
+                "message": "그룹 추천 재요청은 현재 MVP에서 지원하지 않습니다."
+              }
+            }
+            """;
+
     public static final String CREATE_NICKNAME_INVITE_SUCCESS = """
             {
               "success": true,

--- a/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
@@ -38,6 +38,7 @@ public enum GroupErrorCode implements ErrorCode {
     RECOMMENDATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 그룹 추천을 찾을 수 없습니다. sessionId : {0}"),
     RECOMMENDATION_NOT_OPEN(HttpStatus.CONFLICT, "열린 상태의 그룹 추천이 아닙니다. sessionId : {0}"),
     RECOMMENDATION_NOT_PREPARING(HttpStatus.CONFLICT, "준비 중인 그룹 추천이 아닙니다. sessionId : {0}"),
+    RECOMMENDATION_REROLL_DISABLED(HttpStatus.GONE, "그룹 추천 재요청은 현재 MVP에서 지원하지 않습니다."),
     RECOMMENDATION_REROLL_FORBIDDEN(HttpStatus.FORBIDDEN, "그룹 추천 재요청 권한이 없습니다. groupId : {0}"),
     RECOMMENDATION_CANDIDATE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 그룹 추천 후보를 찾을 수 없습니다. candidateId : {0}"),
     RECOMMENDATION_ALREADY_VOTED(HttpStatus.CONFLICT, "이미 해당 그룹 추천에 투표했습니다. sessionId : {0}, memberId : {1}"),

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -25,7 +25,6 @@ import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
 import matchuri.backend.domain.group.entity.GroupRecommendationVote;
 import matchuri.backend.domain.group.entity.GroupInvite;
 import matchuri.backend.domain.group.entity.GroupInviteStatus;
-import matchuri.backend.domain.group.entity.GroupMenuActionType;
 import matchuri.backend.domain.group.entity.GroupMemberRole;
 import matchuri.backend.domain.group.entity.GroupMemberStatus;
 import matchuri.backend.domain.group.entity.GroupRoom;
@@ -639,14 +638,12 @@ class GroupIntegrationTest {
     }
 
     @Test
-    @DisplayName("불만족 그룹 추천 재요청은 source 후보를 SKIP으로 저장하고 새 추천 후보에서 제외한다")
-    void rerollGroupRecommendationWithNotSatisfiedClosesWithSkipAndCreatesNewRecommendation() throws Exception {
+    @DisplayName("그룹 추천 재요청은 MVP 제외 API이므로 410으로 거절한다")
+    void rerollGroupRecommendationReturnsGone() throws Exception {
         Member owner = saveMember("group-reroll-owner", "재요청방장");
         GroupRoom groupRoom = saveGroupOwnedBy(owner, "재요청 그룹");
         MenuItem firstMenu = saveMenu("reroll-first", "첫번째메뉴");
         MenuItem secondMenu = saveMenu("reroll-second", "두번째메뉴");
-        MenuItem thirdMenu = saveMenu("reroll-third", "세번째메뉴");
-        MenuItem fourthMenu = saveMenu("reroll-fourth", "네번째메뉴");
         GroupRecommendation sourceRecommendation = groupRecommendationRepository.save(new GroupRecommendation(
                 groupRoom,
                 "{}",
@@ -680,43 +677,24 @@ class GroupIntegrationTest {
                                   }
                                 }
                                 """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.sessionId").isNumber())
-                .andExpect(jsonPath("$.data.sessionId").value(org.hamcrest.Matchers.not(sourceRecommendation.getId().intValue())))
-                .andExpect(jsonPath("$.data.status").value(GroupRecommendationStatus.OPEN.name()))
-                .andExpect(jsonPath("$.data.candidates.length()").value(2));
+                .andExpect(status().isGone())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.data").value(nullValue()))
+                .andExpect(jsonPath("$.error.status").value(410))
+                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_REROLL_DISABLED"));
 
         GroupRecommendation savedSourceRecommendation =
                 groupRecommendationRepository.findById(sourceRecommendation.getId()).orElseThrow();
-        GroupRecommendation newRecommendation = groupRecommendationRepository.findAll().stream()
-                .filter(recommendation -> !recommendation.getId().equals(sourceRecommendation.getId()))
-                .findFirst()
-                .orElseThrow();
-        List<Long> newCandidateMenuIds = groupRecommendationCandidateRepository
-                .findAllByGroupRecommendationIdOrderByRankNoAsc(newRecommendation.getId())
-                .stream()
-                .map(candidate -> candidate.getMenuItem().getId())
-                .toList();
 
-        assertThat(savedSourceRecommendation.getStatus()).isEqualTo(GroupRecommendationStatus.REROLLED_WITH_SKIP);
-        assertThat(savedSourceRecommendation.getEndedAt()).isNotNull();
-        assertThat(groupMenuActionRepository.findAll())
-                .hasSize(2)
-                .allSatisfy(action -> {
-                    assertThat(action.getGroupRoom().getId()).isEqualTo(groupRoom.getId());
-                    assertThat(action.getGroupRecommendation().getId()).isEqualTo(sourceRecommendation.getId());
-                    assertThat(action.getActorMember().getId()).isEqualTo(owner.getId());
-                    assertThat(action.getActionType()).isEqualTo(GroupMenuActionType.SKIP);
-                });
-        assertThat(newCandidateMenuIds)
-                .containsExactly(thirdMenu.getId(), fourthMenu.getId())
-                .doesNotContain(firstMenu.getId(), secondMenu.getId());
+        assertThat(savedSourceRecommendation.getStatus()).isEqualTo(GroupRecommendationStatus.OPEN);
+        assertThat(savedSourceRecommendation.getEndedAt()).isNull();
+        assertThat(groupMenuActionRepository.count()).isZero();
+        assertThat(groupRecommendationRepository.count()).isEqualTo(1);
     }
 
     @Test
-    @DisplayName("입력 변경 그룹 추천 재요청은 SKIP 없이 source를 종료하고 새 추천을 생성한다")
-    void rerollGroupRecommendationWithInputChangedClosesWithoutSkipAndCreatesNewRecommendation() throws Exception {
+    @DisplayName("입력 변경 그룹 추천 재요청도 410으로 거절한다")
+    void rerollGroupRecommendationWithInputChangedReturnsGone() throws Exception {
         Member owner = saveMember("group-reroll-input-owner", "입력변경방장");
         GroupRoom groupRoom = saveGroupOwnedBy(owner, "입력 변경 그룹");
         saveMenu("input-first", "입력첫번째");
@@ -740,22 +718,22 @@ class GroupIntegrationTest {
                                   }
                                 }
                                 """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.status").value(GroupRecommendationStatus.OPEN.name()));
+                .andExpect(status().isGone())
+                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_REROLL_DISABLED"));
 
         GroupRecommendation savedSourceRecommendation =
                 groupRecommendationRepository.findById(sourceRecommendation.getId()).orElseThrow();
 
         assertThat(savedSourceRecommendation.getStatus())
-                .isEqualTo(GroupRecommendationStatus.REROLLED_WITHOUT_SKIP);
-        assertThat(savedSourceRecommendation.getEndedAt()).isNotNull();
+                .isEqualTo(GroupRecommendationStatus.OPEN);
+        assertThat(savedSourceRecommendation.getEndedAt()).isNull();
         assertThat(groupMenuActionRepository.count()).isZero();
-        assertThat(groupRecommendationRepository.count()).isEqualTo(2);
+        assertThat(groupRecommendationRepository.count()).isEqualTo(1);
     }
 
     @Test
-    @DisplayName("그룹 추천 재요청은 OWNER가 아닌 활성 멤버이면 거절한다")
-    void rerollGroupRecommendationFailsForNonOwnerMember() throws Exception {
+    @DisplayName("그룹 추천 재요청은 OWNER가 아닌 활성 멤버여도 410으로 먼저 거절한다")
+    void rerollGroupRecommendationReturnsGoneForNonOwnerMember() throws Exception {
         Member owner = saveMember("group-reroll-forbidden-owner", "재요청권한방장");
         Member member = saveMember("group-reroll-forbidden-member", "재요청권한멤버");
         GroupRoom groupRoom = saveGroupOwnedBy(owner, "재요청 권한 그룹");
@@ -782,16 +760,16 @@ class GroupIntegrationTest {
                                   "contextJson": {}
                                 }
                                 """))
-                .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_REROLL_FORBIDDEN"));
+                .andExpect(status().isGone())
+                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_REROLL_DISABLED"));
 
         assertThat(groupRecommendationRepository.findById(sourceRecommendation.getId()).orElseThrow().getStatus())
                 .isEqualTo(GroupRecommendationStatus.OPEN);
     }
 
     @Test
-    @DisplayName("그룹 추천 재요청은 열린 상태가 아니면 거절한다")
-    void rerollGroupRecommendationFailsForNotOpenRecommendation() throws Exception {
+    @DisplayName("그룹 추천 재요청은 열린 상태 여부 검증 전 410으로 거절한다")
+    void rerollGroupRecommendationReturnsGoneBeforeStatusValidation() throws Exception {
         Member owner = saveMember("group-reroll-closed-owner", "재요청종료방장");
         GroupRoom groupRoom = saveGroupOwnedBy(owner, "재요청 종료 그룹");
         GroupRecommendation sourceRecommendation = groupRecommendationRepository.save(new GroupRecommendation(
@@ -813,8 +791,8 @@ class GroupIntegrationTest {
                                   "contextJson": {}
                                 }
                                 """))
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_NOT_OPEN"));
+                .andExpect(status().isGone())
+                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_REROLL_DISABLED"));
     }
 
     @Test

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -497,6 +497,12 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/ready'].post.responses['200'].content['application/json'].examples.opened.value.data.candidates[0].menuName")
                         .value("비빔밥"))
                 .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/reroll'].post.deprecated")
+                        .value(true))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/reroll'].post.description")
+                        .value(org.hamcrest.Matchers.containsString("MVP 8단계 클라이언트 연동 범위에서 제외")))
+                .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/votes'].post.responses['200'].content['application/json'].examples.success.value.data.candidateId")
                         .value(8001))
                 .andExpect(jsonPath(

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -503,6 +503,9 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/reroll'].post.description")
                         .value(org.hamcrest.Matchers.containsString("MVP 8단계 클라이언트 연동 범위에서 제외")))
                 .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/reroll'].post.responses['410'].content['application/json'].examples.disabled.value.error.code")
+                        .value("GROUP_RECOMMENDATION_REROLL_DISABLED"))
+                .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/votes'].post.responses['200'].content['application/json'].examples.success.value.data.candidateId")
                         .value(8001))
                 .andExpect(jsonPath(


### PR DESCRIPTION
## 관련 이슈
Closes #272 

## 📝 작업 내용
- 그룹 추천 재요청 deprecated 
- [410](https://developer.mozilla.org/ko/docs/Web/HTTP/Reference/Status/410) 상태값을 반환

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- [해당 글](https://moneystory910.tistory.com/28)을 참고했습니다.
