### PR TITLE
[Refactor] 그룹 수정 API에 non-skip 제거

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -280,9 +280,8 @@ public interface GroupApi {
                     - 요청에는 최소 1개 이상의 지원 필드가 포함되어야 합니다.
                     - 현재 회원이 해당 그룹의 `ACTIVE` OWNER 멤버일 때만 수정할 수 있습니다.
                     - 그룹이 `ACTIVE` 상태일 때만 수정할 수 있습니다.
-                    - 수정 시점에 열린 그룹 추천이 있으면 `openGroupRecommendationId`를 함께 반환합니다.
-                    - `openGroupRecommendationId`가 있으면 위치 변경 등을 반영하기 위해 해당 추천 ID로 `INPUT_CHANGED` 재요청을 이어갈 수 있습니다.
-                    - 진행 중인 그룹 추천이 없으면 `openGroupRecommendationId`는 `null`입니다.
+                    - 그룹 추천 재요청은 MVP 8단계 클라이언트 계약에서 제외되었으므로 수정 응답은 재요청용 추천 ID를 반환하지 않습니다.
+                    - 이미 `PREPARING`인 추천 세션의 후보 생성은 후보 생성 시점의 최신 그룹 위치를 사용합니다.
                     """
     )
     @ApiResponses({

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -207,8 +207,7 @@ public class GroupMapper {
                 result.latitude(),
                 result.longitude(),
                 result.status(),
-                result.updatedAt(),
-                result.openGroupRecommendationId()
+                result.updatedAt()
         );
     }
 

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -181,8 +181,7 @@ public final class GroupApiExamples {
                 "latitude": 37.498095,
                 "longitude": 127.027610,
                 "status": "ACTIVE",
-                "updatedAt": "2026-05-18T12:30:00",
-                "openGroupRecommendationId": 5001
+                "updatedAt": "2026-05-18T12:30:00"
               },
               "error": null
             }

--- a/src/main/java/matchuri/backend/api/group/dto/response/UpdateGroupResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/UpdateGroupResponse.java
@@ -22,13 +22,6 @@ public record UpdateGroupResponse(
         GroupRoomStatus status,
 
         @Schema(description = "수정 시각입니다.", example = "2026-05-18T12:30:00")
-        LocalDateTime updatedAt,
-
-        @Schema(
-                description = "그룹 수정 시점에 INPUT_CHANGED 재요청으로 이어갈 수 있는 열린 그룹 추천 ID입니다. 없으면 null입니다.",
-                example = "5001",
-                nullable = true
-        )
-        Long openGroupRecommendationId
+        LocalDateTime updatedAt
 ) {
 }

--- a/src/main/java/matchuri/backend/domain/group/result/UpdateGroupResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/UpdateGroupResult.java
@@ -10,7 +10,6 @@ public record UpdateGroupResult(
         BigDecimal latitude,
         BigDecimal longitude,
         GroupRoomStatus status,
-        LocalDateTime updatedAt,
-        Long openGroupRecommendationId
+        LocalDateTime updatedAt
 ) {
 }

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -641,19 +641,13 @@ public class GroupServiceImpl implements GroupService {
             room.updateLongitude(command.longitude());
         }
 
-        Long openGroupRecommendationId = groupRecommendationRepository
-                .findFirstByRoomIdAndStatusOrderByStartedAtDesc(room.getId(), GroupRecommendationStatus.OPEN)
-                .map(GroupRecommendation::getId)
-                .orElse(null);
-
         return new UpdateGroupResult(
                 room.getId(),
                 room.getName(),
                 room.getLatitude(),
                 room.getLongitude(),
                 room.getStatus(),
-                room.getUpdatedAt(),
-                openGroupRecommendationId
+                room.getUpdatedAt()
         );
     }
 

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -1760,18 +1760,18 @@ class GroupIntegrationTest {
                 .andExpect(jsonPath("$.data.longitude").value(nullValue()))
                 .andExpect(jsonPath("$.data.status").value(GroupRoomStatus.ACTIVE.name()))
                 .andExpect(jsonPath("$.data.updatedAt").isNotEmpty())
-                .andExpect(jsonPath("$.data.openGroupRecommendationId").value(nullValue()));
+                .andExpect(jsonPath("$.data.openGroupRecommendationId").doesNotExist());
 
         assertThat(groupRoomRepository.findById(groupRoom.getId()).orElseThrow().getName())
                 .isEqualTo("수정 후 그룹");
     }
 
     @Test
-    @DisplayName("그룹 수정은 열린 그룹 추천이 있으면 재요청 가능한 추천 ID를 반환한다")
-    void updateGroupReturnsOpenGroupRecommendationId() throws Exception {
+    @DisplayName("그룹 수정은 열린 그룹 추천이 있어도 재요청용 추천 ID를 반환하지 않는다")
+    void updateGroupDoesNotReturnOpenGroupRecommendationId() throws Exception {
         Member owner = saveMember("update-open-recommendation-owner", "열린추천수정방장");
         GroupRoom groupRoom = saveGroupOwnedBy(owner, "열린 추천 수정 그룹");
-        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+        groupRecommendationRepository.save(new GroupRecommendation(
                 groupRoom,
                 "{}",
                 LocalDateTime.now()
@@ -1788,7 +1788,7 @@ class GroupIntegrationTest {
                                 """))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.groupId").value(groupRoom.getId()))
-                .andExpect(jsonPath("$.data.openGroupRecommendationId").value(recommendation.getId()));
+                .andExpect(jsonPath("$.data.openGroupRecommendationId").doesNotExist());
     }
 
     @Test

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -444,11 +444,11 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/groups/{groupId}'].delete.responses['200'].content['application/json'].examples.success.value.data.status")
                         .value("DELETED"))
                 .andExpect(jsonPath(
-                        "$.components.schemas.UpdateGroupResponse.properties.openGroupRecommendationId.description")
-                        .value("그룹 수정 시점에 INPUT_CHANGED 재요청으로 이어갈 수 있는 열린 그룹 추천 ID입니다. 없으면 null입니다."))
+                        "$.components.schemas.UpdateGroupResponse.properties.openGroupRecommendationId")
+                        .doesNotExist())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}'].patch.responses['200'].content['application/json'].examples.success.value.data.openGroupRecommendationId")
-                        .value(5001))
+                        .doesNotExist())
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}/recommendations'].post.responses['200'].content['application/json'].examples.success.value.data.candidates[0].candidateId")
                         .doesNotExist())


### PR DESCRIPTION
## 관련 이슈
Closes #273 

## 📝 작업 내용
- `PATCH /api/v1/groups/{groupId}` 응답에서 `openGroupRecommendationId` 제거

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 재요청 개념이 없기에 해당 값은 요구되지 않는다
