### PR TITLE
[Fix] 그룹 추천이 OPEN 상태가 아닐 때 예외 처리

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -498,6 +498,8 @@ public interface GroupApi {
                     구현 기준:
                     - 로그인한 활성 회원만 사용할 수 있습니다.
                     - 현재 회원이 해당 그룹의 `ACTIVE` 멤버일 때만 조회할 수 있습니다.
+                    - 후보가 생성된 `OPEN` 상태의 추천 세션에서만 조회할 수 있습니다.
+                    - `PREPARING` 상태의 준비 진행률은 추천 상세 또는 준비 상태 조회 API를 사용합니다.
                     - 후보는 추천 순위 오름차순으로 반환합니다.
                     - 후보별 현재 투표 수를 함께 반환합니다.
                     - 실제 저장 테이블은 `group_recommendation_candidates` 기준입니다.
@@ -513,6 +515,17 @@ public interface GroupApi {
                             examples = @ExampleObject(
                                     name = "success",
                                     value = GroupApiExamples.RECOMMENDATION_CANDIDATES_SUCCESS
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "후보 조회 가능한 OPEN 상태가 아님",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "notOpen",
+                                    value = GroupApiExamples.RECOMMENDATION_NOT_OPEN_ERROR
                             )
                     )
             )

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -199,6 +199,18 @@ public final class GroupApiExamples {
             }
             """;
 
+    public static final String RECOMMENDATION_NOT_OPEN_ERROR = """
+            {
+              "success": false,
+              "data": null,
+              "error": {
+                "status": 409,
+                "code": "GROUP_RECOMMENDATION_NOT_OPEN",
+                "message": "열린 상태의 그룹 추천이 아닙니다. sessionId : 5001"
+              }
+            }
+            """;
+
     public static final String CREATE_NICKNAME_INVITE_SUCCESS = """
             {
               "success": true,

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -274,6 +274,10 @@ public class GroupServiceImpl implements GroupService {
         GroupRecommendation recommendation = groupRecommendationRepository.findByIdAndRoomId(sessionId, groupId)
                 .orElseThrow(() -> new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_FOUND, sessionId));
 
+        if (recommendation.getStatus() != GroupRecommendationStatus.OPEN) {
+            throw new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_OPEN, sessionId);
+        }
+
         return new GroupRecommendationCandidateListResult(
                 recommendation.getId(),
                 toCandidateResults(recommendation)

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -922,6 +922,25 @@ class GroupIntegrationTest {
     }
 
     @Test
+    @DisplayName("그룹 추천 후보 목록 조회는 PREPARING 세션이면 거절한다")
+    void getGroupRecommendationCandidatesFailsForPreparingRecommendation() throws Exception {
+        Member owner = saveMember("recommendation-candidates-preparing-owner", "준비후보방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "준비 후보 조회 그룹");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(GroupRecommendation.preparing(
+                groupRoom,
+                "{}",
+                LocalDateTime.now()
+        ));
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}/recommendations/{sessionId}/candidates",
+                        groupRoom.getId(),
+                        recommendation.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_NOT_OPEN"));
+    }
+
+    @Test
     @DisplayName("그룹 추천 요청 목록 조회는 그룹별 추천 summary를 최신순 페이지로 반환한다")
     void getGroupRecommendationsReturnsSummariesByGroup() throws Exception {
         Member owner = saveMember("recommendation-list-owner", "목록방장");

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -476,6 +476,9 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/candidates'].get.responses['200'].content['application/json'].examples.success.value.data.candidates[1].menuName")
                         .value("돈까스"))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/candidates'].get.responses['409'].content['application/json'].examples.notOpen.value.error.code")
+                        .value("GROUP_RECOMMENDATION_NOT_OPEN"))
                 .andExpect(jsonPath("$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/readiness'].get.summary")
                         .value("[GREC.020.000] 그룹 추천 준비 상태 조회"))
                 .andExpect(jsonPath("$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/readiness'].get['x-api-id']")


### PR DESCRIPTION
## 관련 이슈
Closes #274 

## 📝 작업 내용
- `GET /api/v1/groups/{groupId}/recommendations/{sessionId}/candidates`가 `OPEN` 상태에서만 후보를 반환하도록 변경

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [ ] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [ ] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [ ] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [ ] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
