### PR TITLE
[Feat] 그룹 메뉴 추천 만료일 갱신 스케줄러 

### DIFF
--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationRepository.java
@@ -1,6 +1,8 @@
 package matchuri.backend.domain.group.repository;
 
 import java.util.Collection;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import matchuri.backend.domain.group.entity.GroupRecommendation;
 import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
@@ -29,4 +31,9 @@ public interface GroupRecommendationRepository extends JpaRepository<GroupRecomm
     Optional<GroupRecommendation> findFirstByRoomIdOrderByStartedAtDescIdDesc(Long roomId);
 
     Page<GroupRecommendation> findByRoomIdOrderByStartedAtDescIdDesc(Long roomId, Pageable pageable);
+
+    List<GroupRecommendation> findByStatusInAndEndedAtIsNullAndStartedAtLessThanEqual(
+            Collection<GroupRecommendationStatus> statuses,
+            LocalDateTime startedAt
+    );
 }

--- a/src/main/java/matchuri/backend/domain/group/service/GroupRecommendationExpirationService.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupRecommendationExpirationService.java
@@ -1,0 +1,58 @@
+package matchuri.backend.domain.group.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import matchuri.backend.domain.group.entity.GroupRecommendation;
+import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
+import matchuri.backend.domain.group.repository.GroupRecommendationRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GroupRecommendationExpirationService {
+
+    static final long EXPIRATION_HOURS = 24;
+    private static final List<GroupRecommendationStatus> EXPIRABLE_STATUSES = List.of(
+            GroupRecommendationStatus.PREPARING,
+            GroupRecommendationStatus.OPEN
+    );
+
+    private final GroupRecommendationRepository groupRecommendationRepository;
+
+    @Scheduled(fixedRateString = "PT1H")
+    public void expireActiveGroupRecommendationsOnSchedule() {
+        int expiredCount = expireActiveGroupRecommendations();
+        if (expiredCount > 0) {
+            log.info("Expired {} active group recommendations", expiredCount);
+        }
+    }
+
+    @Transactional
+    public int expireActiveGroupRecommendations() {
+        LocalDateTime now = LocalDateTime.now();
+        List<GroupRecommendation> targets = groupRecommendationRepository
+                .findByStatusInAndEndedAtIsNullAndStartedAtLessThanEqual(
+                        EXPIRABLE_STATUSES,
+                        expirationThreshold(now)
+                );
+
+        targets.forEach(recommendation -> recommendation.expire(now));
+
+        return targets.size();
+    }
+
+    public boolean isExpired(GroupRecommendation recommendation, LocalDateTime now) {
+        return EXPIRABLE_STATUSES.contains(recommendation.getStatus())
+                && recommendation.getEndedAt() == null
+                && !recommendation.getStartedAt().plusHours(EXPIRATION_HOURS).isAfter(now);
+    }
+
+    private LocalDateTime expirationThreshold(LocalDateTime now) {
+        return now.minusHours(EXPIRATION_HOURS);
+    }
+}

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -67,6 +67,7 @@ public class GroupServiceImpl implements GroupService {
     private final MenuIngredientRepository menuIngredientRepository;
     private final MenuRecommendationAlgorithmResolver menuRecommendationAlgorithmResolver;
     private final GroupInviteCodeGenerator groupInviteCodeGenerator;
+    private final GroupRecommendationExpirationService groupRecommendationExpirationService;
     private final ObjectMapper objectMapper;
 
     @Override
@@ -98,6 +99,8 @@ public class GroupServiceImpl implements GroupService {
         if (!validateActiveMembership(room.getId(), member.getId()).isOwner()) {
             throw new BusinessException(GroupErrorCode.RECOMMENDATION_CREATE_FORBIDDEN, room.getId());
         }
+
+        groupRecommendationExpirationService.expireActiveGroupRecommendations();
 
         if (hasActiveRecommendation(room.getId())) {
             throw new BusinessException(GroupErrorCode.RECOMMENDATION_ACTIVE_EXISTS, room.getId());

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -38,6 +38,7 @@ import matchuri.backend.domain.group.repository.GroupRecommendationRepository;
 import matchuri.backend.domain.group.repository.GroupRecommendationVoteRepository;
 import matchuri.backend.domain.group.repository.GroupRoomMemberRepository;
 import matchuri.backend.domain.group.repository.GroupRoomRepository;
+import matchuri.backend.domain.group.service.GroupRecommendationExpirationService;
 import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.entity.MemberRole;
 import matchuri.backend.domain.member.entity.MemberStatus;
@@ -116,6 +117,9 @@ class GroupIntegrationTest {
 
     @Autowired
     private GroupRecommendationVoteRepository groupRecommendationVoteRepository;
+
+    @Autowired
+    private GroupRecommendationExpirationService groupRecommendationExpirationService;
 
     @Autowired
     private MenuItemRepository menuItemRepository;
@@ -343,6 +347,79 @@ class GroupIntegrationTest {
                                 """))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_ACTIVE_EXISTS"));
+    }
+
+    @Test
+    @DisplayName("그룹 추천 시작은 24시간 지난 진행 중 추천을 만료하고 새 준비 세션을 생성한다")
+    void createGroupRecommendationExpiresOldActiveRecommendationAndCreatesPreparingSession() throws Exception {
+        Member owner = saveMember("expired-active-group-owner", "만료추천방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "만료 추천 그룹");
+        GroupRecommendation oldRecommendation = groupRecommendationRepository.save(GroupRecommendation.preparing(
+                groupRoom,
+                "{}",
+                LocalDateTime.now().minusHours(25)
+        ));
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "contextJson": {
+                                    "mealTime": "LUNCH"
+                                  }
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.sessionId").value(org.hamcrest.Matchers.not(oldRecommendation.getId().intValue())))
+                .andExpect(jsonPath("$.data.status").value(GroupRecommendationStatus.PREPARING.name()));
+
+        GroupRecommendation expiredRecommendation = groupRecommendationRepository.findById(oldRecommendation.getId())
+                .orElseThrow();
+        assertThat(expiredRecommendation.getStatus()).isEqualTo(GroupRecommendationStatus.EXPIRED);
+        assertThat(expiredRecommendation.getEndedAt()).isNotNull();
+        assertThat(groupRecommendationRepository.count()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("그룹 추천 만료 서비스는 24시간 지난 PREPARING/OPEN 추천만 종료한다")
+    void expirationServiceClosesActiveGroupRecommendationsAfter24Hours() {
+        Member owner = saveMember("group-expiration-service-owner", "그룹만료방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "그룹 만료 서비스");
+        GroupRecommendation oldPreparing = groupRecommendationRepository.save(GroupRecommendation.preparing(
+                groupRoom,
+                "{}",
+                LocalDateTime.now().minusHours(25)
+        ));
+        GroupRecommendation oldOpen = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now().minusHours(25)
+        ));
+        GroupRecommendation recentPreparing = groupRecommendationRepository.save(GroupRecommendation.preparing(
+                groupRoom,
+                "{}",
+                LocalDateTime.now().minusHours(23)
+        ));
+        GroupRecommendation alreadyClosed = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now().minusHours(25)
+        ));
+        alreadyClosed.rerollWithoutSkip(LocalDateTime.now().minusHours(1));
+        groupRecommendationRepository.save(alreadyClosed);
+
+        int expiredCount = groupRecommendationExpirationService.expireActiveGroupRecommendations();
+
+        assertThat(expiredCount).isEqualTo(2);
+        assertThat(groupRecommendationRepository.findById(oldPreparing.getId()).orElseThrow().getStatus())
+                .isEqualTo(GroupRecommendationStatus.EXPIRED);
+        assertThat(groupRecommendationRepository.findById(oldOpen.getId()).orElseThrow().getStatus())
+                .isEqualTo(GroupRecommendationStatus.EXPIRED);
+        assertThat(groupRecommendationRepository.findById(recentPreparing.getId()).orElseThrow().getStatus())
+                .isEqualTo(GroupRecommendationStatus.PREPARING);
+        assertThat(groupRecommendationRepository.findById(alreadyClosed.getId()).orElseThrow().getStatus())
+                .isEqualTo(GroupRecommendationStatus.REROLLED_WITHOUT_SKIP);
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
Closes #280 

## 📝 작업 내용
- 그룹 메뉴 추천건에 대한 만료 정책 정의 및 스케줄러 추가

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 그룹 메뉴 추천 또한 만료 기간을 24시간으로 둔다
