### PR TITLE
[Refactor] 그룹 준비 상태 조회 응답에서 boolean 값만 반환

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -386,9 +386,7 @@ public class GroupMapper {
                 result.memberId(),
                 result.nickname(),
                 result.role(),
-                result.ready(),
-                result.readinessStatus(),
-                result.readinessUpdatedAt()
+                result.ready()
         );
     }
 

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -485,17 +485,13 @@ public final class GroupApiExamples {
                     "memberId": 1,
                     "nickname": "김철수",
                     "role": "OWNER",
-                    "ready": true,
-                    "readinessStatus": "READY",
-                    "readinessUpdatedAt": "2026-05-26T12:05:00"
+                    "ready": true
                   },
                   {
                     "memberId": 2,
                     "nickname": "김덕배",
                     "role": "MEMBER",
-                    "ready": false,
-                    "readinessStatus": null,
-                    "readinessUpdatedAt": null
+                    "ready": false
                   }
                 ]
               },

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationReadinessMemberResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationReadinessMemberResponse.java
@@ -1,9 +1,7 @@
 package matchuri.backend.api.group.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDateTime;
 import matchuri.backend.domain.group.entity.GroupMemberRole;
-import matchuri.backend.domain.group.entity.GroupRecommendationReadinessStatus;
 
 public record GroupRecommendationReadinessMemberResponse(
         @Schema(description = "회원 ID입니다.", example = "1")
@@ -16,12 +14,6 @@ public record GroupRecommendationReadinessMemberResponse(
         GroupMemberRole role,
 
         @Schema(description = "현재 준비 완료 여부입니다.", example = "true")
-        boolean ready,
-
-        @Schema(description = "준비 상태입니다. 아직 액션이 없으면 null입니다.", example = "READY", nullable = true)
-        GroupRecommendationReadinessStatus readinessStatus,
-
-        @Schema(description = "준비 상태가 마지막으로 변경된 시각입니다. 아직 액션이 없으면 null입니다.", example = "2026-05-26T12:05:00", nullable = true)
-        LocalDateTime readinessUpdatedAt
+        boolean ready
 ) {
 }

--- a/src/main/java/matchuri/backend/domain/group/result/GroupRecommendationReadinessMemberResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupRecommendationReadinessMemberResult.java
@@ -1,15 +1,11 @@
 package matchuri.backend.domain.group.result;
 
-import java.time.LocalDateTime;
 import matchuri.backend.domain.group.entity.GroupMemberRole;
-import matchuri.backend.domain.group.entity.GroupRecommendationReadinessStatus;
 
 public record GroupRecommendationReadinessMemberResult(
         Long memberId,
         String nickname,
         GroupMemberRole role,
-        boolean ready,
-        GroupRecommendationReadinessStatus readinessStatus,
-        LocalDateTime readinessUpdatedAt
+        boolean ready
 ) {
 }

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -413,9 +413,7 @@ public class GroupServiceImpl implements GroupService {
                 member.getId(),
                 member.getNickname(),
                 groupMember.getRole(),
-                readinessStatus == GroupRecommendationReadinessStatus.READY,
-                readinessStatus,
-                readiness == null ? null : readiness.getUpdatedAt()
+                readinessStatus == GroupRecommendationReadinessStatus.READY
         );
     }
 

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -501,17 +501,16 @@ class GroupIntegrationTest {
                 .andExpect(jsonPath("$.data.members.length()").value(3))
                 .andExpect(jsonPath("$.data.members[0].memberId").value(owner.getId()))
                 .andExpect(jsonPath("$.data.members[0].ready").value(true))
-                .andExpect(jsonPath("$.data.members[0].readinessStatus")
-                        .value(GroupRecommendationReadinessStatus.READY.name()))
-                .andExpect(jsonPath("$.data.members[0].readinessUpdatedAt").isNotEmpty())
+                .andExpect(jsonPath("$.data.members[0].readinessStatus").doesNotExist())
+                .andExpect(jsonPath("$.data.members[0].readinessUpdatedAt").doesNotExist())
                 .andExpect(jsonPath("$.data.members[1].memberId").value(member.getId()))
                 .andExpect(jsonPath("$.data.members[1].ready").value(false))
-                .andExpect(jsonPath("$.data.members[1].readinessStatus")
-                        .value(GroupRecommendationReadinessStatus.CANCELED.name()))
+                .andExpect(jsonPath("$.data.members[1].readinessStatus").doesNotExist())
+                .andExpect(jsonPath("$.data.members[1].readinessUpdatedAt").doesNotExist())
                 .andExpect(jsonPath("$.data.members[2].memberId").value(waitingMember.getId()))
                 .andExpect(jsonPath("$.data.members[2].ready").value(false))
-                .andExpect(jsonPath("$.data.members[2].readinessStatus").value(nullValue()))
-                .andExpect(jsonPath("$.data.members[2].readinessUpdatedAt").value(nullValue()));
+                .andExpect(jsonPath("$.data.members[2].readinessStatus").doesNotExist())
+                .andExpect(jsonPath("$.data.members[2].readinessUpdatedAt").doesNotExist());
     }
 
     @Test

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -488,6 +488,12 @@ class OpenApiDocumentationIntegrationTest {
                 .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/readiness'].get.responses['200'].content['application/json'].examples.success.value.data.progress.readyMemberCount")
                         .value(2))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/readiness'].get.responses['200'].content['application/json'].examples.success.value.data.members[0].readinessStatus")
+                        .doesNotExist())
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/readiness'].get.responses['200'].content['application/json'].examples.success.value.data.members[0].readinessUpdatedAt")
+                        .doesNotExist())
                 .andExpect(jsonPath("$.paths['/api/v1/groups/{groupId}/recommendations/{sessionId}/ready'].post.summary")
                         .value("[GREC.030.000] 그룹 추천 준비 완료"))
                 .andExpect(jsonPath(


### PR DESCRIPTION
## 관련 이슈
Closes #275 

## 📝 작업 내용
- `GREC 020.000` 에서 `readinessStatus`, `readinessUpdatedAt` 제거

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항