### PR TITLE
[Refactor] R2 이미지 업로드 트랜잭션 범위 재설정

### DIFF
--- a/src/main/java/matchuri/backend/domain/menu/service/MenuImageAdminServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/menu/service/MenuImageAdminServiceImpl.java
@@ -25,12 +25,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class MenuImageAdminServiceImpl implements MenuImageAdminService {
 
     private final MenuItemRepository menuItemRepository;
@@ -42,6 +42,7 @@ public class MenuImageAdminServiceImpl implements MenuImageAdminService {
     private final ImageUrlResolver imageUrlResolver;
     private final ObjectStorageClient objectStorageClient;
     private final R2Config r2Config;
+    private final TransactionTemplate transactionTemplate;
 
     @Override
     @Transactional(readOnly = true)
@@ -65,30 +66,14 @@ public class MenuImageAdminServiceImpl implements MenuImageAdminService {
 
     @Override
     public MenuImageResult uploadPrimaryImage(Long menuItemId, MultipartFile file) {
-        MenuItem menuItem = getMenuItem(menuItemId);
+        getMenuItem(menuItemId);
         ValidatedImage image = imageUploadValidator.validate(file);
         String objectKey = imageObjectKeyGenerator.menuImageKey(menuItemId, image.contentType());
 
         objectStorageClient.upload(new UploadObjectCommand(objectKey, image.contentType(), image.bytes()));
 
         try {
-            ImageAsset imageAsset = imageAssetRepository.save(new ImageAsset(
-                    ImageStorageProvider.CLOUDFLARE_R2,
-                    r2Config.getBucket(),
-                    objectKey,
-                    normalizeOriginalFilename(file.getOriginalFilename()),
-                    image.contentType(),
-                    image.bytes().length,
-                    imageChecksumCalculator.sha256Hex(image.bytes()),
-                    image.width(),
-                    image.height()
-            ));
-
-            MenuItemImage menuItemImage = menuItemImageRepository.findByMenuId(menuItemId)
-                    .map(existingImage -> replaceImage(existingImage, imageAsset))
-                    .orElseGet(() -> menuItemImageRepository.save(new MenuItemImage(menuItem, imageAsset)));
-
-            return toResult(menuItemImage);
+            return transactionTemplate.execute(status -> saveUploadedImage(menuItemId, file, image, objectKey));
         } catch (RuntimeException exception) {
             deleteUploadedObjectAfterDbFailure(objectKey, menuItemId);
             throw exception;
@@ -96,6 +81,7 @@ public class MenuImageAdminServiceImpl implements MenuImageAdminService {
     }
 
     @Override
+    @Transactional
     public void deletePrimaryImage(Long menuItemId) {
         getMenuItem(menuItemId);
         MenuItemImage menuItemImage = menuItemImageRepository.findByMenuId(menuItemId)
@@ -111,6 +97,32 @@ public class MenuImageAdminServiceImpl implements MenuImageAdminService {
         imageAsset.markDeleted();
 
         deleteObjectAfterCommit(objectKey, menuItemId);
+    }
+
+    private MenuImageResult saveUploadedImage(
+            Long menuItemId,
+            MultipartFile file,
+            ValidatedImage image,
+            String objectKey
+    ) {
+        MenuItem menuItem = getMenuItem(menuItemId);
+        ImageAsset imageAsset = imageAssetRepository.save(new ImageAsset(
+                ImageStorageProvider.CLOUDFLARE_R2,
+                r2Config.getBucket(),
+                objectKey,
+                normalizeOriginalFilename(file.getOriginalFilename()),
+                image.contentType(),
+                image.bytes().length,
+                imageChecksumCalculator.sha256Hex(image.bytes()),
+                image.width(),
+                image.height()
+        ));
+
+        MenuItemImage menuItemImage = menuItemImageRepository.findByMenuId(menuItemId)
+                .map(existingImage -> replaceImage(existingImage, imageAsset))
+                .orElseGet(() -> menuItemImageRepository.save(new MenuItemImage(menuItem, imageAsset)));
+
+        return toResult(menuItemImage);
     }
 
     private MenuItem getMenuItem(Long menuItemId) {

--- a/src/main/java/matchuri/backend/domain/menu/service/MenuImageAdminServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/menu/service/MenuImageAdminServiceImpl.java
@@ -66,7 +66,7 @@ public class MenuImageAdminServiceImpl implements MenuImageAdminService {
 
     @Override
     public MenuImageResult uploadPrimaryImage(Long menuItemId, MultipartFile file) {
-        getMenuItem(menuItemId);
+        validateMenuItemExists(menuItemId);
         ValidatedImage image = imageUploadValidator.validate(file);
         String objectKey = imageObjectKeyGenerator.menuImageKey(menuItemId, image.contentType());
 
@@ -83,7 +83,7 @@ public class MenuImageAdminServiceImpl implements MenuImageAdminService {
     @Override
     @Transactional
     public void deletePrimaryImage(Long menuItemId) {
-        getMenuItem(menuItemId);
+        validateMenuItemExists(menuItemId);
         MenuItemImage menuItemImage = menuItemImageRepository.findByMenuId(menuItemId)
                 .orElse(null);
 
@@ -128,6 +128,10 @@ public class MenuImageAdminServiceImpl implements MenuImageAdminService {
     private MenuItem getMenuItem(Long menuItemId) {
         return menuItemRepository.findById(menuItemId)
                 .orElseThrow(() -> new BusinessException(MenuErrorCode.NOT_FOUND, menuItemId));
+    }
+
+    private void validateMenuItemExists(Long menuItemId) {
+        getMenuItem(menuItemId);
     }
 
     private MenuItemImage replaceImage(MenuItemImage existingImage, ImageAsset newImageAsset) {


### PR DESCRIPTION
## 관련 이슈
Closes #285 

## 📝 작업 내용
- 메뉴 이미지 업로드 서비스의 트랜잭션 범위를 조정했습니다.
- 기존에는 `MenuImageAdminServiceImpl` 클래스 전체에 `@Transactional`이 적용되어 R2 업로드 같은 외부 I/O도 DB 트랜잭션 안에서 실행되었습니다.
- R2 업로드는 트랜잭션 밖에서 수행하고, DB 저장/교체 구간만 `TransactionTemplate`으로 감싸도록 변경했습니다.
- 메뉴 존재 확인 의도를 명확히 하기 위해 `validateMenuItemExists()` 메서드로 분리했습니다.
- 대표 이미지 삭제는 DB 변경이 필요하므로 메서드 단위 `@Transactional`을 유지했습니다.

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?