### PR TITLE
[Refactor] 그룹 상세보기 응답에 자신에 대한 표시

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -138,6 +138,7 @@ public interface GroupApi {
                     - 로그인한 활성 회원만 사용할 수 있습니다.
                     - 현재 회원이 해당 그룹의 `ACTIVE` 멤버일 때만 조회할 수 있습니다.
                     - 그룹의 모든 `ACTIVE` 멤버에게 고정 초대 코드를 함께 반환합니다.
+                    - 멤버 목록의 각 항목은 현재 로그인한 회원이면 `isMe=true`, 아니면 `false`를 반환합니다.
                     - 삭제된 그룹은 조회할 수 없습니다.
                     - `PREPARING` 또는 `OPEN` 추천 세션이 있으면 `activeRecommendation`을 함께 반환합니다.
                     - `PREPARING`이면 readiness 진행률을, `OPEN`이면 후보와 투표 진행률을 포함합니다.

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -355,7 +355,8 @@ public class GroupMapper {
                 result.nickname(),
                 result.role(),
                 result.status(),
-                result.joinedAt()
+                result.joinedAt(),
+                result.isMe()
         );
     }
 

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -62,28 +62,32 @@ public final class GroupApiExamples {
                     "nickname": "점심탐험가",
                     "role": "OWNER",
                     "status": "ACTIVE",
-                    "joinedAt": "2026-05-06T12:01:00"
+                    "joinedAt": "2026-05-06T12:01:00",
+                    "isMe": true
                   },
                   {
                     "memberId": 2,
                     "nickname": "든든한한끼",
                     "role": "MEMBER",
                     "status": "ACTIVE",
-                    "joinedAt": "2026-05-06T12:02:00"
+                    "joinedAt": "2026-05-06T12:02:00",
+                    "isMe": false
                   },
                   {
                     "memberId": 3,
                     "nickname": "매콤러버",
                     "role": "MEMBER",
                     "status": "ACTIVE",
-                    "joinedAt": "2026-05-06T12:02:00"
+                    "joinedAt": "2026-05-06T12:02:00",
+                    "isMe": false
                   },
                   {
                     "memberId": 4,
                     "nickname": "국물파",
                     "role": "MEMBER",
                     "status": "ACTIVE",
-                    "joinedAt": "2026-05-06T12:02:00"
+                    "joinedAt": "2026-05-06T12:02:00",
+                    "isMe": false
                   }
                 ],
                 "activeRecommendation": {
@@ -120,14 +124,16 @@ public final class GroupApiExamples {
                     "nickname": "점심탐험가",
                     "role": "OWNER",
                     "status": "ACTIVE",
-                    "joinedAt": "2026-05-06T12:01:00"
+                    "joinedAt": "2026-05-06T12:01:00",
+                    "isMe": true
                   },
                   {
                     "memberId": 2,
                     "nickname": "든든한한끼",
                     "role": "MEMBER",
                     "status": "ACTIVE",
-                    "joinedAt": "2026-05-06T12:02:00"
+                    "joinedAt": "2026-05-06T12:02:00",
+                    "isMe": false
                   }
                 ],
                 "activeRecommendation": {

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupMemberSummaryResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupMemberSummaryResponse.java
@@ -19,7 +19,10 @@ public record GroupMemberSummaryResponse(
         GroupMemberStatus status,
 
         @Schema(description = "그룹 참여 시각입니다.", example = "2026-05-06T12:01:00")
-        LocalDateTime joinedAt
+        LocalDateTime joinedAt,
+
+        @Schema(description = "현재 로그인한 회원 본인 여부입니다.", example = "true")
+        boolean isMe
 ) {
     public static GroupMemberSummaryResponse mockOwner() {
         return new GroupMemberSummaryResponse(
@@ -27,7 +30,8 @@ public record GroupMemberSummaryResponse(
                 "점심탐험가",
                 GroupMemberRole.OWNER,
                 GroupMemberStatus.ACTIVE,
-                LocalDateTime.of(2026, 5, 6, 12, 1)
+                LocalDateTime.of(2026, 5, 6, 12, 1),
+                true
         );
     }
 
@@ -37,7 +41,8 @@ public record GroupMemberSummaryResponse(
                 nickname,
                 GroupMemberRole.MEMBER,
                 GroupMemberStatus.ACTIVE,
-                LocalDateTime.of(2026, 5, 6, 12, 2)
+                LocalDateTime.of(2026, 5, 6, 12, 2),
+                false
         );
     }
 }

--- a/src/main/java/matchuri/backend/domain/group/result/GroupMemberSummaryResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupMemberSummaryResult.java
@@ -9,6 +9,7 @@ public record GroupMemberSummaryResult(
         String nickname,
         GroupMemberRole role,
         GroupMemberStatus status,
-        LocalDateTime joinedAt
+        LocalDateTime joinedAt,
+        boolean isMe
 ) {
 }

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -843,7 +843,7 @@ public class GroupServiceImpl implements GroupService {
 
         List<GroupMemberSummaryResult> members = groupRoomMemberRepository.findActiveMembersByRoomId(groupId)
                 .stream()
-                .map(this::toMemberSummaryResult)
+                .map(membership -> toMemberSummaryResult(membership, member.getId()))
                 .toList();
         GroupRecommendationResult activeRecommendation = groupRecommendationRepository
                 .findFirstByRoomIdAndStatusInOrderByStartedAtDescIdDesc(
@@ -1178,7 +1178,7 @@ public class GroupServiceImpl implements GroupService {
                 .forEach(membership -> membership.leave(leftAt));
     }
 
-    private GroupMemberSummaryResult toMemberSummaryResult(GroupRoomMember membership) {
+    private GroupMemberSummaryResult toMemberSummaryResult(GroupRoomMember membership, Long currentMemberId) {
         Member member = membership.getMember();
 
         return new GroupMemberSummaryResult(
@@ -1186,7 +1186,8 @@ public class GroupServiceImpl implements GroupService {
                 member.getNickname(),
                 membership.getRole(),
                 membership.getStatus(),
-                membership.getJoinedAt()
+                membership.getJoinedAt(),
+                member.getId().equals(currentMemberId)
         );
     }
 }

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -1801,8 +1801,19 @@ class GroupIntegrationTest {
                 .andExpect(jsonPath("$.data.members[0].memberId").value(owner.getId()))
                 .andExpect(jsonPath("$.data.members[0].nickname").value("상세방장"))
                 .andExpect(jsonPath("$.data.members[0].role").value(GroupMemberRole.OWNER.name()))
+                .andExpect(jsonPath("$.data.members[0].isMe").value(true))
                 .andExpect(jsonPath("$.data.members[1].memberId").value(activeMember.getId()))
                 .andExpect(jsonPath("$.data.members[1].nickname").value("상세멤버"))
+                .andExpect(jsonPath("$.data.members[1].isMe").value(false))
+                .andExpect(jsonPath("$.data.activeRecommendation").value(nullValue()));
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(activeMember))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.members[0].memberId").value(owner.getId()))
+                .andExpect(jsonPath("$.data.members[0].isMe").value(false))
+                .andExpect(jsonPath("$.data.members[1].memberId").value(activeMember.getId()))
+                .andExpect(jsonPath("$.data.members[1].isMe").value(true))
                 .andExpect(jsonPath("$.data.activeRecommendation").value(nullValue()));
     }
 

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -407,6 +407,14 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/groups/{groupId}'].get.responses['200'].content['application/json'].examples.preparing.value.data.inviteCode")
                         .value("LUNCH42"))
                 .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}'].get.responses['200'].content['application/json'].examples.preparing.value.data.members[0].isMe")
+                        .value(true))
+                .andExpect(jsonPath(
+                        "$.paths['/api/v1/groups/{groupId}'].get.responses['200'].content['application/json'].examples.preparing.value.data.members[1].isMe")
+                        .value(false))
+                .andExpect(jsonPath("$.components.schemas.GroupMemberSummaryResponse.properties.isMe.description")
+                        .value("현재 로그인한 회원 본인 여부입니다."))
+                .andExpect(jsonPath(
                         "$.paths['/api/v1/groups/{groupId}'].patch.responses['200'].content['application/json'].examples.success.value.data.name")
                         .value("점심 회의방"))
                 .andExpect(jsonPath(


### PR DESCRIPTION
## 관련 이슈
Closes #292

## 📝 작업 내용
- 그룹 상세 조회 응답의 `members[]` 항목에 현재 로그인 회원 여부를 나타내는 `isMe` 필드를 추가했습니다.
- 그룹 상세 API 문서와 OpenAPI 예시를 갱신했습니다.
- owner와 일반 멤버가 같은 그룹을 조회할 때 `isMe` 값이 각각 올바르게 표시되는 통합 테스트를 추가했습니다.

이 변경은 클라이언트가 그룹 상세 화면에서 별도 회원 ID 비교 로직 없이 현재 사용자를 명확히 표시할 수 있도록 하기 위해 필요합니다.

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 알려진 제한 사항: 그룹 상세의 활성 멤버 목록에만 적용되며, readiness 멤버 응답 등 다른 멤버 목록 응답에는 포함하지 않았습니다.