### PR TITLE
[Fix] 추천 결과 임계값 초과 현상 해결

### DIFF
--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationCandidateResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationCandidateResponse.java
@@ -18,7 +18,7 @@ public record GroupRecommendationCandidateResponse(
         @Schema(description = "추천 순위입니다.", example = "1")
         Integer rankNo,
 
-        @Schema(description = "추천 점수입니다.", example = "91.5")
+        @Schema(description = "0에서 100 사이로 정규화된 추천 점수입니다.", example = "91.5")
         Double score,
 
         @Schema(description = "현재 찬성 투표 수입니다.", example = "3")

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/GuestPersonalRecommendationCandidateResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/GuestPersonalRecommendationCandidateResponse.java
@@ -15,7 +15,7 @@ public record GuestPersonalRecommendationCandidateResponse(
         @Schema(description = "추천 순위입니다.", example = "1")
         Integer rankNo,
 
-        @Schema(description = "추천 점수입니다.", example = "93.5")
+        @Schema(description = "0에서 100 사이로 정규화된 추천 점수입니다.", example = "93.5")
         Double score
 ) {
     public static GuestPersonalRecommendationCandidateResponse mockBibimbap() {

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationCandidateResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationCandidateResponse.java
@@ -18,7 +18,7 @@ public record PersonalRecommendationCandidateResponse(
         @Schema(description = "추천 순위입니다.", example = "1")
         Integer rankNo,
 
-        @Schema(description = "추천 점수입니다.", example = "93.5")
+        @Schema(description = "0에서 100 사이로 정규화된 추천 점수입니다.", example = "93.5")
         Double score
 ) {
     public static PersonalRecommendationCandidateResponse mockBibimbap() {

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationCandidate.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendationCandidate.java
@@ -47,7 +47,7 @@ public class GroupRecommendationCandidate extends BaseEntity {
     @Column(name = "rank_no", nullable = false, comment = "후보 순위")
     private int rankNo;
 
-    @Column(nullable = false, comment = "추천 점수")
+    @Column(nullable = false, comment = "0~100 정규화 추천 점수")
     private double score;
 
     @Column(name = "candidate_meta_json", columnDefinition = "json", comment = "후보 메타 JSON")

--- a/src/main/java/matchuri/backend/domain/recommendation/algorithm/group/GroupMenuRecommendationAlgorithmV1.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/algorithm/group/GroupMenuRecommendationAlgorithmV1.java
@@ -13,6 +13,7 @@ import matchuri.backend.domain.recommendation.algorithm.input.MenuRecommendation
 import matchuri.backend.domain.recommendation.algorithm.input.TasteProfileSnapshot;
 import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendationCandidateResult;
 import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendationResult;
+import matchuri.backend.domain.recommendation.algorithm.support.RecommendationScoreNormalizer;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -71,6 +72,10 @@ public class GroupMenuRecommendationAlgorithmV1 implements MenuRecommendationAlg
         }
 
         double dislikedPenalty = dislikedMemberCount * DISLIKED_MENU_PENALTY;
+        double rawScore = preferenceScore - dislikedPenalty;
+        double maxPossibleScore = participants.stream()
+                .filter(participant -> !participant.preferredAttributeCategoryIds().isEmpty())
+                .count() * PARTICIPANT_PREFERENCE_SCORE;
 
         return new ScoredMenu(
                 menu,
@@ -79,7 +84,8 @@ public class GroupMenuRecommendationAlgorithmV1 implements MenuRecommendationAlg
                 dislikedMemberCount,
                 preferenceScore,
                 dislikedPenalty,
-                preferenceScore - dislikedPenalty
+                RecommendationScoreNormalizer.normalize(rawScore, maxPossibleScore),
+                rawScore
         );
     }
 
@@ -91,12 +97,14 @@ public class GroupMenuRecommendationAlgorithmV1 implements MenuRecommendationAlg
                     return new MenuRecommendationCandidateResult(
                             scoredMenu.menu().menuId(),
                             index + 1,
-                            scoredMenu.totalScore(),
+                            scoredMenu.normalizedScore(),
                             Map.of(
                                     "preferenceMatchingCount", scoredMenu.preferenceMatchingCount(),
                                     "dislikedMemberCount", scoredMenu.dislikedMemberCount(),
                                     "preferenceScore", scoredMenu.preferenceScore(),
-                                    "dislikedPenalty", scoredMenu.dislikedPenalty()
+                                    "dislikedPenalty", scoredMenu.dislikedPenalty(),
+                                    "normalizedScore", scoredMenu.normalizedScore(),
+                                    "rawScore", scoredMenu.totalScore()
                             ),
                             Map.of(
                                     "participantCount", scoredMenu.participantCount()
@@ -136,6 +144,7 @@ public class GroupMenuRecommendationAlgorithmV1 implements MenuRecommendationAlg
             int dislikedMemberCount,
             double preferenceScore,
             double dislikedPenalty,
+            double normalizedScore,
             double totalScore
     ) {
     }

--- a/src/main/java/matchuri/backend/domain/recommendation/algorithm/support/RecommendationScoreNormalizer.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/algorithm/support/RecommendationScoreNormalizer.java
@@ -1,0 +1,22 @@
+package matchuri.backend.domain.recommendation.algorithm.support;
+
+public final class RecommendationScoreNormalizer {
+
+    private static final double MIN_SCORE = 0.0;
+    private static final double MAX_SCORE = 100.0;
+    private static final double DECIMAL_SCALE = 10.0;
+
+    private RecommendationScoreNormalizer() {
+    }
+
+    public static double normalize(double score, double maxPossibleScore) {
+        if (score <= 0 || maxPossibleScore <= 0) {
+            return MIN_SCORE;
+        }
+
+        double normalizedScore = score * MAX_SCORE / maxPossibleScore;
+        double clampedScore = Math.max(MIN_SCORE, Math.min(MAX_SCORE, normalizedScore));
+
+        return Math.round(clampedScore * DECIMAL_SCALE) / DECIMAL_SCALE;
+    }
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/algorithm/support/SingleParticipantMenuRecommendationAlgorithm.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/algorithm/support/SingleParticipantMenuRecommendationAlgorithm.java
@@ -15,6 +15,9 @@ import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendatio
 
 public abstract class SingleParticipantMenuRecommendationAlgorithm implements MenuRecommendationAlgorithm {
 
+    private static final double CATEGORY_SCORE_MAX = 50.0;
+    private static final double HISTORY_SCORE_MAX = 50.0;
+
     /**
      * 단일 참여자의 제한 재료, 비선호 메뉴, 최근 선택 메뉴를 제외한 뒤 취향과 선택 이력 기반 점수로 추천 후보를 만든다.
      *
@@ -67,6 +70,12 @@ public abstract class SingleParticipantMenuRecommendationAlgorithm implements Me
                 historyWeightMatchingCount,
                 categoryMatchingScore,
                 historyWeightScore,
+                calculateNormalizedScore(
+                        categoryMatchingScore,
+                        historyWeightMatchingCount,
+                        participant,
+                        selectedAttributeCategoryFrequency
+                ),
                 categoryMatchingScore + historyWeightScore
         );
     }
@@ -79,12 +88,14 @@ public abstract class SingleParticipantMenuRecommendationAlgorithm implements Me
                     return new MenuRecommendationCandidateResult(
                             scoredMenu.menu().menuId(),
                             index + 1,
-                            scoredMenu.totalScore(),
+                            scoredMenu.normalizedScore(),
                             Map.of(
                                     "categoryMatchingCount", scoredMenu.categoryMatchingCount(),
                                     "historyWeightMatchingCount", scoredMenu.historyWeightMatchingCount(),
                                     "categoryMatchingScore", scoredMenu.categoryMatchingScore(),
-                                    "historyWeightScore", scoredMenu.historyWeightScore()
+                                    "historyWeightScore", scoredMenu.historyWeightScore(),
+                                    "normalizedScore", scoredMenu.normalizedScore(),
+                                    "rawScore", scoredMenu.totalScore()
                             ),
                             Map.of()
                     );
@@ -97,7 +108,7 @@ public abstract class SingleParticipantMenuRecommendationAlgorithm implements Me
             return 0;
         }
 
-        return matchingCount * (50.0 / preferredCategoryCount);
+        return matchingCount * (CATEGORY_SCORE_MAX / preferredCategoryCount);
     }
 
     private double calculateHistoryWeightScore(
@@ -113,7 +124,52 @@ public abstract class SingleParticipantMenuRecommendationAlgorithm implements Me
             return 0;
         }
 
-        return historyWeightMatchingCount * (50.0 / maxFrequency);
+        return historyWeightMatchingCount * (HISTORY_SCORE_MAX / maxFrequency);
+    }
+
+    private double calculateNormalizedScore(
+            double categoryMatchingScore,
+            long historyWeightMatchingCount,
+            TasteProfileSnapshot participant,
+            Map<Long, Long> selectedAttributeCategoryFrequency
+    ) {
+        double normalizableScore = categoryMatchingScore
+                + calculateNormalizedHistoryWeightScore(historyWeightMatchingCount, selectedAttributeCategoryFrequency);
+        double maxPossibleScore = calculateMaxPossibleScore(participant, selectedAttributeCategoryFrequency);
+
+        return RecommendationScoreNormalizer.normalize(normalizableScore, maxPossibleScore);
+    }
+
+    private double calculateNormalizedHistoryWeightScore(
+            long historyWeightMatchingCount,
+            Map<Long, Long> selectedAttributeCategoryFrequency
+    ) {
+        long totalFrequency = selectedAttributeCategoryFrequency.values().stream()
+                .mapToLong(Long::longValue)
+                .sum();
+
+        if (totalFrequency == 0) {
+            return 0;
+        }
+
+        return historyWeightMatchingCount * (HISTORY_SCORE_MAX / totalFrequency);
+    }
+
+    private double calculateMaxPossibleScore(
+            TasteProfileSnapshot participant,
+            Map<Long, Long> selectedAttributeCategoryFrequency
+    ) {
+        double maxScore = 0;
+
+        if (!participant.preferredAttributeCategoryIds().isEmpty()) {
+            maxScore += CATEGORY_SCORE_MAX;
+        }
+
+        if (!selectedAttributeCategoryFrequency.isEmpty()) {
+            maxScore += HISTORY_SCORE_MAX;
+        }
+
+        return maxScore;
     }
 
     private long countMatches(List<Long> sourceIds, List<Long> targetIds) {
@@ -137,6 +193,7 @@ public abstract class SingleParticipantMenuRecommendationAlgorithm implements Me
             long historyWeightMatchingCount,
             double categoryMatchingScore,
             double historyWeightScore,
+            double normalizedScore,
             double totalScore
     ) {
     }

--- a/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendationCandidate.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendationCandidate.java
@@ -48,7 +48,7 @@ public class PersonalRecommendationCandidate extends BaseEntity {
     @Column(name = "rank_no", nullable = false, comment = "후보 순위")
     private int rankNo;
 
-    @Column(comment = "추천 점수")
+    @Column(comment = "0~100 정규화 추천 점수")
     private Double score;
 
     @Column(name = "candidate_meta_json", columnDefinition = "json", comment = "후보 메타 JSON")

--- a/src/test/java/matchuri/backend/domain/recommendation/algorithm/group/GroupMenuRecommendationAlgorithmV1Test.java
+++ b/src/test/java/matchuri/backend/domain/recommendation/algorithm/group/GroupMenuRecommendationAlgorithmV1Test.java
@@ -1,0 +1,65 @@
+package matchuri.backend.domain.recommendation.algorithm.group;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import matchuri.backend.domain.recommendation.algorithm.RecommendationAlgorithmType;
+import matchuri.backend.domain.recommendation.algorithm.RecommendationTargetType;
+import matchuri.backend.domain.recommendation.algorithm.input.MenuRecommendationInput;
+import matchuri.backend.domain.recommendation.algorithm.input.MenuRecommendationProfile;
+import matchuri.backend.domain.recommendation.algorithm.input.RecommendationContextSnapshot;
+import matchuri.backend.domain.recommendation.algorithm.input.TasteProfileSnapshot;
+import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendationResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GroupMenuRecommendationAlgorithmV1Test {
+
+    private final GroupMenuRecommendationAlgorithmV1 algorithm = new GroupMenuRecommendationAlgorithmV1();
+
+    @Test
+    @DisplayName("그룹 추천 응답 점수는 0에서 100 사이로 정규화하고 원점수는 메타에 남긴다")
+    void recommendNormalizesGroupCandidateScore() {
+        TasteProfileSnapshot firstParticipant = new TasteProfileSnapshot(
+                1L,
+                "1",
+                List.of(10L),
+                List.of(),
+                List.of()
+        );
+        TasteProfileSnapshot secondParticipant = new TasteProfileSnapshot(
+                2L,
+                "2",
+                List.of(10L),
+                List.of(),
+                List.of()
+        );
+        TasteProfileSnapshot thirdParticipant = new TasteProfileSnapshot(
+                3L,
+                "3",
+                List.of(10L),
+                List.of(),
+                List.of()
+        );
+        MenuRecommendationInput input = new MenuRecommendationInput(
+                RecommendationTargetType.GROUP,
+                List.of(firstParticipant, secondParticipant, thirdParticipant),
+                List.of(
+                        new MenuRecommendationProfile(1L, "M1", "메뉴1", List.of(10L), List.of())
+                ),
+                RecommendationContextSnapshot.of("{}"),
+                3,
+                List.of(),
+                List.of(),
+                Map.of()
+        );
+
+        MenuRecommendationResult result = algorithm.recommend(input);
+
+        assertThat(result.algorithmType()).isEqualTo(RecommendationAlgorithmType.GROUP);
+        assertThat(result.algorithmVersion()).isEqualTo("v1");
+        assertThat(result.candidates().getFirst().score()).isEqualTo(100.0);
+        assertThat(result.candidates().getFirst().scoreBreakdown().get("rawScore")).isEqualTo(150.0);
+    }
+}

--- a/src/test/java/matchuri/backend/domain/recommendation/algorithm/personal/PersonalMenuRecommendationAlgorithmV1Test.java
+++ b/src/test/java/matchuri/backend/domain/recommendation/algorithm/personal/PersonalMenuRecommendationAlgorithmV1Test.java
@@ -55,6 +55,38 @@ class PersonalMenuRecommendationAlgorithmV1Test {
         assertThat(result.candidates())
                 .extracting(candidate -> candidate.rankNo())
                 .containsExactly(1, 2);
+        assertThat(result.candidates())
+                .extracting(candidate -> candidate.score())
+                .containsExactly(83.3, 16.7);
+    }
+
+    @Test
+    @DisplayName("개인 추천 응답 점수는 0에서 100 사이로 정규화하고 원점수는 메타에 남긴다")
+    void recommendNormalizesPersonalCandidateScore() {
+        TasteProfileSnapshot participant = new TasteProfileSnapshot(
+                1L,
+                "1",
+                List.of(10L),
+                List.of(),
+                List.of()
+        );
+        MenuRecommendationInput input = new MenuRecommendationInput(
+                RecommendationTargetType.PERSONAL,
+                List.of(participant),
+                List.of(
+                        new MenuRecommendationProfile(1L, "M1", "메뉴1", List.of(10L, 20L, 30L), List.of())
+                ),
+                RecommendationContextSnapshot.of("{}"),
+                3,
+                List.of(),
+                List.of(),
+                Map.of(20L, 2L, 30L, 2L)
+        );
+
+        MenuRecommendationResult result = algorithm.recommend(input);
+
+        assertThat(result.candidates().getFirst().score()).isEqualTo(100.0);
+        assertThat(result.candidates().getFirst().scoreBreakdown().get("rawScore")).isEqualTo(150.0);
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
Closes #290

## 📝 작업 내용
- 개인/비회원/그룹 추천 후보의 `score`를 프론트 노출용 0~100 정규화 점수로 변경했습니다.
- 기존 알고리즘 원점수는 API 응답에 노출하지 않고, 디버깅/추적용 `candidate_meta_json.scoreBreakdown.rawScore`에만 남기도록 했습니다.
- 추천 점수 정규화 공통 유틸을 추가하고, 개인/그룹 알고리즘 테스트에 100점 초과 원점수 케이스를 보강했습니다.
- Swagger DTO 설명과 API 문서에 `score`가 0~100 정규화 점수임을 명시했습니다.

이 변경은 기존 알고리즘 점수가 내부 합산 구조상 100점을 초과할 수 있어, 프론트에서 사용자에게 보여주는 점수로는 혼동을 줄 수 있었기 때문에 필요했습니다. 정렬/디버깅에 필요한 원점수는 유지하되, 사용자-facing API에는 일관된 0~100 점수만 제공하도록 정리했습니다.

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 알려진 제한 사항:
  - 기존에 저장된 추천 후보의 `score` 값은 별도 마이그레이션하지 않았습니다.
  - 정규화 점수는 소수점 첫째 자리로 반올림합니다.