### PR TITLE
[Refactor] 그룹 위치정보 보강

### DIFF
--- a/init/sql/01-schema.sql
+++ b/init/sql/01-schema.sql
@@ -269,16 +269,25 @@ CREATE TABLE group_rooms (
     name VARCHAR(100) NOT NULL,
     invite_code VARCHAR(32) NOT NULL,
     host_member_id BIGINT NOT NULL,
-    latitude DECIMAL(10,7),
-    longitude DECIMAL(10,7),
-    location_level INT,
-    location_address VARCHAR(255),
     status VARCHAR(20) NOT NULL,
     created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
     updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
     PRIMARY KEY (id),
     CONSTRAINT uk_group_rooms_invite_code UNIQUE (invite_code),
     INDEX idx_group_rooms_host_member (host_member_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE group_locations (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    group_room_id BIGINT NOT NULL,
+    latitude DECIMAL(10,7),
+    longitude DECIMAL(10,7),
+    radius_meters INT,
+    address VARCHAR(255),
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    INDEX idx_group_locations_room (group_room_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE group_room_members (

--- a/init/sql/01-schema.sql
+++ b/init/sql/01-schema.sql
@@ -271,6 +271,8 @@ CREATE TABLE group_rooms (
     host_member_id BIGINT NOT NULL,
     latitude DECIMAL(10,7),
     longitude DECIMAL(10,7),
+    location_level INT,
+    location_address VARCHAR(255),
     status VARCHAR(20) NOT NULL,
     created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
     updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),

--- a/init/sql/03-local-sample-seed.sql
+++ b/init/sql/03-local-sample-seed.sql
@@ -113,12 +113,16 @@ JOIN menu_items menu ON menu.code = seed.menu_code
 ON DUPLICATE KEY UPDATE profile_id = VALUES(profile_id);
 
 -- Local sample groups for group recommendation flows
-INSERT INTO group_rooms (name, invite_code, host_member_id, latitude, longitude, status, created_at, updated_at)
-SELECT seed.name, seed.invite_code, host.id, seed.latitude, seed.longitude, 'ACTIVE', NOW(6), NOW(6)
+INSERT INTO group_rooms (
+    name, invite_code, host_member_id, latitude, longitude, location_level, location_address, status, created_at,
+    updated_at
+)
+SELECT seed.name, seed.invite_code, host.id, seed.latitude, seed.longitude, seed.location_level,
+       seed.location_address, 'ACTIVE', NOW(6), NOW(6)
 FROM (
-    SELECT '점심 결정 A팀' AS name, 'LUNCHA2026' AS invite_code, 'tester01' AS host_login_id, 37.5665000 AS latitude, 126.9780000 AS longitude
+    SELECT '점심 결정 A팀' AS name, 'LUNCHA2026' AS invite_code, 'tester01' AS host_login_id, 37.5665000 AS latitude, 126.9780000 AS longitude, 5 AS location_level, '서울 중구 세종대로' AS location_address
     UNION ALL
-    SELECT '매운맛 탐험대' AS name, 'SPICY2026' AS invite_code, 'tester04' AS host_login_id, 37.4979000 AS latitude, 127.0276000 AS longitude
+    SELECT '매운맛 탐험대' AS name, 'SPICY2026' AS invite_code, 'tester04' AS host_login_id, 37.4979000 AS latitude, 127.0276000 AS longitude, 5 AS location_level, '서울 강남구 강남대로' AS location_address
 ) seed
 JOIN members host ON host.login_id = seed.host_login_id
 ON DUPLICATE KEY UPDATE
@@ -126,6 +130,8 @@ ON DUPLICATE KEY UPDATE
     host_member_id = VALUES(host_member_id),
     latitude = VALUES(latitude),
     longitude = VALUES(longitude),
+    location_level = VALUES(location_level),
+    location_address = VALUES(location_address),
     status = VALUES(status),
     updated_at = VALUES(updated_at);
 

--- a/init/sql/03-local-sample-seed.sql
+++ b/init/sql/03-local-sample-seed.sql
@@ -113,27 +113,33 @@ JOIN menu_items menu ON menu.code = seed.menu_code
 ON DUPLICATE KEY UPDATE profile_id = VALUES(profile_id);
 
 -- Local sample groups for group recommendation flows
-INSERT INTO group_rooms (
-    name, invite_code, host_member_id, latitude, longitude, location_level, location_address, status, created_at,
-    updated_at
-)
-SELECT seed.name, seed.invite_code, host.id, seed.latitude, seed.longitude, seed.location_level,
-       seed.location_address, 'ACTIVE', NOW(6), NOW(6)
+INSERT INTO group_rooms (name, invite_code, host_member_id, status, created_at, updated_at)
+SELECT seed.name, seed.invite_code, host.id, 'ACTIVE', NOW(6), NOW(6)
 FROM (
-    SELECT '점심 결정 A팀' AS name, 'LUNCHA2026' AS invite_code, 'tester01' AS host_login_id, 37.5665000 AS latitude, 126.9780000 AS longitude, 5 AS location_level, '서울 중구 세종대로' AS location_address
+    SELECT '점심 결정 A팀' AS name, 'LUNCHA2026' AS invite_code, 'tester01' AS host_login_id
     UNION ALL
-    SELECT '매운맛 탐험대' AS name, 'SPICY2026' AS invite_code, 'tester04' AS host_login_id, 37.4979000 AS latitude, 127.0276000 AS longitude, 5 AS location_level, '서울 강남구 강남대로' AS location_address
+    SELECT '매운맛 탐험대' AS name, 'SPICY2026' AS invite_code, 'tester04' AS host_login_id
 ) seed
 JOIN members host ON host.login_id = seed.host_login_id
 ON DUPLICATE KEY UPDATE
     name = VALUES(name),
     host_member_id = VALUES(host_member_id),
-    latitude = VALUES(latitude),
-    longitude = VALUES(longitude),
-    location_level = VALUES(location_level),
-    location_address = VALUES(location_address),
     status = VALUES(status),
     updated_at = VALUES(updated_at);
+
+INSERT INTO group_locations (group_room_id, latitude, longitude, radius_meters, address, created_at, updated_at)
+SELECT room.id, seed.latitude, seed.longitude, seed.radius_meters, seed.address, NOW(6), NOW(6)
+FROM (
+    SELECT 'LUNCHA2026' AS invite_code, 37.5665000 AS latitude, 126.9780000 AS longitude, 1000 AS radius_meters, '서울 중구 세종대로' AS address
+    UNION ALL
+    SELECT 'SPICY2026' AS invite_code, 37.4979000 AS latitude, 127.0276000 AS longitude, 1000 AS radius_meters, '서울 강남구 강남대로' AS address
+) seed
+JOIN group_rooms room ON room.invite_code = seed.invite_code
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM group_locations location
+    WHERE location.group_room_id = room.id
+);
 
 INSERT INTO group_room_members (room_id, member_id, role, status, joined_at, left_at, created_at, updated_at)
 SELECT room.id, member.id, seed.role, 'ACTIVE', NOW(6), NULL, NOW(6), NOW(6)

--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -276,7 +276,7 @@ public interface GroupApi {
                     그룹 정보를 수정합니다.
 
                     구현 기준:
-                    - 현재 MVP에서는 그룹 이름과 위치(위도/경도)를 수정합니다.
+                    - 현재 MVP에서는 그룹 이름과 위치(위도/경도/지도 레벨/주소)를 수정합니다.
                     - 생략된 필드는 변경하지 않습니다.
                     - 요청에는 최소 1개 이상의 지원 필드가 포함되어야 합니다.
                     - 현재 회원이 해당 그룹의 `ACTIVE` OWNER 멤버일 때만 수정할 수 있습니다.
@@ -398,6 +398,7 @@ public interface GroupApi {
                     - 한 그룹에는 동시에 `PREPARING` 또는 `OPEN` 그룹 추천을 1개만 허용합니다.
                     - 생성 직후 상태는 `PREPARING`이며, 후보는 아직 생성하지 않습니다.
                     - 그룹원 준비 완료 API가 추가되면 모든 활성 멤버가 준비 완료한 시점에 후보를 생성하고 `OPEN`으로 전환합니다.
+                    - `contextJson`에 정상 위치 값(`latitude`, `longitude`, `level`, `address`)이 있으면 그룹의 기억 위치도 갱신합니다.
                     - API 경로는 사용자 흐름상 `recommendations`를 사용하며, 최신 저장 테이블은 `group_recommendations` 기준입니다.
                     """
     )

--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -397,8 +397,10 @@ public interface GroupApi {
                     - MVP에서는 해당 그룹의 `OWNER`만 시작할 수 있습니다.
                     - 한 그룹에는 동시에 `PREPARING` 또는 `OPEN` 그룹 추천을 1개만 허용합니다.
                     - 생성 직후 상태는 `PREPARING`이며, 후보는 아직 생성하지 않습니다.
+                    - 준비 상태에서는 `group_recommendations.context_json`을 저장하지 않습니다.
+                    - 요청에 정상 위치 값(`latitude`, `longitude`, `level`, `address`)이 있으면 그룹의 기억 위치만 갱신합니다.
                     - 그룹원 준비 완료 API가 추가되면 모든 활성 멤버가 준비 완료한 시점에 후보를 생성하고 `OPEN`으로 전환합니다.
-                    - `contextJson`에 정상 위치 값(`latitude`, `longitude`, `level`, `address`)이 있으면 그룹의 기억 위치도 갱신합니다.
+                    - 후보 생성 시점에 현재 그룹 기억 위치를 확정 `contextJson` 스냅샷으로 기록합니다.
                     - API 경로는 사용자 흐름상 `recommendations`를 사용하며, 최신 저장 테이블은 `group_recommendations` 기준입니다.
                     """
     )

--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -276,7 +276,7 @@ public interface GroupApi {
                     그룹 정보를 수정합니다.
 
                     구현 기준:
-                    - 현재 MVP에서는 그룹 이름과 위치(위도/경도/지도 레벨/주소)를 수정합니다.
+                    - 현재 MVP에서는 그룹 이름과 위치(위도/경도/반경 거리/주소)를 수정합니다.
                     - 생략된 필드는 변경하지 않습니다.
                     - 요청에는 최소 1개 이상의 지원 필드가 포함되어야 합니다.
                     - 현재 회원이 해당 그룹의 `ACTIVE` OWNER 멤버일 때만 수정할 수 있습니다.
@@ -398,7 +398,7 @@ public interface GroupApi {
                     - 한 그룹에는 동시에 `PREPARING` 또는 `OPEN` 그룹 추천을 1개만 허용합니다.
                     - 생성 직후 상태는 `PREPARING`이며, 후보는 아직 생성하지 않습니다.
                     - 준비 상태에서는 `group_recommendations.context_json`을 저장하지 않습니다.
-                    - 요청에 정상 위치 값(`latitude`, `longitude`, `level`, `address`)이 있으면 그룹의 기억 위치만 갱신합니다.
+                    - 요청에 정상 위치 값(`latitude`, `longitude`, `radiusMeters`, `address`)이 있으면 그룹의 기억 위치만 갱신합니다.
                     - 그룹원 준비 완료 API가 추가되면 모든 활성 멤버가 준비 완료한 시점에 후보를 생성하고 `OPEN`으로 전환합니다.
                     - 후보 생성 시점에 현재 그룹 기억 위치를 확정 `contextJson` 스냅샷으로 기록합니다.
                     - API 경로는 사용자 흐름상 `recommendations`를 사용하며, 최신 저장 테이블은 `group_recommendations` 기준입니다.

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -75,7 +75,7 @@ public class GroupMapper {
                 request.name(),
                 request.latitude(),
                 request.longitude(),
-                request.level(),
+                request.radiusMeters(),
                 request.address()
         );
     }
@@ -96,7 +96,7 @@ public class GroupMapper {
                 groupId,
                 request.latitude(),
                 request.longitude(),
-                request.level(),
+                request.radiusMeters(),
                 request.address()
         );
     }
@@ -198,7 +198,7 @@ public class GroupMapper {
                 request.name(),
                 request.latitude(),
                 request.longitude(),
-                request.level(),
+                request.radiusMeters(),
                 request.address()
         );
     }
@@ -209,7 +209,7 @@ public class GroupMapper {
                 result.name(),
                 result.latitude(),
                 result.longitude(),
-                result.level(),
+                result.radiusMeters(),
                 result.address(),
                 result.status(),
                 result.updatedAt()
@@ -242,7 +242,7 @@ public class GroupMapper {
                 result.inviteCode(),
                 result.latitude(),
                 result.longitude(),
-                result.level(),
+                result.radiusMeters(),
                 result.address(),
                 result.status(),
                 result.members().stream()

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -1,9 +1,5 @@
 package matchuri.backend.api.group;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Map;
-import lombok.RequiredArgsConstructor;
 import matchuri.backend.api.group.dto.request.CreateGroupRecommendationRequest;
 import matchuri.backend.api.group.dto.request.CreateGroupRequest;
 import matchuri.backend.api.group.dto.request.CreateNicknameGroupInviteRequest;
@@ -72,10 +68,7 @@ import matchuri.backend.domain.group.result.UpdateGroupResult;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 public class GroupMapper {
-
-    private final ObjectMapper objectMapper;
 
     public CreateGroupCommand toCreateGroupCommand(CreateGroupRequest request) {
         return new CreateGroupCommand(
@@ -99,14 +92,20 @@ public class GroupMapper {
             Long groupId,
             CreateGroupRecommendationRequest request
     ) {
-        return new CreateGroupRecommendationCommand(groupId, toContextJson(request.contextJson()));
+        return new CreateGroupRecommendationCommand(
+                groupId,
+                request.latitude(),
+                request.longitude(),
+                request.level(),
+                request.address()
+        );
     }
 
     public CreateGroupRecommendationCommand toCreateGroupRecommendationCommand(
             Long groupId,
             RerollGroupRecommendationRequest request
     ) {
-        return new CreateGroupRecommendationCommand(groupId, toContextJson(request.contextJson()));
+        return new CreateGroupRecommendationCommand(groupId, null, null, null, null);
     }
 
     public CreateGroupRecommendationResponse toCreateGroupRecommendationResponse(
@@ -408,15 +407,5 @@ public class GroupMapper {
                 result.readyMemberCount(),
                 result.allReady()
         );
-    }
-
-    private String toContextJson(Map<String, Object> contextJson) {
-        try {
-            Map<String, Object> normalizedContextJson = contextJson == null ? Map.of() : contextJson;
-
-            return objectMapper.writeValueAsString(normalizedContextJson);
-        } catch (JsonProcessingException exception) {
-            throw new IllegalArgumentException("contextJson을 JSON 문자열로 변환할 수 없습니다.", exception);
-        }
     }
 }

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -81,7 +81,9 @@ public class GroupMapper {
         return new CreateGroupCommand(
                 request.name(),
                 request.latitude(),
-                request.longitude()
+                request.longitude(),
+                request.level(),
+                request.address()
         );
     }
 
@@ -196,7 +198,9 @@ public class GroupMapper {
                 groupId,
                 request.name(),
                 request.latitude(),
-                request.longitude()
+                request.longitude(),
+                request.level(),
+                request.address()
         );
     }
 
@@ -206,6 +210,8 @@ public class GroupMapper {
                 result.name(),
                 result.latitude(),
                 result.longitude(),
+                result.level(),
+                result.address(),
                 result.status(),
                 result.updatedAt()
         );
@@ -237,6 +243,8 @@ public class GroupMapper {
                 result.inviteCode(),
                 result.latitude(),
                 result.longitude(),
+                result.level(),
+                result.address(),
                 result.status(),
                 result.members().stream()
                         .map(this::toGroupMemberSummaryResponse)

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -55,7 +55,7 @@ public final class GroupApiExamples {
                 "inviteCode": "LUNCH42",
                 "latitude": 37.498095,
                 "longitude": 127.027610,
-                "level": 5,
+                "radiusMeters": 1000,
                 "address": "서울 강남구 테헤란로 123",
                 "status": "ACTIVE",
                 "members": [
@@ -119,7 +119,7 @@ public final class GroupApiExamples {
                 "inviteCode": "LUNCH42",
                 "latitude": 37.498095,
                 "longitude": 127.027610,
-                "level": 5,
+                "radiusMeters": 1000,
                 "address": "서울 강남구 테헤란로 123",
                 "status": "ACTIVE",
                 "members": [
@@ -190,7 +190,7 @@ public final class GroupApiExamples {
                 "name": "점심 회의방",
                 "latitude": 37.498095,
                 "longitude": 127.027610,
-                "level": 5,
+                "radiusMeters": 1000,
                 "address": "서울 강남구 테헤란로 123",
                 "status": "ACTIVE",
                 "updatedAt": "2026-05-18T12:30:00"

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -55,6 +55,8 @@ public final class GroupApiExamples {
                 "inviteCode": "LUNCH42",
                 "latitude": 37.498095,
                 "longitude": 127.027610,
+                "level": 5,
+                "address": "서울 강남구 테헤란로 123",
                 "status": "ACTIVE",
                 "members": [
                   {
@@ -117,6 +119,8 @@ public final class GroupApiExamples {
                 "inviteCode": "LUNCH42",
                 "latitude": 37.498095,
                 "longitude": 127.027610,
+                "level": 5,
+                "address": "서울 강남구 테헤란로 123",
                 "status": "ACTIVE",
                 "members": [
                   {
@@ -186,6 +190,8 @@ public final class GroupApiExamples {
                 "name": "점심 회의방",
                 "latitude": 37.498095,
                 "longitude": 127.027610,
+                "level": 5,
+                "address": "서울 강남구 테헤란로 123",
                 "status": "ACTIVE",
                 "updatedAt": "2026-05-18T12:30:00"
               },

--- a/src/main/java/matchuri/backend/api/group/dto/request/CreateGroupRecommendationRequest.java
+++ b/src/main/java/matchuri/backend/api/group/dto/request/CreateGroupRecommendationRequest.java
@@ -19,9 +19,9 @@ public record CreateGroupRecommendationRequest(
         @DecimalMax(value = "180.0", message = "longitude는 180 이하여야 합니다.")
         BigDecimal longitude,
 
-        @Schema(description = "이번 그룹 추천 요청 위치의 지도 확대/축소 레벨입니다. 포함 시 그룹의 기억 위치를 갱신합니다.", example = "5")
-        @Min(value = 0, message = "level은 0 이상이어야 합니다.")
-        Integer level,
+        @Schema(description = "이번 그룹 추천 요청 위치의 반경 거리(미터)입니다. 포함 시 그룹의 기억 위치를 갱신합니다.", example = "1000")
+        @Min(value = 0, message = "radiusMeters는 0 이상이어야 합니다.")
+        Integer radiusMeters,
 
         @Schema(description = "이번 그룹 추천 요청 위치의 주소 문자열입니다. 포함 시 그룹의 기억 위치를 갱신합니다.", example = "서울 강남구 테헤란로 123")
         @Size(max = 255, message = "address는 255자를 초과할 수 없습니다.")

--- a/src/main/java/matchuri/backend/api/group/dto/request/CreateGroupRecommendationRequest.java
+++ b/src/main/java/matchuri/backend/api/group/dto/request/CreateGroupRecommendationRequest.java
@@ -1,15 +1,36 @@
 package matchuri.backend.api.group.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
-import java.util.Map;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
 
 public record CreateGroupRecommendationRequest(
-        @Schema(
-                description = "그룹 추천 컨텍스트입니다. MVP에서는 mealTime, partySize, locationLabel 같은 느슨한 JSON 값으로 시작합니다.",
-                example = "{\"mealTime\":\"LUNCH\",\"partySize\":4}"
-        )
-        @NotNull(message = "contextJson은 null일 수 없습니다.")
-        Map<String, Object> contextJson
+        @Schema(description = "이번 그룹 추천 요청 위치의 위도입니다. 포함 시 그룹의 기억 위치를 갱신합니다.", example = "37.498095")
+        @DecimalMin(value = "-90.0", message = "latitude는 -90 이상이어야 합니다.")
+        @DecimalMax(value = "90.0", message = "latitude는 90 이하여야 합니다.")
+        BigDecimal latitude,
+
+        @Schema(description = "이번 그룹 추천 요청 위치의 경도입니다. 포함 시 그룹의 기억 위치를 갱신합니다.", example = "127.027610")
+        @DecimalMin(value = "-180.0", message = "longitude는 -180 이상이어야 합니다.")
+        @DecimalMax(value = "180.0", message = "longitude는 180 이하여야 합니다.")
+        BigDecimal longitude,
+
+        @Schema(description = "이번 그룹 추천 요청 위치의 지도 확대/축소 레벨입니다. 포함 시 그룹의 기억 위치를 갱신합니다.", example = "5")
+        @Min(value = 0, message = "level은 0 이상이어야 합니다.")
+        Integer level,
+
+        @Schema(description = "이번 그룹 추천 요청 위치의 주소 문자열입니다. 포함 시 그룹의 기억 위치를 갱신합니다.", example = "서울 강남구 테헤란로 123")
+        @Size(max = 255, message = "address는 255자를 초과할 수 없습니다.")
+        String address
 ) {
+
+    @Schema(hidden = true)
+    @AssertTrue(message = "address는 비어 있을 수 없습니다.")
+    public boolean isAddressNullOrNotBlank() {
+        return address == null || !address.isBlank();
+    }
 }

--- a/src/main/java/matchuri/backend/api/group/dto/request/CreateGroupRequest.java
+++ b/src/main/java/matchuri/backend/api/group/dto/request/CreateGroupRequest.java
@@ -3,6 +3,7 @@ package matchuri.backend.api.group.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
@@ -21,6 +22,14 @@ public record CreateGroupRequest(
         @Schema(description = "그룹 추천 기준 위치의 경도입니다.", example = "127.027610")
         @DecimalMin(value = "-180.0", message = "longitude는 -180 이상이어야 합니다.")
         @DecimalMax(value = "180.0", message = "longitude는 180 이하여야 합니다.")
-        BigDecimal longitude
+        BigDecimal longitude,
+
+        @Schema(description = "그룹 추천 기준 위치의 지도 확대/축소 레벨입니다.", example = "5")
+        @Min(value = 0, message = "level은 0 이상이어야 합니다.")
+        Integer level,
+
+        @Schema(description = "그룹 추천 기준 위치의 주소 문자열입니다.", example = "서울 강남구 테헤란로 123")
+        @Size(max = 255, message = "address는 255자를 초과할 수 없습니다.")
+        String address
 ) {
 }

--- a/src/main/java/matchuri/backend/api/group/dto/request/CreateGroupRequest.java
+++ b/src/main/java/matchuri/backend/api/group/dto/request/CreateGroupRequest.java
@@ -24,9 +24,9 @@ public record CreateGroupRequest(
         @DecimalMax(value = "180.0", message = "longitude는 180 이하여야 합니다.")
         BigDecimal longitude,
 
-        @Schema(description = "그룹 추천 기준 위치의 지도 확대/축소 레벨입니다.", example = "5")
-        @Min(value = 0, message = "level은 0 이상이어야 합니다.")
-        Integer level,
+        @Schema(description = "그룹 추천 기준 위치의 반경 거리(미터)입니다.", example = "1000")
+        @Min(value = 0, message = "radiusMeters는 0 이상이어야 합니다.")
+        Integer radiusMeters,
 
         @Schema(description = "그룹 추천 기준 위치의 주소 문자열입니다.", example = "서울 강남구 테헤란로 123")
         @Size(max = 255, message = "address는 255자를 초과할 수 없습니다.")

--- a/src/main/java/matchuri/backend/api/group/dto/request/UpdateGroupRequest.java
+++ b/src/main/java/matchuri/backend/api/group/dto/request/UpdateGroupRequest.java
@@ -23,9 +23,9 @@ public record UpdateGroupRequest(
         @DecimalMax(value = "180.0", message = "longitude는 180 이하여야 합니다.")
         BigDecimal longitude,
 
-        @Schema(description = "변경할 그룹 추천 기준 위치의 지도 확대/축소 레벨입니다. 생략하면 변경하지 않습니다.", example = "5")
-        @Min(value = 0, message = "level은 0 이상이어야 합니다.")
-        Integer level,
+        @Schema(description = "변경할 그룹 추천 기준 위치의 반경 거리(미터)입니다. 생략하면 변경하지 않습니다.", example = "1000")
+        @Min(value = 0, message = "radiusMeters는 0 이상이어야 합니다.")
+        Integer radiusMeters,
 
         @Schema(description = "변경할 그룹 추천 기준 위치의 주소 문자열입니다. 생략하면 변경하지 않습니다.", example = "서울 강남구 테헤란로 123")
         @Size(max = 255, message = "address는 255자를 초과할 수 없습니다.")

--- a/src/main/java/matchuri/backend/api/group/dto/request/UpdateGroupRequest.java
+++ b/src/main/java/matchuri/backend/api/group/dto/request/UpdateGroupRequest.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
 
@@ -20,12 +21,26 @@ public record UpdateGroupRequest(
         @Schema(description = "변경할 그룹 추천 기준 위치의 경도입니다. 생략하면 변경하지 않습니다.", example = "127.027610")
         @DecimalMin(value = "-180.0", message = "longitude는 -180 이상이어야 합니다.")
         @DecimalMax(value = "180.0", message = "longitude는 180 이하여야 합니다.")
-        BigDecimal longitude
+        BigDecimal longitude,
+
+        @Schema(description = "변경할 그룹 추천 기준 위치의 지도 확대/축소 레벨입니다. 생략하면 변경하지 않습니다.", example = "5")
+        @Min(value = 0, message = "level은 0 이상이어야 합니다.")
+        Integer level,
+
+        @Schema(description = "변경할 그룹 추천 기준 위치의 주소 문자열입니다. 생략하면 변경하지 않습니다.", example = "서울 강남구 테헤란로 123")
+        @Size(max = 255, message = "address는 255자를 초과할 수 없습니다.")
+        String address
 ) {
 
     @Schema(hidden = true)
     @AssertTrue(message = "name은 비어 있을 수 없습니다.")
     public boolean isNameNullOrNotBlank() {
         return name == null || !name.isBlank();
+    }
+
+    @Schema(hidden = true)
+    @AssertTrue(message = "address는 비어 있을 수 없습니다.")
+    public boolean isAddressNullOrNotBlank() {
+        return address == null || !address.isBlank();
     }
 }

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupDetailResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupDetailResponse.java
@@ -21,8 +21,8 @@ public record GroupDetailResponse(
         @Schema(description = "추천 기준 위치의 경도입니다.", example = "127.027610")
         BigDecimal longitude,
 
-        @Schema(description = "추천 기준 위치의 지도 확대/축소 레벨입니다.", example = "5")
-        Integer level,
+        @Schema(description = "추천 기준 위치의 반경 거리(미터)입니다.", example = "1000")
+        Integer radiusMeters,
 
         @Schema(description = "추천 기준 위치의 주소 문자열입니다.", example = "서울 강남구 테헤란로 123")
         String address,
@@ -43,7 +43,7 @@ public record GroupDetailResponse(
                 "LUNCH42",
                 new BigDecimal("37.498095"),
                 new BigDecimal("127.027610"),
-                5,
+                1000,
                 "서울 강남구 테헤란로 123",
                 GroupRoomStatus.ACTIVE,
                 GroupMocks.members(),

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupDetailResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupDetailResponse.java
@@ -21,6 +21,12 @@ public record GroupDetailResponse(
         @Schema(description = "추천 기준 위치의 경도입니다.", example = "127.027610")
         BigDecimal longitude,
 
+        @Schema(description = "추천 기준 위치의 지도 확대/축소 레벨입니다.", example = "5")
+        Integer level,
+
+        @Schema(description = "추천 기준 위치의 주소 문자열입니다.", example = "서울 강남구 테헤란로 123")
+        String address,
+
         @Schema(description = "그룹 상태입니다.", example = "ACTIVE")
         GroupRoomStatus status,
 
@@ -37,6 +43,8 @@ public record GroupDetailResponse(
                 "LUNCH42",
                 new BigDecimal("37.498095"),
                 new BigDecimal("127.027610"),
+                5,
+                "서울 강남구 테헤란로 123",
                 GroupRoomStatus.ACTIVE,
                 GroupMocks.members(),
                 GroupRecommendationSessionResponse.mockOpen()

--- a/src/main/java/matchuri/backend/api/group/dto/response/UpdateGroupResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/UpdateGroupResponse.java
@@ -18,6 +18,12 @@ public record UpdateGroupResponse(
         @Schema(description = "수정된 그룹 추천 기준 위치의 경도입니다.", example = "127.027610")
         BigDecimal longitude,
 
+        @Schema(description = "수정된 그룹 추천 기준 위치의 지도 확대/축소 레벨입니다.", example = "5")
+        Integer level,
+
+        @Schema(description = "수정된 그룹 추천 기준 위치의 주소 문자열입니다.", example = "서울 강남구 테헤란로 123")
+        String address,
+
         @Schema(description = "그룹 상태입니다.", example = "ACTIVE")
         GroupRoomStatus status,
 

--- a/src/main/java/matchuri/backend/api/group/dto/response/UpdateGroupResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/UpdateGroupResponse.java
@@ -18,8 +18,8 @@ public record UpdateGroupResponse(
         @Schema(description = "수정된 그룹 추천 기준 위치의 경도입니다.", example = "127.027610")
         BigDecimal longitude,
 
-        @Schema(description = "수정된 그룹 추천 기준 위치의 지도 확대/축소 레벨입니다.", example = "5")
-        Integer level,
+        @Schema(description = "수정된 그룹 추천 기준 위치의 반경 거리(미터)입니다.", example = "1000")
+        Integer radiusMeters,
 
         @Schema(description = "수정된 그룹 추천 기준 위치의 주소 문자열입니다.", example = "서울 강남구 테헤란로 123")
         String address,

--- a/src/main/java/matchuri/backend/domain/group/command/CreateGroupCommand.java
+++ b/src/main/java/matchuri/backend/domain/group/command/CreateGroupCommand.java
@@ -5,6 +5,8 @@ import java.math.BigDecimal;
 public record CreateGroupCommand(
         String name,
         BigDecimal latitude,
-        BigDecimal longitude
+        BigDecimal longitude,
+        Integer level,
+        String address
 ) {
 }

--- a/src/main/java/matchuri/backend/domain/group/command/CreateGroupCommand.java
+++ b/src/main/java/matchuri/backend/domain/group/command/CreateGroupCommand.java
@@ -6,7 +6,7 @@ public record CreateGroupCommand(
         String name,
         BigDecimal latitude,
         BigDecimal longitude,
-        Integer level,
+        Integer radiusMeters,
         String address
 ) {
 }

--- a/src/main/java/matchuri/backend/domain/group/command/CreateGroupRecommendationCommand.java
+++ b/src/main/java/matchuri/backend/domain/group/command/CreateGroupRecommendationCommand.java
@@ -1,7 +1,12 @@
 package matchuri.backend.domain.group.command;
 
+import java.math.BigDecimal;
+
 public record CreateGroupRecommendationCommand(
         Long groupId,
-        String contextJson
+        BigDecimal latitude,
+        BigDecimal longitude,
+        Integer level,
+        String address
 ) {
 }

--- a/src/main/java/matchuri/backend/domain/group/command/CreateGroupRecommendationCommand.java
+++ b/src/main/java/matchuri/backend/domain/group/command/CreateGroupRecommendationCommand.java
@@ -6,7 +6,7 @@ public record CreateGroupRecommendationCommand(
         Long groupId,
         BigDecimal latitude,
         BigDecimal longitude,
-        Integer level,
+        Integer radiusMeters,
         String address
 ) {
 }

--- a/src/main/java/matchuri/backend/domain/group/command/UpdateGroupCommand.java
+++ b/src/main/java/matchuri/backend/domain/group/command/UpdateGroupCommand.java
@@ -6,10 +6,12 @@ public record UpdateGroupCommand(
         Long groupId,
         String name,
         BigDecimal latitude,
-        BigDecimal longitude
+        BigDecimal longitude,
+        Integer level,
+        String address
 ) {
 
     public boolean hasNoFields() {
-        return name == null && latitude == null && longitude == null;
+        return name == null && latitude == null && longitude == null && level == null && address == null;
     }
 }

--- a/src/main/java/matchuri/backend/domain/group/command/UpdateGroupCommand.java
+++ b/src/main/java/matchuri/backend/domain/group/command/UpdateGroupCommand.java
@@ -7,11 +7,11 @@ public record UpdateGroupCommand(
         String name,
         BigDecimal latitude,
         BigDecimal longitude,
-        Integer level,
+        Integer radiusMeters,
         String address
 ) {
 
     public boolean hasNoFields() {
-        return name == null && latitude == null && longitude == null && level == null && address == null;
+        return name == null && latitude == null && longitude == null && radiusMeters == null && address == null;
     }
 }

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupLocation.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupLocation.java
@@ -1,0 +1,81 @@
+package matchuri.backend.domain.group.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import matchuri.backend.domain.common.BaseEntity;
+
+@Getter
+@Entity
+@Table(
+        name = "group_locations",
+        comment = "그룹 위치"
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GroupLocation extends BaseEntity {
+
+    public static final int ADDRESS_MAX_LENGTH = 255;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(comment = "그룹 위치 ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "group_room_id", nullable = false, comment = "그룹 방 ID")
+    private GroupRoom room;
+
+    @Column(precision = 10, scale = 7, comment = "위도")
+    private BigDecimal latitude;
+
+    @Column(precision = 10, scale = 7, comment = "경도")
+    private BigDecimal longitude;
+
+    @Column(name = "radius_meters", comment = "반경 거리(미터)")
+    private Integer radiusMeters;
+
+    @Column(length = ADDRESS_MAX_LENGTH, comment = "주소 문자열")
+    private String address;
+
+    public GroupLocation(
+            GroupRoom room,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            Integer radiusMeters,
+            String address
+    ) {
+        this.room = room;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.radiusMeters = radiusMeters;
+        this.address = address;
+    }
+
+    public void update(
+            BigDecimal latitude,
+            BigDecimal longitude,
+            Integer radiusMeters,
+            String address
+    ) {
+        if (latitude != null && longitude != null) {
+            this.latitude = latitude;
+            this.longitude = longitude;
+        }
+        if (radiusMeters != null) {
+            this.radiusMeters = radiusMeters;
+        }
+        if (address != null) {
+            this.address = address;
+        }
+    }
+}

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendation.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendation.java
@@ -59,6 +59,18 @@ public class GroupRecommendation extends BaseEntity {
         this.status = GroupRecommendationStatus.OPEN;
     }
 
+    public GroupRecommendation(GroupRoom room, LocalDateTime startedAt) {
+        this.room = room;
+        this.startedAt = startedAt;
+        this.status = GroupRecommendationStatus.OPEN;
+    }
+
+    public static GroupRecommendation preparing(GroupRoom room, LocalDateTime startedAt) {
+        GroupRecommendation recommendation = new GroupRecommendation(room, startedAt);
+        recommendation.status = GroupRecommendationStatus.PREPARING;
+        return recommendation;
+    }
+
     public static GroupRecommendation preparing(GroupRoom room, String contextJson, LocalDateTime startedAt) {
         GroupRecommendation recommendation = new GroupRecommendation(room, contextJson, startedAt);
         recommendation.status = GroupRecommendationStatus.PREPARING;
@@ -66,6 +78,11 @@ public class GroupRecommendation extends BaseEntity {
     }
 
     public void open() {
+        this.status = GroupRecommendationStatus.OPEN;
+    }
+
+    public void openWithContextJson(String contextJson) {
+        this.contextJson = contextJson;
         this.status = GroupRecommendationStatus.OPEN;
     }
 

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRoom.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRoom.java
@@ -14,7 +14,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -55,18 +54,6 @@ public class GroupRoom extends BaseEntity {
     @JoinColumn(name = "host_member_id", nullable = false, comment = "방장 회원 ID")
     private Member hostMember;
 
-    @Column(precision = 10, scale = 7, comment = "위도")
-    private BigDecimal latitude;
-
-    @Column(precision = 10, scale = 7, comment = "경도")
-    private BigDecimal longitude;
-
-    @Column(name = "location_level", comment = "지도 확대/축소 레벨")
-    private Integer level;
-
-    @Column(name = "location_address", comment = "주소 문자열")
-    private String address;
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20, comment = "그룹 방 상태")
     private GroupRoomStatus status;
@@ -77,42 +64,20 @@ public class GroupRoom extends BaseEntity {
     private GroupRoom(
             String name,
             String inviteCode,
-            Member hostMember,
-            BigDecimal latitude,
-            BigDecimal longitude,
-            Integer level,
-            String address
+            Member hostMember
     ) {
         this.name = name;
         this.inviteCode = inviteCode;
         this.hostMember = hostMember;
-        this.latitude = latitude;
-        this.longitude = longitude;
-        this.level = level;
-        this.address = address;
         this.status = GroupRoomStatus.ACTIVE;
     }
 
     public static GroupRoom createOwnedBy(
             String name,
             String inviteCode,
-            Member hostMember,
-            BigDecimal latitude,
-            BigDecimal longitude
+            Member hostMember
     ) {
-        return createOwnedBy(name, inviteCode, hostMember, latitude, longitude, null, null);
-    }
-
-    public static GroupRoom createOwnedBy(
-            String name,
-            String inviteCode,
-            Member hostMember,
-            BigDecimal latitude,
-            BigDecimal longitude,
-            Integer level,
-            String address
-    ) {
-        GroupRoom newGroupRoom = new GroupRoom(name, inviteCode, hostMember, latitude, longitude, level, address);
+        GroupRoom newGroupRoom = new GroupRoom(name, inviteCode, hostMember);
         newGroupRoom.addGroupMember(hostMember, GroupMemberRole.OWNER);
         return newGroupRoom;
     }
@@ -124,22 +89,6 @@ public class GroupRoom extends BaseEntity {
 
     public void updateName(String name) {
         this.name = name;
-    }
-
-    public void updateLatitude(BigDecimal latitude) {
-        if (latitude != null) this.latitude = latitude;
-    }
-
-    public void updateLongitude(BigDecimal longitude) {
-        if (longitude != null) this.longitude = longitude;
-    }
-
-    public void updateLevel(Integer level) {
-        if (level != null) this.level = level;
-    }
-
-    public void updateAddress(String address) {
-        if (address != null) this.address = address;
     }
 
     public void close() {

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRoom.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRoom.java
@@ -127,19 +127,19 @@ public class GroupRoom extends BaseEntity {
     }
 
     public void updateLatitude(BigDecimal latitude) {
-        this.latitude = latitude;
+        if (latitude != null) this.latitude = latitude;
     }
 
     public void updateLongitude(BigDecimal longitude) {
-        this.longitude = longitude;
+        if (longitude != null) this.longitude = longitude;
     }
 
     public void updateLevel(Integer level) {
-        this.level = level;
+        if (level != null) this.level = level;
     }
 
     public void updateAddress(String address) {
-        this.address = address;
+        if (address != null) this.address = address;
     }
 
     public void close() {

--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRoom.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRoom.java
@@ -61,6 +61,12 @@ public class GroupRoom extends BaseEntity {
     @Column(precision = 10, scale = 7, comment = "경도")
     private BigDecimal longitude;
 
+    @Column(name = "location_level", comment = "지도 확대/축소 레벨")
+    private Integer level;
+
+    @Column(name = "location_address", comment = "주소 문자열")
+    private String address;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20, comment = "그룹 방 상태")
     private GroupRoomStatus status;
@@ -73,13 +79,17 @@ public class GroupRoom extends BaseEntity {
             String inviteCode,
             Member hostMember,
             BigDecimal latitude,
-            BigDecimal longitude
+            BigDecimal longitude,
+            Integer level,
+            String address
     ) {
         this.name = name;
         this.inviteCode = inviteCode;
         this.hostMember = hostMember;
         this.latitude = latitude;
         this.longitude = longitude;
+        this.level = level;
+        this.address = address;
         this.status = GroupRoomStatus.ACTIVE;
     }
 
@@ -90,7 +100,19 @@ public class GroupRoom extends BaseEntity {
             BigDecimal latitude,
             BigDecimal longitude
     ) {
-        GroupRoom newGroupRoom = new GroupRoom(name, inviteCode, hostMember, latitude, longitude);
+        return createOwnedBy(name, inviteCode, hostMember, latitude, longitude, null, null);
+    }
+
+    public static GroupRoom createOwnedBy(
+            String name,
+            String inviteCode,
+            Member hostMember,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            Integer level,
+            String address
+    ) {
+        GroupRoom newGroupRoom = new GroupRoom(name, inviteCode, hostMember, latitude, longitude, level, address);
         newGroupRoom.addGroupMember(hostMember, GroupMemberRole.OWNER);
         return newGroupRoom;
     }
@@ -110,6 +132,14 @@ public class GroupRoom extends BaseEntity {
 
     public void updateLongitude(BigDecimal longitude) {
         this.longitude = longitude;
+    }
+
+    public void updateLevel(Integer level) {
+        this.level = level;
+    }
+
+    public void updateAddress(String address) {
+        this.address = address;
     }
 
     public void close() {

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupLocationRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupLocationRepository.java
@@ -1,0 +1,10 @@
+package matchuri.backend.domain.group.repository;
+
+import java.util.Optional;
+import matchuri.backend.domain.group.entity.GroupLocation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupLocationRepository extends JpaRepository<GroupLocation, Long> {
+
+    Optional<GroupLocation> findFirstByRoomIdOrderByCreatedAtDescIdDesc(Long roomId);
+}

--- a/src/main/java/matchuri/backend/domain/group/result/GroupDetailResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupDetailResult.java
@@ -10,7 +10,7 @@ public record GroupDetailResult(
         String inviteCode,
         BigDecimal latitude,
         BigDecimal longitude,
-        Integer level,
+        Integer radiusMeters,
         String address,
         GroupRoomStatus status,
         List<GroupMemberSummaryResult> members,

--- a/src/main/java/matchuri/backend/domain/group/result/GroupDetailResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupDetailResult.java
@@ -10,6 +10,8 @@ public record GroupDetailResult(
         String inviteCode,
         BigDecimal latitude,
         BigDecimal longitude,
+        Integer level,
+        String address,
         GroupRoomStatus status,
         List<GroupMemberSummaryResult> members,
         GroupRecommendationResult activeRecommendation

--- a/src/main/java/matchuri/backend/domain/group/result/UpdateGroupResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/UpdateGroupResult.java
@@ -9,6 +9,8 @@ public record UpdateGroupResult(
         String name,
         BigDecimal latitude,
         BigDecimal longitude,
+        Integer level,
+        String address,
         GroupRoomStatus status,
         LocalDateTime updatedAt
 ) {

--- a/src/main/java/matchuri/backend/domain/group/result/UpdateGroupResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/UpdateGroupResult.java
@@ -9,7 +9,7 @@ public record UpdateGroupResult(
         String name,
         BigDecimal latitude,
         BigDecimal longitude,
-        Integer level,
+        Integer radiusMeters,
         String address,
         GroupRoomStatus status,
         LocalDateTime updatedAt

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -70,6 +70,7 @@ public class GroupServiceImpl implements GroupService {
     private final ActiveMemberReader activeMemberReader;
     private final MemberRepository memberRepository;
     private final GroupRoomRepository groupRoomRepository;
+    private final GroupLocationRepository groupLocationRepository;
     private final GroupRoomMemberRepository groupRoomMemberRepository;
     private final GroupInviteRepository groupInviteRepository;
     private final GroupMenuActionRepository groupMenuActionRepository;
@@ -94,13 +95,16 @@ public class GroupServiceImpl implements GroupService {
         GroupRoom groupRoom = GroupRoom.createOwnedBy(
                 command.name(),
                 inviteCode,
-                hostMember,
-                command.latitude(),
-                command.longitude(),
-                command.level(),
-                command.address());
+                hostMember);
 
         GroupRoom savedGroupRoom = groupRoomRepository.save(groupRoom);
+        updateLatestGroupLocation(
+                savedGroupRoom,
+                command.latitude(),
+                command.longitude(),
+                command.radiusMeters(),
+                command.address()
+        );
 
         return new CreateGroupResult(
                 savedGroupRoom.getId(),
@@ -124,10 +128,13 @@ public class GroupServiceImpl implements GroupService {
             throw new BusinessException(GroupErrorCode.RECOMMENDATION_ACTIVE_EXISTS, room.getId());
         }
 
-        room.updateLatitude(command.latitude());
-        room.updateLongitude(command.longitude());
-        room.updateLevel(command.level());
-        room.updateAddress(command.address());
+        updateLatestGroupLocation(
+                room,
+                command.latitude(),
+                command.longitude(),
+                command.radiusMeters(),
+                command.address()
+        );
 
         GroupRecommendation recommendation = groupRecommendationRepository.save(
                 GroupRecommendation.preparing(room, LocalDateTime.now())
@@ -757,18 +764,21 @@ public class GroupServiceImpl implements GroupService {
             room.updateName(command.name());
         }
 
-        room.updateLatitude(command.latitude());
-        room.updateLongitude(command.longitude());
-        room.updateLevel(command.level());
-        room.updateAddress(command.address());
+        GroupLocation location = updateLatestGroupLocation(
+                room,
+                command.latitude(),
+                command.longitude(),
+                command.radiusMeters(),
+                command.address()
+        );
 
         return new UpdateGroupResult(
                 room.getId(),
                 room.getName(),
-                room.getLatitude(),
-                room.getLongitude(),
-                room.getLevel(),
-                room.getAddress(),
+                location == null ? null : location.getLatitude(),
+                location == null ? null : location.getLongitude(),
+                location == null ? null : location.getRadiusMeters(),
+                location == null ? null : location.getAddress(),
                 room.getStatus(),
                 room.getUpdatedAt()
         );
@@ -866,15 +876,16 @@ public class GroupServiceImpl implements GroupService {
                 )
                 .map(this::toGroupRecommendationResult)
                 .orElse(null);
+        GroupLocation location = latestGroupLocation(room.getId());
 
         return new GroupDetailResult(
                 room.getId(),
                 room.getName(),
                 room.getInviteCode(),
-                room.getLatitude(),
-                room.getLongitude(),
-                room.getLevel(),
-                room.getAddress(),
+                location == null ? null : location.getLatitude(),
+                location == null ? null : location.getLongitude(),
+                location == null ? null : location.getRadiusMeters(),
+                location == null ? null : location.getAddress(),
                 room.getStatus(),
                 members,
                 activeRecommendation
@@ -1149,17 +1160,21 @@ public class GroupServiceImpl implements GroupService {
 
     private String toRecommendationContextJson(GroupRoom room) {
         Map<String, Object> context = new LinkedHashMap<>();
-        if (room.getLatitude() != null) {
-            context.put("latitude", room.getLatitude());
+        GroupLocation location = latestGroupLocation(room.getId());
+        if (location == null) {
+            return "{}";
         }
-        if (room.getLongitude() != null) {
-            context.put("longitude", room.getLongitude());
+        if (location.getLatitude() != null) {
+            context.put("latitude", location.getLatitude());
         }
-        if (room.getLevel() != null) {
-            context.put("level", room.getLevel());
+        if (location.getLongitude() != null) {
+            context.put("longitude", location.getLongitude());
         }
-        if (room.getAddress() != null) {
-            context.put("address", room.getAddress());
+        if (location.getRadiusMeters() != null) {
+            context.put("radiusMeters", location.getRadiusMeters());
+        }
+        if (location.getAddress() != null) {
+            context.put("address", location.getAddress());
         }
 
         try {
@@ -1184,23 +1199,36 @@ public class GroupServiceImpl implements GroupService {
                     new BigDecimal("90"));
             BigDecimal longitude = toLocationDecimal(contextNode.get("longitude"), new BigDecimal("-180"),
                     new BigDecimal("180"));
-            if (latitude != null && longitude != null) {
-                room.updateLatitude(latitude);
-                room.updateLongitude(longitude);
-            }
-
-            Integer level = toLocationLevel(contextNode.get("level"));
-            if (level != null) {
-                room.updateLevel(level);
-            }
-
+            Integer radiusMeters = toRadiusMeters(contextNode.get("radiusMeters"));
             String address = toLocationAddress(contextNode.get("address"));
-            if (address != null) {
-                room.updateAddress(address);
-            }
+            updateLatestGroupLocation(room, latitude, longitude, radiusMeters, address);
         } catch (JsonProcessingException ignored) {
             // contextJson is an open-ended recommendation snapshot; invalid location data must not break creation.
         }
+    }
+
+    private GroupLocation updateLatestGroupLocation(
+            GroupRoom room,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            Integer radiusMeters,
+            String address
+    ) {
+        if (latitude == null && longitude == null && radiusMeters == null && address == null) {
+            return latestGroupLocation(room.getId());
+        }
+
+        GroupLocation location = latestGroupLocation(room.getId());
+        if (location == null) {
+            return groupLocationRepository.save(new GroupLocation(room, latitude, longitude, radiusMeters, address));
+        }
+
+        location.update(latitude, longitude, radiusMeters, address);
+        return location;
+    }
+
+    private GroupLocation latestGroupLocation(Long roomId) {
+        return groupLocationRepository.findFirstByRoomIdOrderByCreatedAtDescIdDesc(roomId).orElse(null);
     }
 
     private BigDecimal toLocationDecimal(JsonNode valueNode, BigDecimal min, BigDecimal max) {
@@ -1222,7 +1250,7 @@ public class GroupServiceImpl implements GroupService {
         }
     }
 
-    private Integer toLocationLevel(JsonNode valueNode) {
+    private Integer toRadiusMeters(JsonNode valueNode) {
         if (valueNode == null || valueNode.isNull() || !valueNode.canConvertToInt()) {
             return null;
         }

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -1,7 +1,9 @@
 package matchuri.backend.domain.group.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -94,7 +96,9 @@ public class GroupServiceImpl implements GroupService {
                 inviteCode,
                 hostMember,
                 command.latitude(),
-                command.longitude());
+                command.longitude(),
+                command.level(),
+                command.address());
 
         GroupRoom savedGroupRoom = groupRoomRepository.save(groupRoom);
 
@@ -119,6 +123,8 @@ public class GroupServiceImpl implements GroupService {
         if (hasActiveRecommendation(room.getId())) {
             throw new BusinessException(GroupErrorCode.RECOMMENDATION_ACTIVE_EXISTS, room.getId());
         }
+
+        updateRoomLocationFromContextJson(room, command.contextJson());
 
         GroupRecommendation recommendation = groupRecommendationRepository.save(GroupRecommendation.preparing(
                 room,
@@ -182,6 +188,7 @@ public class GroupServiceImpl implements GroupService {
                 contextJson,
                 LocalDateTime.now()
         ));
+        updateRoomLocationFromContextJson(room, contextJson);
         List<GroupRecommendationCandidate> candidates = generateCandidatesForRecommendation(
                 room,
                 newRecommendation,
@@ -750,11 +757,21 @@ public class GroupServiceImpl implements GroupService {
             room.updateLongitude(command.longitude());
         }
 
+        if (command.level() != null) {
+            room.updateLevel(command.level());
+        }
+
+        if (command.address() != null) {
+            room.updateAddress(command.address());
+        }
+
         return new UpdateGroupResult(
                 room.getId(),
                 room.getName(),
                 room.getLatitude(),
                 room.getLongitude(),
+                room.getLevel(),
+                room.getAddress(),
                 room.getStatus(),
                 room.getUpdatedAt()
         );
@@ -859,6 +876,8 @@ public class GroupServiceImpl implements GroupService {
                 room.getInviteCode(),
                 room.getLatitude(),
                 room.getLongitude(),
+                room.getLevel(),
+                room.getAddress(),
                 room.getStatus(),
                 members,
                 activeRecommendation
@@ -1129,6 +1148,81 @@ public class GroupServiceImpl implements GroupService {
         if (invite.isExpired(now)) {
             throw new BusinessException(GroupErrorCode.INVITE_EXPIRED, invite.getId());
         }
+    }
+
+    private void updateRoomLocationFromContextJson(GroupRoom room, String contextJson) {
+        if (contextJson == null || contextJson.isBlank()) {
+            return;
+        }
+
+        try {
+            JsonNode contextNode = objectMapper.readTree(contextJson);
+            if (contextNode == null || !contextNode.isObject()) {
+                return;
+            }
+
+            BigDecimal latitude = toLocationDecimal(contextNode.get("latitude"), new BigDecimal("-90"),
+                    new BigDecimal("90"));
+            BigDecimal longitude = toLocationDecimal(contextNode.get("longitude"), new BigDecimal("-180"),
+                    new BigDecimal("180"));
+            if (latitude != null && longitude != null) {
+                room.updateLatitude(latitude);
+                room.updateLongitude(longitude);
+            }
+
+            Integer level = toLocationLevel(contextNode.get("level"));
+            if (level != null) {
+                room.updateLevel(level);
+            }
+
+            String address = toLocationAddress(contextNode.get("address"));
+            if (address != null) {
+                room.updateAddress(address);
+            }
+        } catch (JsonProcessingException ignored) {
+            // contextJson is an open-ended recommendation snapshot; invalid location data must not break creation.
+        }
+    }
+
+    private BigDecimal toLocationDecimal(JsonNode valueNode, BigDecimal min, BigDecimal max) {
+        if (valueNode == null || valueNode.isNull()) {
+            return null;
+        }
+
+        try {
+            BigDecimal value = valueNode.isNumber()
+                    ? valueNode.decimalValue()
+                    : new BigDecimal(valueNode.asText());
+            if (value.compareTo(min) < 0 || value.compareTo(max) > 0) {
+                return null;
+            }
+
+            return value;
+        } catch (NumberFormatException exception) {
+            return null;
+        }
+    }
+
+    private Integer toLocationLevel(JsonNode valueNode) {
+        if (valueNode == null || valueNode.isNull() || !valueNode.canConvertToInt()) {
+            return null;
+        }
+
+        int value = valueNode.intValue();
+        return value >= 0 ? value : null;
+    }
+
+    private String toLocationAddress(JsonNode valueNode) {
+        if (valueNode == null || valueNode.isNull() || !valueNode.isTextual()) {
+            return null;
+        }
+
+        String address = valueNode.textValue();
+        if (address.isBlank()) {
+            return null;
+        }
+
+        return address;
     }
 
     private String createUniqueInviteCode() {

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -124,13 +124,15 @@ public class GroupServiceImpl implements GroupService {
             throw new BusinessException(GroupErrorCode.RECOMMENDATION_ACTIVE_EXISTS, room.getId());
         }
 
-        updateRoomLocationFromContextJson(room, command.contextJson());
+        room.updateLatitude(command.latitude());
+        room.updateLongitude(command.longitude());
+        room.updateLevel(command.level());
+        room.updateAddress(command.address());
 
-        GroupRecommendation recommendation = groupRecommendationRepository.save(GroupRecommendation.preparing(
-                room,
-                command.contextJson(),
-                LocalDateTime.now()
-        ));
+        GroupRecommendation recommendation = groupRecommendationRepository.save(
+                GroupRecommendation.preparing(room, LocalDateTime.now())
+        );
+
         int totalMemberCount = groupRoomMemberRepository.findActiveMembersByRoomId(room.getId()).size();
         GroupRecommendationReadinessProgressResult readiness =
                 GroupRecommendationReadinessProgressResult.of(totalMemberCount, 0);
@@ -220,6 +222,9 @@ public class GroupServiceImpl implements GroupService {
         List<MenuItem> menuItems = menuItemRepository.searchActiveMenuItems(null, List.of(), true, List.of(), true);
         Map<Long, MenuItem> menuItemById = menuItems.stream()
                 .collect(Collectors.toMap(MenuItem::getId, Function.identity()));
+        String recommendationContextJson = contextJson == null
+                ? toRecommendationContextJson(room)
+                : contextJson;
 
         MenuRecommendationAlgorithm algorithm =
                 menuRecommendationAlgorithmResolver.resolve(RecommendationAlgorithmType.GROUP);
@@ -228,7 +233,7 @@ public class GroupServiceImpl implements GroupService {
                 RecommendationTargetType.GROUP,
                 toTasteProfileSnapshots(activeMembers),
                 toMenuRecommendationProfiles(menuItems),
-                RecommendationContextSnapshot.of(contextJson),
+                RecommendationContextSnapshot.of(recommendationContextJson),
                 GROUP_RECOMMENDATION_CANDIDATE_LIMIT,
                 List.of(),
                 excludedMenuIds,
@@ -240,7 +245,7 @@ public class GroupServiceImpl implements GroupService {
                 recommendationResult,
                 menuItemById
         );
-        recommendation.open();
+        recommendation.openWithContextJson(recommendationContextJson);
 
         return candidates;
     }
@@ -401,7 +406,7 @@ public class GroupServiceImpl implements GroupService {
             candidates = generateCandidatesForRecommendation(
                     room,
                     recommendation,
-                    recommendation.getContextJson(),
+                    null,
                     recentlySkippedMenuIds(room.getId())
             );
         }
@@ -752,18 +757,10 @@ public class GroupServiceImpl implements GroupService {
             room.updateName(command.name());
         }
 
-        if (command.latitude() != null && command.longitude() != null) {
-            room.updateLatitude(command.latitude());
-            room.updateLongitude(command.longitude());
-        }
-
-        if (command.level() != null) {
-            room.updateLevel(command.level());
-        }
-
-        if (command.address() != null) {
-            room.updateAddress(command.address());
-        }
+        room.updateLatitude(command.latitude());
+        room.updateLongitude(command.longitude());
+        room.updateLevel(command.level());
+        room.updateAddress(command.address());
 
         return new UpdateGroupResult(
                 room.getId(),
@@ -1147,6 +1144,28 @@ public class GroupServiceImpl implements GroupService {
 
         if (invite.isExpired(now)) {
             throw new BusinessException(GroupErrorCode.INVITE_EXPIRED, invite.getId());
+        }
+    }
+
+    private String toRecommendationContextJson(GroupRoom room) {
+        Map<String, Object> context = new LinkedHashMap<>();
+        if (room.getLatitude() != null) {
+            context.put("latitude", room.getLatitude());
+        }
+        if (room.getLongitude() != null) {
+            context.put("longitude", room.getLongitude());
+        }
+        if (room.getLevel() != null) {
+            context.put("level", room.getLevel());
+        }
+        if (room.getAddress() != null) {
+            context.put("address", room.getAddress());
+        }
+
+        try {
+            return objectMapper.writeValueAsString(context);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("그룹 추천 컨텍스트 정보를 JSON으로 변환할 수 없습니다.", exception);
         }
     }
 

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -258,9 +259,6 @@ class GroupIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                  "contextJson": {
-                                    "mealTime": "LUNCH"
-                                  }
                                 }
                                 """))
                 .andExpect(status().isOk())
@@ -277,7 +275,7 @@ class GroupIntegrationTest {
 
         assertThat(savedRecommendation.getRoom().getId()).isEqualTo(groupRoom.getId());
         assertThat(savedRecommendation.getStatus()).isEqualTo(GroupRecommendationStatus.PREPARING);
-        assertThat(savedRecommendation.getContextJson()).contains("LUNCH");
+        assertThat(savedRecommendation.getContextJson()).isNull();
     }
 
     @Test
@@ -291,13 +289,10 @@ class GroupIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                  "contextJson": {
-                                    "mealTime": "LUNCH",
-                                    "latitude": 37.498095,
-                                    "longitude": 127.027610,
-                                    "level": 5,
-                                    "address": "서울 강남구 테헤란로 123"
-                                  }
+                                  "latitude": 37.498095,
+                                  "longitude": 127.027610,
+                                  "level": 5,
+                                  "address": "서울 강남구 테헤란로 123"
                                 }
                                 """))
                 .andExpect(status().isOk())
@@ -310,7 +305,7 @@ class GroupIntegrationTest {
         assertThat(updatedGroup.getAddress()).isEqualTo("서울 강남구 테헤란로 123");
 
         GroupRecommendation savedRecommendation = groupRecommendationRepository.findAll().getFirst();
-        assertThat(savedRecommendation.getContextJson()).contains("서울 강남구 테헤란로 123");
+        assertThat(savedRecommendation.getContextJson()).isNull();
     }
 
     @Test
@@ -331,7 +326,6 @@ class GroupIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                  "contextJson": {}
                                 }
                                 """))
                 .andExpect(status().isForbidden())
@@ -356,7 +350,6 @@ class GroupIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                  "contextJson": {}
                                 }
                                 """))
                 .andExpect(status().isConflict())
@@ -379,7 +372,6 @@ class GroupIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                  "contextJson": {}
                                 }
                                 """))
                 .andExpect(status().isConflict())
@@ -402,9 +394,6 @@ class GroupIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                  "contextJson": {
-                                    "mealTime": "LUNCH"
-                                  }
                                 }
                                 """))
                 .andExpect(status().isOk())
@@ -482,7 +471,6 @@ class GroupIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                  "contextJson": {}
                                 }
                                 """))
                 .andExpect(status().isOk())
@@ -671,6 +659,11 @@ class GroupIntegrationTest {
         Member owner = saveMember("ready-open-owner", "준비오픈방장");
         Member member = saveMember("ready-open-member", "준비오픈멤버");
         GroupRoom groupRoom = saveGroupOwnedBy(owner, "준비 오픈 그룹");
+        groupRoom.updateLatitude(new BigDecimal("37.498095"));
+        groupRoom.updateLongitude(new BigDecimal("127.027610"));
+        groupRoom.updateLevel(5);
+        groupRoom.updateAddress("서울 강남구 테헤란로 123");
+        groupRoomRepository.save(groupRoom);
         groupRoomMemberRepository.save(new GroupRoomMember(
                 groupRoom,
                 member,
@@ -681,7 +674,7 @@ class GroupIntegrationTest {
         saveMenu("ready-open-second", "준비오픈두번째");
         GroupRecommendation recommendation = groupRecommendationRepository.save(GroupRecommendation.preparing(
                 groupRoom,
-                "{\"mealTime\":\"LUNCH\"}",
+                null,
                 LocalDateTime.now()
         ));
 
@@ -706,6 +699,9 @@ class GroupIntegrationTest {
         GroupRecommendation openedRecommendation =
                 groupRecommendationRepository.findById(recommendation.getId()).orElseThrow();
         assertThat(openedRecommendation.getStatus()).isEqualTo(GroupRecommendationStatus.OPEN);
+        assertThat(openedRecommendation.getContextJson()).contains("37.498095");
+        assertThat(openedRecommendation.getContextJson()).contains("127.027610");
+        assertThat(openedRecommendation.getContextJson()).contains("서울 강남구 테헤란로 123");
         assertThat(groupRecommendationCandidateRepository
                 .findAllByGroupRecommendationIdOrderByRankNoAsc(recommendation.getId()))
                 .hasSize(2);

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -192,7 +192,9 @@ class GroupIntegrationTest {
                                 {
                                   "name": "오늘 점심 메뉴 회의",
                                   "latitude": 37.498095,
-                                  "longitude": 127.027610
+                                  "longitude": 127.027610,
+                                  "level": 5,
+                                  "address": "서울 강남구 테헤란로 123"
                                 }
                                 """))
                 .andExpect(status().isOk())
@@ -213,6 +215,8 @@ class GroupIntegrationTest {
         assertThat(savedGroup.getHostMember().getId()).isEqualTo(member.getId());
         assertThat(savedGroup.getLatitude()).isEqualByComparingTo("37.498095");
         assertThat(savedGroup.getLongitude()).isEqualByComparingTo("127.027610");
+        assertThat(savedGroup.getLevel()).isEqualTo(5);
+        assertThat(savedGroup.getAddress()).isEqualTo("서울 강남구 테헤란로 123");
         assertThat(savedGroup.getStatus()).isEqualTo(GroupRoomStatus.ACTIVE);
         assertThat(savedMember.getRoom().getId()).isEqualTo(savedGroup.getId());
         assertThat(savedMember.getMember().getId()).isEqualTo(member.getId());
@@ -274,6 +278,39 @@ class GroupIntegrationTest {
         assertThat(savedRecommendation.getRoom().getId()).isEqualTo(groupRoom.getId());
         assertThat(savedRecommendation.getStatus()).isEqualTo(GroupRecommendationStatus.PREPARING);
         assertThat(savedRecommendation.getContextJson()).contains("LUNCH");
+    }
+
+    @Test
+    @DisplayName("그룹 추천 생성은 요청 위치를 그룹의 기억 위치로 갱신한다")
+    void createGroupRecommendationUpdatesRememberedGroupLocation() throws Exception {
+        Member owner = saveMember("recommendation-location-owner", "추천위치방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "추천 위치 그룹");
+
+        mockMvc.perform(post("/api/v1/groups/{groupId}/recommendations", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "contextJson": {
+                                    "mealTime": "LUNCH",
+                                    "latitude": 37.498095,
+                                    "longitude": 127.027610,
+                                    "level": 5,
+                                    "address": "서울 강남구 테헤란로 123"
+                                  }
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value(GroupRecommendationStatus.PREPARING.name()));
+
+        GroupRoom updatedGroup = groupRoomRepository.findById(groupRoom.getId()).orElseThrow();
+        assertThat(updatedGroup.getLatitude()).isEqualByComparingTo("37.498095");
+        assertThat(updatedGroup.getLongitude()).isEqualByComparingTo("127.027610");
+        assertThat(updatedGroup.getLevel()).isEqualTo(5);
+        assertThat(updatedGroup.getAddress()).isEqualTo("서울 강남구 테헤란로 123");
+
+        GroupRecommendation savedRecommendation = groupRecommendationRepository.findAll().getFirst();
+        assertThat(savedRecommendation.getContextJson()).contains("서울 강남구 테헤란로 123");
     }
 
     @Test
@@ -1889,7 +1926,9 @@ class GroupIntegrationTest {
                         .content("""
                                 {
                                   "latitude": 37.498095,
-                                  "longitude": 127.027610
+                                  "longitude": 127.027610,
+                                  "level": 5,
+                                  "address": "서울 강남구 테헤란로 123"
                                 }
                                 """))
                 .andExpect(status().isOk())
@@ -1909,7 +1948,9 @@ class GroupIntegrationTest {
                         .content("""
                                 {
                                   "latitude": 37.498095,
-                                  "longitude": 127.027610
+                                  "longitude": 127.027610,
+                                  "level": 5,
+                                  "address": "서울 강남구 테헤란로 123"
                                 }
                                 """))
                 .andExpect(status().isOk())
@@ -1917,12 +1958,16 @@ class GroupIntegrationTest {
                 .andExpect(jsonPath("$.data.name").value("위치 수정 그룹"))
                 .andExpect(jsonPath("$.data.latitude").value(37.498095))
                 .andExpect(jsonPath("$.data.longitude").value(127.027610))
+                .andExpect(jsonPath("$.data.level").value(5))
+                .andExpect(jsonPath("$.data.address").value("서울 강남구 테헤란로 123"))
                 .andExpect(jsonPath("$.data.status").value(GroupRoomStatus.ACTIVE.name()));
 
         GroupRoom updatedGroup = groupRoomRepository.findById(groupRoom.getId()).orElseThrow();
         assertThat(updatedGroup.getName()).isEqualTo("위치 수정 그룹");
         assertThat(updatedGroup.getLatitude()).isEqualByComparingTo("37.498095");
         assertThat(updatedGroup.getLongitude()).isEqualByComparingTo("127.027610");
+        assertThat(updatedGroup.getLevel()).isEqualTo(5);
+        assertThat(updatedGroup.getAddress()).isEqualTo("서울 강남구 테헤란로 123");
     }
 
     @Test

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -24,6 +24,7 @@ import matchuri.backend.domain.group.entity.GroupRecommendationReadiness;
 import matchuri.backend.domain.group.entity.GroupRecommendationReadinessStatus;
 import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
 import matchuri.backend.domain.group.entity.GroupRecommendationVote;
+import matchuri.backend.domain.group.entity.GroupLocation;
 import matchuri.backend.domain.group.entity.GroupInvite;
 import matchuri.backend.domain.group.entity.GroupInviteStatus;
 import matchuri.backend.domain.group.entity.GroupMemberRole;
@@ -32,6 +33,7 @@ import matchuri.backend.domain.group.entity.GroupRoom;
 import matchuri.backend.domain.group.entity.GroupRoomMember;
 import matchuri.backend.domain.group.entity.GroupRoomStatus;
 import matchuri.backend.domain.group.repository.GroupInviteRepository;
+import matchuri.backend.domain.group.repository.GroupLocationRepository;
 import matchuri.backend.domain.group.repository.GroupMenuActionRepository;
 import matchuri.backend.domain.group.repository.GroupRecommendationCandidateRepository;
 import matchuri.backend.domain.group.repository.GroupRecommendationReadinessRepository;
@@ -97,6 +99,9 @@ class GroupIntegrationTest {
 
     @Autowired
     private GroupRoomRepository groupRoomRepository;
+
+    @Autowired
+    private GroupLocationRepository groupLocationRepository;
 
     @Autowired
     private GroupRoomMemberRepository groupRoomMemberRepository;
@@ -167,6 +172,7 @@ class GroupIntegrationTest {
         groupRecommendationCandidateRepository.deleteAll();
         groupRecommendationRepository.deleteAll();
         groupInviteRepository.deleteAll();
+        groupLocationRepository.deleteAll();
         groupRoomMemberRepository.deleteAll();
         groupRoomRepository.deleteAll();
         memberTasteProfileDislikedMenuItemRepository.deleteAll();
@@ -194,7 +200,7 @@ class GroupIntegrationTest {
                                   "name": "오늘 점심 메뉴 회의",
                                   "latitude": 37.498095,
                                   "longitude": 127.027610,
-                                  "level": 5,
+                                  "radiusMeters": 1000,
                                   "address": "서울 강남구 테헤란로 123"
                                 }
                                 """))
@@ -214,10 +220,11 @@ class GroupIntegrationTest {
         assertThat(savedGroup.getName()).isEqualTo("오늘 점심 메뉴 회의");
         assertThat(savedGroup.getInviteCode()).hasSize(8);
         assertThat(savedGroup.getHostMember().getId()).isEqualTo(member.getId());
-        assertThat(savedGroup.getLatitude()).isEqualByComparingTo("37.498095");
-        assertThat(savedGroup.getLongitude()).isEqualByComparingTo("127.027610");
-        assertThat(savedGroup.getLevel()).isEqualTo(5);
-        assertThat(savedGroup.getAddress()).isEqualTo("서울 강남구 테헤란로 123");
+        GroupLocation savedLocation = latestGroupLocation(savedGroup);
+        assertThat(savedLocation.getLatitude()).isEqualByComparingTo("37.498095");
+        assertThat(savedLocation.getLongitude()).isEqualByComparingTo("127.027610");
+        assertThat(savedLocation.getRadiusMeters()).isEqualTo(1000);
+        assertThat(savedLocation.getAddress()).isEqualTo("서울 강남구 테헤란로 123");
         assertThat(savedGroup.getStatus()).isEqualTo(GroupRoomStatus.ACTIVE);
         assertThat(savedMember.getRoom().getId()).isEqualTo(savedGroup.getId());
         assertThat(savedMember.getMember().getId()).isEqualTo(member.getId());
@@ -291,18 +298,18 @@ class GroupIntegrationTest {
                                 {
                                   "latitude": 37.498095,
                                   "longitude": 127.027610,
-                                  "level": 5,
+                                  "radiusMeters": 1000,
                                   "address": "서울 강남구 테헤란로 123"
                                 }
                                 """))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.status").value(GroupRecommendationStatus.PREPARING.name()));
 
-        GroupRoom updatedGroup = groupRoomRepository.findById(groupRoom.getId()).orElseThrow();
-        assertThat(updatedGroup.getLatitude()).isEqualByComparingTo("37.498095");
-        assertThat(updatedGroup.getLongitude()).isEqualByComparingTo("127.027610");
-        assertThat(updatedGroup.getLevel()).isEqualTo(5);
-        assertThat(updatedGroup.getAddress()).isEqualTo("서울 강남구 테헤란로 123");
+        GroupLocation updatedLocation = latestGroupLocation(groupRoom);
+        assertThat(updatedLocation.getLatitude()).isEqualByComparingTo("37.498095");
+        assertThat(updatedLocation.getLongitude()).isEqualByComparingTo("127.027610");
+        assertThat(updatedLocation.getRadiusMeters()).isEqualTo(1000);
+        assertThat(updatedLocation.getAddress()).isEqualTo("서울 강남구 테헤란로 123");
 
         GroupRecommendation savedRecommendation = groupRecommendationRepository.findAll().getFirst();
         assertThat(savedRecommendation.getContextJson()).isNull();
@@ -659,11 +666,13 @@ class GroupIntegrationTest {
         Member owner = saveMember("ready-open-owner", "준비오픈방장");
         Member member = saveMember("ready-open-member", "준비오픈멤버");
         GroupRoom groupRoom = saveGroupOwnedBy(owner, "준비 오픈 그룹");
-        groupRoom.updateLatitude(new BigDecimal("37.498095"));
-        groupRoom.updateLongitude(new BigDecimal("127.027610"));
-        groupRoom.updateLevel(5);
-        groupRoom.updateAddress("서울 강남구 테헤란로 123");
-        groupRoomRepository.save(groupRoom);
+        groupLocationRepository.save(new GroupLocation(
+                groupRoom,
+                new BigDecimal("37.498095"),
+                new BigDecimal("127.027610"),
+                1000,
+                "서울 강남구 테헤란로 123"
+        ));
         groupRoomMemberRepository.save(new GroupRoomMember(
                 groupRoom,
                 member,
@@ -701,6 +710,7 @@ class GroupIntegrationTest {
         assertThat(openedRecommendation.getStatus()).isEqualTo(GroupRecommendationStatus.OPEN);
         assertThat(openedRecommendation.getContextJson()).contains("37.498095");
         assertThat(openedRecommendation.getContextJson()).contains("127.027610");
+        assertThat(openedRecommendation.getContextJson()).contains("1000");
         assertThat(openedRecommendation.getContextJson()).contains("서울 강남구 테헤란로 123");
         assertThat(groupRecommendationCandidateRepository
                 .findAllByGroupRecommendationIdOrderByRankNoAsc(recommendation.getId()))
@@ -1756,7 +1766,7 @@ class GroupIntegrationTest {
                 GroupMemberRole.MEMBER,
                 LocalDateTime.now()
         ));
-        GroupRoom deletedGroup = GroupRoom.createOwnedBy("삭제된 그룹", nextInviteCode(), member, null, null);
+        GroupRoom deletedGroup = GroupRoom.createOwnedBy("삭제된 그룹", nextInviteCode(), member);
         deletedGroup.delete();
         groupRoomRepository.save(deletedGroup);
         GroupRoom leftGroup = saveGroupOwnedBy(member, "나간 그룹");
@@ -1784,7 +1794,7 @@ class GroupIntegrationTest {
     void getMyGroupsAppliesStatusFilterAndPagination() throws Exception {
         Member member = saveMember("group-filter-user", "필터사용자");
         saveGroupOwnedBy(member, "활성 그룹");
-        GroupRoom closedGroup = GroupRoom.createOwnedBy("닫힌 그룹", nextInviteCode(), member, null, null);
+        GroupRoom closedGroup = GroupRoom.createOwnedBy("닫힌 그룹", nextInviteCode(), member);
         closedGroup.close();
         groupRoomRepository.save(closedGroup);
 
@@ -1923,7 +1933,7 @@ class GroupIntegrationTest {
                                 {
                                   "latitude": 37.498095,
                                   "longitude": 127.027610,
-                                  "level": 5,
+                                  "radiusMeters": 1000,
                                   "address": "서울 강남구 테헤란로 123"
                                 }
                                 """))
@@ -1945,7 +1955,7 @@ class GroupIntegrationTest {
                                 {
                                   "latitude": 37.498095,
                                   "longitude": 127.027610,
-                                  "level": 5,
+                                  "radiusMeters": 1000,
                                   "address": "서울 강남구 테헤란로 123"
                                 }
                                 """))
@@ -1954,16 +1964,17 @@ class GroupIntegrationTest {
                 .andExpect(jsonPath("$.data.name").value("위치 수정 그룹"))
                 .andExpect(jsonPath("$.data.latitude").value(37.498095))
                 .andExpect(jsonPath("$.data.longitude").value(127.027610))
-                .andExpect(jsonPath("$.data.level").value(5))
+                .andExpect(jsonPath("$.data.radiusMeters").value(1000))
                 .andExpect(jsonPath("$.data.address").value("서울 강남구 테헤란로 123"))
                 .andExpect(jsonPath("$.data.status").value(GroupRoomStatus.ACTIVE.name()));
 
         GroupRoom updatedGroup = groupRoomRepository.findById(groupRoom.getId()).orElseThrow();
+        GroupLocation updatedLocation = latestGroupLocation(updatedGroup);
         assertThat(updatedGroup.getName()).isEqualTo("위치 수정 그룹");
-        assertThat(updatedGroup.getLatitude()).isEqualByComparingTo("37.498095");
-        assertThat(updatedGroup.getLongitude()).isEqualByComparingTo("127.027610");
-        assertThat(updatedGroup.getLevel()).isEqualTo(5);
-        assertThat(updatedGroup.getAddress()).isEqualTo("서울 강남구 테헤란로 123");
+        assertThat(updatedLocation.getLatitude()).isEqualByComparingTo("37.498095");
+        assertThat(updatedLocation.getLongitude()).isEqualByComparingTo("127.027610");
+        assertThat(updatedLocation.getRadiusMeters()).isEqualTo(1000);
+        assertThat(updatedLocation.getAddress()).isEqualTo("서울 강남구 테헤란로 123");
     }
 
     @Test
@@ -2829,7 +2840,7 @@ class GroupIntegrationTest {
     }
 
     private GroupRoom saveGroupOwnedBy(Member member, String name) {
-        return groupRoomRepository.save(GroupRoom.createOwnedBy(name, nextInviteCode(), member, null, null));
+        return groupRoomRepository.save(GroupRoom.createOwnedBy(name, nextInviteCode(), member));
     }
 
     private AttributeCategory saveCategory(String code, String name, int sortOrder) {
@@ -2881,6 +2892,10 @@ class GroupIntegrationTest {
 
     private String nextInviteCode() {
         return "T%07d".formatted(groupRoomRepository.count() + 1);
+    }
+
+    private GroupLocation latestGroupLocation(GroupRoom groupRoom) {
+        return groupLocationRepository.findFirstByRoomIdOrderByCreatedAtDescIdDesc(groupRoom.getId()).orElseThrow();
     }
 
     private GroupInvite saveInvite(


### PR DESCRIPTION
## 관련 이슈
Closes #291

## 📝 작업 내용
- 그룹 위치 기억 정보를 `GroupLocation` 별도 엔티티와 `group_locations` 테이블로 분리했습니다.
- `GroupRoom : GroupLocation` 관계는 확장성을 고려해 1:N으로 설계하고, 현재 운영 흐름에서는 최신 위치 row를 그룹의 기억 위치로 사용하도록 구현했습니다.
- 위치 정보는 없을 수 있도록 nullable 구조로 두었습니다.
- 기존 위치 확대/축소 값인 `level` 대신 반경 거리 `radiusMeters`를 저장하도록 API DTO, command/result, 응답, Swagger 예시에 반영했습니다.
- 그룹 생성/수정/상세 조회 응답에서 최신 그룹 위치 정보를 반환하도록 변경했습니다.
- 그룹 추천 시작 요청은 `latitude`, `longitude`, `radiusMeters`, `address` 평면 필드 기반으로 받고, 전달된 위치 값은 `group_locations`의 최신 기억 위치로 반영하도록 변경했습니다.
- `PREPARING` 상태의 그룹 추천은 `contextJson = null`로 저장하고, 모든 멤버가 준비 완료되어 후보가 실제 생성되는 `OPEN` 전환 시점에 현재 그룹 기억 위치를 확정 `contextJson` 스냅샷으로 저장하도록 변경했습니다.
- 초기 SQL schema/seed, API/data 문서를 갱신했습니다.
- 그룹 통합 테스트에 위치 기억 생성/갱신, `PREPARING` context null, `OPEN` 전환 시 context 스냅샷 기록 검증을 추가했습니다.

이 변경은 그룹 위치 기억 책임을 `group_rooms`에서 분리해 위치 이력 확장 가능성을 열어두고, 추천 실행 이력의 기준 정보는 실제 후보가 생성된 시점의 확정 스냅샷으로만 유지하기 위해 필요합니다.

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [x] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
  - `GroupLocation`을 1:N으로 분리하되 현재 서비스 로직에서 최신 row를 갱신/조회하는 방식이 적절한지
  - `PREPARING`에서는 `contextJson`을 비워두고 `OPEN` 전환 시점에 확정 스냅샷을 저장하는 흐름이 의도와 맞는지
  - `level` 제거 후 `radiusMeters` API 계약이 누락 없이 반영됐는지

- 알려진 제한 사항:
  - 현재는 운영상 그룹별 최신 위치 1개만 사용하며, 위치 이력 조회 API는 제공하지 않습니다.

검증:
- `./gradlew test --tests matchuri.backend.api.group.GroupIntegrationTest`
- `./gradlew test --tests matchuri.backend.global.docs.OpenApiDocumentationIntegrationTest`
- `./gradlew test`