### PR TITLE
[Feat] 네이버 소셜 로그인 구현

### DIFF
--- a/src/main/java/matchuri/backend/api/auth/AuthApi.java
+++ b/src/main/java/matchuri/backend/api/auth/AuthApi.java
@@ -240,7 +240,7 @@ public interface AuthApi {
                     
                     - 일반 JSON API가 아니라 `302 Redirect` 응답입니다.
                     - 브라우저 이동 또는 팝업/리다이렉트 흐름에서 사용합니다.
-                    - 현재 지원 provider는 `google`, `kakao`입니다.
+                    - 현재 지원 provider는 `google`, `kakao`, `naver`입니다.
                     - 로그인 성공 후 프론트는 최종적으로 `code`를 전달받고, 별도 교환 API를 호출해 `accessToken`을 받습니다.
                     """
     )
@@ -260,7 +260,7 @@ public interface AuthApi {
                     
                     - 성공 시 응답 body에는 `accessToken`과 회원 요약 정보가 포함됩니다.
                     - `refreshToken`은 이미 OAuth2 성공 리다이렉트 단계에서 `HttpOnly` 쿠키로 처리되므로 body에는 포함되지 않습니다.
-                    - 현재 지원 provider는 `GOOGLE`, `KAKAO`입니다.
+                    - 현재 지원 provider는 `GOOGLE`, `KAKAO`, `NAVER`입니다.
                     - 같은 교환 코드는 한 번만 사용할 수 있습니다.
                     - 만료되었거나 이미 사용한 코드는 `AUTH_OAUTH2_EXCHANGE_CODE_INVALID`를 반환합니다.
                     """

--- a/src/main/java/matchuri/backend/api/auth/dto/request/OAuth2ExchangeRequest.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/request/OAuth2ExchangeRequest.java
@@ -7,8 +7,8 @@ import matchuri.backend.domain.member.entity.SocialProviderType;
 
 public record OAuth2ExchangeRequest(
         @Schema(
-                description = "교환 코드가 속한 소셜 로그인 제공자입니다. 현재 지원 값은 GOOGLE, KAKAO입니다.",
-                example = "KAKAO"
+                description = "교환 코드가 속한 소셜 로그인 제공자입니다. 현재 지원 값은 GOOGLE, KAKAO, NAVER입니다.",
+                example = "NAVER"
         )
         @NotNull(message = "provider는 비어 있을 수 없습니다.")
         SocialProviderType provider,

--- a/src/main/java/matchuri/backend/domain/auth/support/oauth2/KakaoOAuth2UserInfoResolver.java
+++ b/src/main/java/matchuri/backend/domain/auth/support/oauth2/KakaoOAuth2UserInfoResolver.java
@@ -2,6 +2,7 @@ package matchuri.backend.domain.auth.support.oauth2;
 
 import java.util.Map;
 import matchuri.backend.domain.member.entity.SocialProviderType;
+import matchuri.backend.global.util.TypeUtils;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
 
@@ -15,50 +16,19 @@ public class KakaoOAuth2UserInfoResolver implements OAuth2UserInfoResolver {
 
     @Override
     public OAuth2ProviderUserInfo resolve(OAuth2User oauth2User) {
-        Map<?, ?> kakaoAccount = asMap(oauth2User.getAttribute("kakao_account"));
-        Map<?, ?> properties = asMap(oauth2User.getAttribute("properties"));
-        Map<?, ?> profile = asMap(kakaoAccount.get("profile"));
+        Map<?, ?> kakaoAccount = TypeUtils.asMap(oauth2User.getAttribute("kakao_account"));
+        Map<?, ?> properties = TypeUtils.asMap(oauth2User.getAttribute("properties"));
+        Map<?, ?> profile = TypeUtils.asMap(kakaoAccount.get("profile"));
 
         return new OAuth2ProviderUserInfo(
                 SocialProviderType.KAKAO,
-                stringValue(oauth2User.getAttribute("id")),
-                stringValue(kakaoAccount.get("email")),
-                firstPresent(
-                        stringValue(properties.get("nickname")),
-                        stringValue(profile.get("nickname")),
-                        stringValue(kakaoAccount.get("name"))
+                TypeUtils.stringValue(oauth2User.getAttribute("id")),
+                TypeUtils.stringValue(kakaoAccount.get("email")),
+                TypeUtils.firstPresent(
+                        TypeUtils.stringValue(properties.get("nickname")),
+                        TypeUtils.stringValue(profile.get("nickname")),
+                        TypeUtils.stringValue(kakaoAccount.get("name"))
                 )
         );
-    }
-
-    private Map<?, ?> asMap(Object value) {
-        if (value instanceof Map<?, ?> map) {
-            return map;
-        }
-
-        return Map.of();
-    }
-
-    private String stringValue(Object value) {
-        if (value == null) {
-            return null;
-        }
-
-        String stringValue = String.valueOf(value);
-        if (stringValue.isBlank()) {
-            return null;
-        }
-
-        return stringValue;
-    }
-
-    private String firstPresent(String... values) {
-        for (String value : values) {
-            if (value != null && !value.isBlank()) {
-                return value;
-            }
-        }
-
-        return null;
     }
 }

--- a/src/main/java/matchuri/backend/domain/auth/support/oauth2/NaverOAuth2UserInfoResolver.java
+++ b/src/main/java/matchuri/backend/domain/auth/support/oauth2/NaverOAuth2UserInfoResolver.java
@@ -1,0 +1,28 @@
+package matchuri.backend.domain.auth.support.oauth2;
+
+import java.util.Map;
+import matchuri.backend.domain.member.entity.SocialProviderType;
+import matchuri.backend.global.util.TypeUtils;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NaverOAuth2UserInfoResolver implements OAuth2UserInfoResolver {
+    @Override
+    public boolean supports(SocialProviderType provider) {
+        return provider == SocialProviderType.NAVER;
+    }
+
+    @Override
+    public OAuth2ProviderUserInfo resolve(OAuth2User oauth2User) {
+        Map<String, Object> root = oauth2User.getAttributes();
+        Map<?, ?> response = TypeUtils.asMap(root.get("response"));
+
+        return new OAuth2ProviderUserInfo(
+                SocialProviderType.NAVER,
+                TypeUtils.stringValue(response.get("id")),
+                TypeUtils.stringValue(response.get("email")),
+                TypeUtils.stringValue(response.get("nickname"))
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/domain/member/entity/SocialProviderType.java
+++ b/src/main/java/matchuri/backend/domain/member/entity/SocialProviderType.java
@@ -26,6 +26,6 @@ public enum SocialProviderType {
     }
 
     public boolean isOAuth2LoginSupported() {
-        return this == GOOGLE || this == KAKAO;
+        return this == GOOGLE || this == KAKAO || this == NAVER;
     }
 }

--- a/src/main/java/matchuri/backend/global/util/TypeUtils.java
+++ b/src/main/java/matchuri/backend/global/util/TypeUtils.java
@@ -1,0 +1,36 @@
+package matchuri.backend.global.util;
+
+import java.util.Map;
+
+public class TypeUtils {
+    public static Map<?, ?> asMap(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            return map;
+        }
+
+        return Map.of();
+    }
+
+    public static String stringValue(Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        String stringValue = String.valueOf(value);
+        if (stringValue.isBlank()) {
+            return null;
+        }
+
+        return stringValue;
+    }
+
+    public static String firstPresent(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -31,11 +31,26 @@ spring:
               - profile_nickname
               - profile_image_url
               - account_email
+          naver:
+            client-id: ${MATCHURI_NAVER_CLIENT_ID:dummy-naver-client-id}
+            client-secret: ${MATCHURI_NAVER_CLIENT_SECRET:dummy-naver-client-secret}
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            scope:
+              - nickname
+              - email
+              - profile_image
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: id
 
   mail:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,7 +29,7 @@ spring:
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
             scope:
               - profile_nickname
-              - profile_image_url
+              - profile_image
               - account_email
           naver:
             client-id: ${MATCHURI_NAVER_CLIENT_ID:dummy-naver-client-id}
@@ -51,7 +51,7 @@ spring:
             authorization-uri: https://nid.naver.com/oauth2.0/authorize
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
-            user-name-attribute: id
+            user-name-attribute: response
 
   mail:
     host: ${MATCHURI_MAIL_HOST:smtp.gmail.com}

--- a/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
@@ -883,9 +883,17 @@ class MemberAuthIntegrationTest {
     }
 
     @Test
+    @DisplayName("네이버 OAuth2 시작 요청은 Spring Security authorization 엔드포인트로 리다이렉트한다")
+    void startNaverOAuth2LoginRedirects() throws Exception {
+        mockMvc.perform(get("/api/v1/auth/oauth2/naver"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(header().string(HttpHeaders.LOCATION, "/oauth2/authorization/naver"));
+    }
+
+    @Test
     @DisplayName("지원하지 않는 OAuth2 provider 시작 요청은 거절한다")
     void startOAuth2LoginRejectsUnsupportedProvider() throws Exception {
-        mockMvc.perform(get("/api/v1/auth/oauth2/naver"))
+        mockMvc.perform(get("/api/v1/auth/oauth2/apple"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error.code").value("AUTH_OAUTH2_PROVIDER_NOT_SUPPORTED"));
     }
@@ -914,6 +922,19 @@ class MemberAuthIntegrationTest {
                 .andExpect(status().is3xxRedirection())
                 .andExpect(header().string(HttpHeaders.LOCATION,
                         org.hamcrest.Matchers.containsString("https://kauth.kakao.com/oauth/authorize")))
+                .andReturn();
+
+        assertThat(result.getRequest().getSession(false)).isNotNull();
+        assertThat(result.getResponse().getCookie("matchuri_oauth2_auth_request")).isNull();
+    }
+
+    @Test
+    @DisplayName("네이버 Spring Security OAuth2 authorization 엔드포인트는 네이버 인증 서버로 리다이렉트한다")
+    void naverAuthorizationEndpointRedirectsToNaver() throws Exception {
+        MvcResult result = mockMvc.perform(get("/oauth2/authorization/naver"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(header().string(HttpHeaders.LOCATION,
+                        org.hamcrest.Matchers.containsString("https://nid.naver.com/oauth2.0/authorize")))
                 .andReturn();
 
         assertThat(result.getRequest().getSession(false)).isNotNull();
@@ -987,6 +1008,35 @@ class MemberAuthIntegrationTest {
                 .andExpect(jsonPath("$.data.refreshToken").value(nullValue()))
                 .andExpect(jsonPath("$.data.member.id").value(member.getId()))
                 .andExpect(jsonPath("$.data.member.nickname").value("kakao_kakao"))
+                .andExpect(jsonPath("$.data.onboarding.nextStep").value("REQUIRED_AGREEMENTS"));
+    }
+
+    @Test
+    @DisplayName("유효한 네이버 소셜 교환 코드는 액세스 토큰으로 교환된다")
+    void exchangeNaverOAuth2Code() throws Exception {
+        Member member = memberRepository.save(
+                Member.createSocialMember(SocialProviderType.NAVER, "naver-user-1", "naver@example.com",
+                        "naver_naver"));
+        authExchangeCodeRepository.save(AuthExchangeCode.issue(
+                member,
+                SocialProviderType.NAVER,
+                "valid-naver-exchange-code",
+                LocalDateTime.now().plusMinutes(5)
+        ));
+
+        mockMvc.perform(post("/api/v1/auth/oauth2/exchange")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "provider": "NAVER",
+                                  "code": "valid-naver-exchange-code"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").isString())
+                .andExpect(jsonPath("$.data.refreshToken").value(nullValue()))
+                .andExpect(jsonPath("$.data.member.id").value(member.getId()))
+                .andExpect(jsonPath("$.data.member.nickname").value("naver_naver"))
                 .andExpect(jsonPath("$.data.onboarding.nextStep").value("REQUIRED_AGREEMENTS"));
     }
 

--- a/src/test/java/matchuri/backend/domain/auth/support/oauth2/NaverOAuth2UserInfoResolverTest.java
+++ b/src/test/java/matchuri/backend/domain/auth/support/oauth2/NaverOAuth2UserInfoResolverTest.java
@@ -1,0 +1,56 @@
+package matchuri.backend.domain.auth.support.oauth2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import matchuri.backend.domain.member.entity.SocialProviderType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+class NaverOAuth2UserInfoResolverTest {
+
+    private final NaverOAuth2UserInfoResolver resolver = new NaverOAuth2UserInfoResolver();
+
+    @Test
+    @DisplayName("Naver OAuth2 사용자 정보를 공통 구조로 정규화한다")
+    void resolvesNaverUserInfo() {
+        OAuth2User oauth2User = new DefaultOAuth2User(
+                List.of(),
+                Map.of(
+                        "response", Map.of(
+                                "id", "naver-user-1",
+                                "email", "naver@example.com",
+                                "nickname", "네이버사용자"
+                        )
+                ),
+                "response"
+        );
+
+        OAuth2ProviderUserInfo userInfo = resolver.resolve(oauth2User);
+
+        assertThat(resolver.supports(SocialProviderType.NAVER)).isTrue();
+        assertThat(userInfo.provider()).isEqualTo(SocialProviderType.NAVER);
+        assertThat(userInfo.providerUserId()).isEqualTo("naver-user-1");
+        assertThat(userInfo.email()).isEqualTo("naver@example.com");
+        assertThat(userInfo.nickname()).isEqualTo("네이버사용자");
+    }
+
+    @Test
+    @DisplayName("Naver 계정 이메일과 닉네임이 없어도 고유 식별자를 정규화한다")
+    void resolvesNaverUserInfoWithoutOptionalFields() {
+        OAuth2User oauth2User = new DefaultOAuth2User(
+                List.of(),
+                Map.of("response", Map.of("id", "naver-user-2")),
+                "response"
+        );
+
+        OAuth2ProviderUserInfo userInfo = resolver.resolve(oauth2User);
+
+        assertThat(userInfo.providerUserId()).isEqualTo("naver-user-2");
+        assertThat(userInfo.email()).isNull();
+        assertThat(userInfo.nickname()).isNull();
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -34,12 +34,27 @@ spring:
             scope:
               - profile_nickname
               - account_email
+          naver:
+            client-id: test-naver-client-id
+            client-secret: test-naver-client-secret
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            scope:
+              - nickname
+              - email
+              - profile_image
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
 
 logging:
   level:


### PR DESCRIPTION
## 관련 이슈
Closes #298 

## 📝 작업 내용
- Naver OAuth2 로그인을 실제 지원 provider로 활성화했습니다.
- Naver OAuth2 client/provider 설정을 테스트 환경에도 추가했습니다.
- Naver 사용자 정보 응답 구조에 맞춰 `user-name-attribute`를 `response`로 보정했습니다.
- OAuth2 시작, authorization redirect, exchange, Naver user info resolver 테스트를 추가했습니다.
- Swagger/OpenAPI 설명과 OAuth2 API/운영 문서를 Google/Kakao/Naver 기준으로 갱신했습니다.

Naver 백엔드 연동 코드 일부는 이미 들어와 있었지만, 지원 provider 판정과 문서/테스트가 아직 Google/Kakao 기준으로 남아 있어 프론트에서 Naver 로그인 버튼을 눌러도 테스트 가능한 상태가 아니었습니다. 이번 변경으로 Kakao와 Naver 모두 같은 OAuth2 시작 -> callback -> exchange -> onboarding 흐름으로 검증할 수 있게 맞췄습니다.

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
  - `SocialProviderType.isOAuth2LoginSupported()`에 `NAVER`를 포함한 것이 현재 운영 오픈 범위와 맞는지 확인 부탁드립니다.
  - Naver OAuth2 응답 구조 기준으로 `user-name-attribute: response` 설정이 적절한지 확인 부탁드립니다.
  - `POST /api/v1/auth/oauth2/exchange`에서 `NAVER` 교환 코드가 기존 Google/Kakao와 같은 정책으로 처리되는지 봐주세요.

- 알려진 제한 사항:
  - 실제 운영 로그인은 Naver Developers callback URL 등록과 운영 환경 변수 반영 이후 브라우저에서 최종 검증이 필요합니다.
  - 소셜 계정 병합/연결 해제, provider access token 저장은 이번 범위에 포함하지 않았습니다.