### PR TITLE
[Feat] 백오피스 화면 추가

### DIFF
--- a/src/main/java/matchuri/backend/api/menu/AdminPageController.java
+++ b/src/main/java/matchuri/backend/api/menu/AdminPageController.java
@@ -1,0 +1,20 @@
+package matchuri.backend.api.menu;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/admin")
+public class AdminPageController {
+
+    @GetMapping
+    public String getAdminHome() {
+        return "redirect:/admin/menu-items";
+    }
+
+    @GetMapping("/login")
+    public String getLoginPage() {
+        return "admin/login";
+    }
+}

--- a/src/main/java/matchuri/backend/api/menu/AdminReferencePageController.java
+++ b/src/main/java/matchuri/backend/api/menu/AdminReferencePageController.java
@@ -1,0 +1,135 @@
+package matchuri.backend.api.menu;
+
+import lombok.RequiredArgsConstructor;
+import matchuri.backend.api.menu.dto.request.CreateAdminAttributeCategoryRequest;
+import matchuri.backend.api.menu.dto.request.CreateAdminIngredientRequest;
+import matchuri.backend.api.menu.dto.request.UpdateAdminAttributeCategoryRequest;
+import matchuri.backend.api.menu.dto.request.UpdateAdminIngredientRequest;
+import matchuri.backend.api.menu.mapper.MenuReferenceMapper;
+import matchuri.backend.domain.menu.entity.CategoryType;
+import matchuri.backend.domain.menu.service.MenuAdminReferenceService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class AdminReferencePageController {
+
+    private final MenuAdminReferenceService menuAdminReferenceService;
+    private final MenuReferenceMapper menuReferenceMapper;
+
+    @GetMapping("/attribute-categories")
+    public String getAttributeCategoriesPage(Model model) {
+        model.addAttribute("categoryTypes", CategoryType.values());
+        model.addAttribute("attributeCategories", menuAdminReferenceService.getAttributeCategories());
+
+        return "admin/attribute-categories";
+    }
+
+    @PostMapping("/attribute-categories")
+    public String createAttributeCategory(
+            @RequestParam String categoryType,
+            @RequestParam String code,
+            @RequestParam String name,
+            @RequestParam Integer sortOrder,
+            RedirectAttributes redirectAttributes
+    ) {
+        var command = menuReferenceMapper.toCreateAdminAttributeCategoryCommand(
+                new CreateAdminAttributeCategoryRequest(categoryType, code, name, sortOrder)
+        );
+        menuAdminReferenceService.createAttributeCategory(command);
+        redirectAttributes.addFlashAttribute("message", "속성 카테고리가 생성되었습니다.");
+
+        return "redirect:/admin/attribute-categories";
+    }
+
+    @PostMapping("/attribute-categories/{attributeCategoryId}")
+    public String updateAttributeCategory(
+            @PathVariable Long attributeCategoryId,
+            @RequestParam String name,
+            @RequestParam Integer sortOrder,
+            @RequestParam Boolean isActive,
+            RedirectAttributes redirectAttributes
+    ) {
+        var command = menuReferenceMapper.toUpdateAdminAttributeCategoryCommand(
+                attributeCategoryId,
+                new UpdateAdminAttributeCategoryRequest(name, sortOrder, isActive)
+        );
+        menuAdminReferenceService.updateAttributeCategory(command);
+        redirectAttributes.addFlashAttribute("message", "속성 카테고리가 저장되었습니다.");
+
+        return "redirect:/admin/attribute-categories";
+    }
+
+    @PostMapping("/attribute-categories/{attributeCategoryId}/deactivate")
+    public String deactivateAttributeCategory(
+            @PathVariable Long attributeCategoryId,
+            RedirectAttributes redirectAttributes
+    ) {
+        menuAdminReferenceService.deactivateAttributeCategory(attributeCategoryId);
+        redirectAttributes.addFlashAttribute("message", "속성 카테고리가 비활성화되었습니다.");
+
+        return "redirect:/admin/attribute-categories";
+    }
+
+    @GetMapping("/ingredients")
+    public String getIngredientsPage(Model model) {
+        model.addAttribute("ingredients", menuAdminReferenceService.getIngredients());
+
+        return "admin/ingredients";
+    }
+
+    @PostMapping("/ingredients")
+    public String createIngredient(
+            @RequestParam String code,
+            @RequestParam String name,
+            @RequestParam(defaultValue = "false") Boolean allergen,
+            @RequestParam Integer sortOrder,
+            RedirectAttributes redirectAttributes
+    ) {
+        var command = menuReferenceMapper.toCreateAdminIngredientCommand(
+                new CreateAdminIngredientRequest(code, name, allergen, sortOrder)
+        );
+        menuAdminReferenceService.createIngredient(command);
+        redirectAttributes.addFlashAttribute("message", "재료가 생성되었습니다.");
+
+        return "redirect:/admin/ingredients";
+    }
+
+    @PostMapping("/ingredients/{ingredientId}")
+    public String updateIngredient(
+            @PathVariable Long ingredientId,
+            @RequestParam String name,
+            @RequestParam(defaultValue = "false") Boolean allergen,
+            @RequestParam Integer sortOrder,
+            @RequestParam Boolean isActive,
+            RedirectAttributes redirectAttributes
+    ) {
+        var command = menuReferenceMapper.toUpdateAdminIngredientCommand(
+                ingredientId,
+                new UpdateAdminIngredientRequest(name, allergen, sortOrder, isActive)
+        );
+        menuAdminReferenceService.updateIngredient(command);
+        redirectAttributes.addFlashAttribute("message", "재료가 저장되었습니다.");
+
+        return "redirect:/admin/ingredients";
+    }
+
+    @PostMapping("/ingredients/{ingredientId}/deactivate")
+    public String deactivateIngredient(
+            @PathVariable Long ingredientId,
+            RedirectAttributes redirectAttributes
+    ) {
+        menuAdminReferenceService.deactivateIngredient(ingredientId);
+        redirectAttributes.addFlashAttribute("message", "재료가 비활성화되었습니다.");
+
+        return "redirect:/admin/ingredients";
+    }
+}

--- a/src/main/java/matchuri/backend/api/menu/MenuAdminReferenceApi.java
+++ b/src/main/java/matchuri/backend/api/menu/MenuAdminReferenceApi.java
@@ -13,15 +13,19 @@ import matchuri.backend.api.menu.dto.docs.AdminAttributeCategoryApiResponse;
 import matchuri.backend.api.menu.dto.docs.AdminAttributeCategoryListApiResponse;
 import matchuri.backend.api.menu.dto.docs.AdminIngredientApiResponse;
 import matchuri.backend.api.menu.dto.docs.AdminIngredientListApiResponse;
+import matchuri.backend.api.menu.dto.docs.AdminMenuItemDetailApiResponse;
 import matchuri.backend.api.menu.dto.docs.AdminMenuItemApiResponse;
 import matchuri.backend.api.menu.dto.docs.AdminMenuItemListApiResponse;
 import matchuri.backend.api.menu.dto.request.CreateAdminAttributeCategoryRequest;
 import matchuri.backend.api.menu.dto.request.CreateAdminIngredientRequest;
+import matchuri.backend.api.menu.dto.request.CreateAdminMenuItemRequest;
 import matchuri.backend.api.menu.dto.request.UpdateAdminAttributeCategoryRequest;
 import matchuri.backend.api.menu.dto.request.UpdateAdminIngredientRequest;
 import matchuri.backend.api.menu.dto.request.UpdateAdminMenuItemRequest;
+import matchuri.backend.api.menu.dto.request.UpdateAdminMenuItemReferencesRequest;
 import matchuri.backend.api.menu.dto.response.AdminAttributeCategoryResponse;
 import matchuri.backend.api.menu.dto.response.AdminIngredientResponse;
+import matchuri.backend.api.menu.dto.response.AdminMenuItemDetailResponse;
 import matchuri.backend.api.menu.dto.response.AdminMenuItemResponse;
 import matchuri.backend.global.api.ApiResponse;
 
@@ -254,6 +258,113 @@ public interface MenuAdminReferenceApi {
     ApiResponse<List<AdminMenuItemResponse>> getAdminMenuItems();
 
     @Operation(
+            summary = "관리자 메뉴 상세 조회",
+            description = """
+                    운영 관리용 `menu item` 단건 상세를 조회합니다.
+                    
+                    - `ADMIN` 권한이 필요합니다.
+                    - 메뉴 기본 정보, 대표 이미지 URL, attribute category 연결, ingredient 연결을 함께 반환합니다.
+                    - 연결 목록에는 활성/비활성 상태를 포함합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = AdminMenuItemDetailApiResponse.class)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 메뉴",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "notFound",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "data": null,
+                                              "error": {
+                                                "status": 404,
+                                                "code": "MENU_NOT_FOUND",
+                                                "message": "메뉴를 찾을 수 없습니다. menuId : 999",
+                                                "details": []
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken이 없거나 유효하지 않거나 만료됨",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "tokenMissing", value = ErrorExamples.AUTH_TOKEN_MISSING),
+                                    @ExampleObject(name = "tokenInvalid", value = ErrorExamples.AUTH_TOKEN_INVALID),
+                                    @ExampleObject(name = "tokenExpired", value = ErrorExamples.AUTH_TOKEN_EXPIRED)
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "관리자 권한 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(name = "forbidden", value = ErrorExamples.AUTH_FORBIDDEN)
+                    )
+            )
+    })
+    ApiResponse<AdminMenuItemDetailResponse> getAdminMenuItem(Long menuItemId);
+
+    @Operation(
+            summary = "관리자 메뉴 생성",
+            description = """
+                    운영 관리용 `menu item`을 생성합니다.
+                    
+                    - `ADMIN` 권한이 필요합니다.
+                    - 생성 직후 기본 활성 상태는 `true`입니다.
+                    - `code`는 생성 이후 안정적인 비즈니스 키로 보고 수정하지 않습니다.
+                    - attribute category와 ingredient 연결은 활성 데이터만 허용합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "생성 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = AdminMenuItemDetailApiResponse.class)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken이 없거나 유효하지 않거나 만료됨",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "tokenMissing", value = ErrorExamples.AUTH_TOKEN_MISSING),
+                                    @ExampleObject(name = "tokenInvalid", value = ErrorExamples.AUTH_TOKEN_INVALID),
+                                    @ExampleObject(name = "tokenExpired", value = ErrorExamples.AUTH_TOKEN_EXPIRED)
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "관리자 권한 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(name = "forbidden", value = ErrorExamples.AUTH_FORBIDDEN)
+                    )
+            )
+    })
+    ApiResponse<AdminMenuItemDetailResponse> createAdminMenuItem(CreateAdminMenuItemRequest request);
+
+    @Operation(
             summary = "관리자 메뉴 수정",
             description = """
                     운영 관리용 `menu item`의 수정 가능 필드만 갱신합니다.
@@ -336,6 +447,74 @@ public interface MenuAdminReferenceApi {
     ApiResponse<AdminMenuItemResponse> updateAdminMenuItem(
             Long menuItemId,
             UpdateAdminMenuItemRequest request
+    );
+
+    @Operation(
+            summary = "관리자 메뉴 연결 수정",
+            description = """
+                    운영 관리용 `menu item`의 attribute category와 ingredient 연결을 전체 교체합니다.
+                    
+                    - `ADMIN` 권한이 필요합니다.
+                    - 요청 배열이 최신 상태가 되며, 빈 배열이면 해당 연결을 모두 제거합니다.
+                    - 연결 대상은 활성 데이터만 허용합니다.
+                    - 추천 알고리즘 입력 데이터에 직접 영향을 줍니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "수정 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = AdminMenuItemDetailApiResponse.class)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 메뉴",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "notFound",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "data": null,
+                                              "error": {
+                                                "status": 404,
+                                                "code": "MENU_NOT_FOUND",
+                                                "message": "메뉴를 찾을 수 없습니다. menuId : 999",
+                                                "details": []
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken이 없거나 유효하지 않거나 만료됨",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "tokenMissing", value = ErrorExamples.AUTH_TOKEN_MISSING),
+                                    @ExampleObject(name = "tokenInvalid", value = ErrorExamples.AUTH_TOKEN_INVALID),
+                                    @ExampleObject(name = "tokenExpired", value = ErrorExamples.AUTH_TOKEN_EXPIRED)
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "관리자 권한 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(name = "forbidden", value = ErrorExamples.AUTH_FORBIDDEN)
+                    )
+            )
+    })
+    ApiResponse<AdminMenuItemDetailResponse> updateAdminMenuItemReferences(
+            Long menuItemId,
+            UpdateAdminMenuItemReferencesRequest request
     );
 
     @Operation(

--- a/src/main/java/matchuri/backend/api/menu/MenuAdminReferenceController.java
+++ b/src/main/java/matchuri/backend/api/menu/MenuAdminReferenceController.java
@@ -5,11 +5,14 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.api.menu.dto.request.CreateAdminAttributeCategoryRequest;
 import matchuri.backend.api.menu.dto.request.CreateAdminIngredientRequest;
+import matchuri.backend.api.menu.dto.request.CreateAdminMenuItemRequest;
 import matchuri.backend.api.menu.dto.request.UpdateAdminAttributeCategoryRequest;
 import matchuri.backend.api.menu.dto.request.UpdateAdminIngredientRequest;
 import matchuri.backend.api.menu.dto.request.UpdateAdminMenuItemRequest;
+import matchuri.backend.api.menu.dto.request.UpdateAdminMenuItemReferencesRequest;
 import matchuri.backend.api.menu.dto.response.AdminAttributeCategoryResponse;
 import matchuri.backend.api.menu.dto.response.AdminIngredientResponse;
+import matchuri.backend.api.menu.dto.response.AdminMenuItemDetailResponse;
 import matchuri.backend.api.menu.dto.response.AdminMenuItemResponse;
 import matchuri.backend.api.menu.mapper.MenuReferenceMapper;
 import matchuri.backend.domain.menu.service.MenuAdminReferenceService;
@@ -62,6 +65,29 @@ public class MenuAdminReferenceController implements MenuAdminReferenceApi {
     }
 
     @Override
+    @GetMapping("/menu-items/{menuItemId}")
+    public ApiResponse<AdminMenuItemDetailResponse> getAdminMenuItem(
+            @PathVariable Long menuItemId
+    ) {
+        var result = menuAdminReferenceService.getMenuItemDetail(menuItemId);
+        var response = menuReferenceMapper.toAdminMenuItemDetailResponse(result);
+
+        return ApiResponse.success(response);
+    }
+
+    @Override
+    @PostMapping("/menu-items")
+    public ApiResponse<AdminMenuItemDetailResponse> createAdminMenuItem(
+            @Valid @RequestBody CreateAdminMenuItemRequest request
+    ) {
+        var command = menuReferenceMapper.toCreateAdminMenuItemCommand(request);
+        var result = menuAdminReferenceService.createMenuItem(command);
+        var response = menuReferenceMapper.toAdminMenuItemDetailResponse(result);
+
+        return ApiResponse.success(response);
+    }
+
+    @Override
     @PatchMapping("/menu-items/{menuItemId}")
     public ApiResponse<AdminMenuItemResponse> updateAdminMenuItem(
             @PathVariable Long menuItemId,
@@ -71,6 +97,19 @@ public class MenuAdminReferenceController implements MenuAdminReferenceApi {
         var command = menuReferenceMapper.toUpdateAdminMenuItemCommand(menuItemId, request);
         var result = menuAdminReferenceService.updateMenuItem(command);
         var response = menuReferenceMapper.toAdminMenuItemResponse(result);
+
+        return ApiResponse.success(response);
+    }
+
+    @Override
+    @PatchMapping("/menu-items/{menuItemId}/references")
+    public ApiResponse<AdminMenuItemDetailResponse> updateAdminMenuItemReferences(
+            @PathVariable Long menuItemId,
+            @Valid @RequestBody UpdateAdminMenuItemReferencesRequest request
+    ) {
+        var command = menuReferenceMapper.toUpdateAdminMenuItemReferencesCommand(menuItemId, request);
+        var result = menuAdminReferenceService.updateMenuItemReferences(command);
+        var response = menuReferenceMapper.toAdminMenuItemDetailResponse(result);
 
         return ApiResponse.success(response);
     }

--- a/src/main/java/matchuri/backend/api/menu/MenuImageAdminPageController.java
+++ b/src/main/java/matchuri/backend/api/menu/MenuImageAdminPageController.java
@@ -1,7 +1,13 @@
 package matchuri.backend.api.menu;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import matchuri.backend.api.menu.dto.request.CreateAdminMenuItemRequest;
+import matchuri.backend.api.menu.dto.request.UpdateAdminMenuItemReferencesRequest;
+import matchuri.backend.api.menu.dto.request.UpdateAdminMenuItemRequest;
+import matchuri.backend.api.menu.mapper.MenuReferenceMapper;
 import matchuri.backend.domain.menu.service.MenuImageAdminService;
+import matchuri.backend.domain.menu.service.MenuAdminReferenceService;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -19,12 +25,95 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 public class MenuImageAdminPageController {
 
     private final MenuImageAdminService menuImageAdminService;
+    private final MenuAdminReferenceService menuAdminReferenceService;
+    private final MenuReferenceMapper menuReferenceMapper;
+
+    @GetMapping
+    public String getMenuItemsPage(Model model) {
+        model.addAttribute("menuItems", menuAdminReferenceService.getMenuItems());
+
+        return "admin/menu-items";
+    }
+
+    @GetMapping("/new")
+    public String getNewMenuItemPage(Model model) {
+        addReferenceData(model);
+
+        return "admin/menu-item-form";
+    }
+
+    @PostMapping
+    public String createMenuItem(
+            @RequestParam String code,
+            @RequestParam String name,
+            @RequestParam(required = false) String description,
+            @RequestParam(required = false) List<Long> attributeCategoryIds,
+            @RequestParam(required = false) List<Long> ingredientIds,
+            RedirectAttributes redirectAttributes
+    ) {
+        var request = new CreateAdminMenuItemRequest(
+                code,
+                name,
+                description,
+                emptyIfNull(attributeCategoryIds),
+                emptyIfNull(ingredientIds)
+        );
+        var command = menuReferenceMapper.toCreateAdminMenuItemCommand(request);
+        var result = menuAdminReferenceService.createMenuItem(command);
+        redirectAttributes.addFlashAttribute("message", "메뉴가 생성되었습니다.");
+
+        return "redirect:/admin/menu-items/" + result.id();
+    }
 
     @GetMapping("/{menuItemId}")
     public String getMenuItemDetailPage(@PathVariable Long menuItemId, Model model) {
-        model.addAttribute("menuItem", menuImageAdminService.getAdminMenuItemDetail(menuItemId));
+        var menuItem = menuAdminReferenceService.getMenuItemDetail(menuItemId);
+        model.addAttribute("menuItem", menuItem);
+        model.addAttribute("selectedAttributeCategoryIds", menuItem.attributeCategories().stream()
+                .map(attributeCategory -> attributeCategory.id())
+                .toList());
+        model.addAttribute("selectedIngredientIds", menuItem.ingredients().stream()
+                .map(ingredient -> ingredient.id())
+                .toList());
+        addReferenceData(model);
 
         return "admin/menu-item-detail";
+    }
+
+    @PostMapping("/{menuItemId}")
+    public String updateMenuItem(
+            @PathVariable Long menuItemId,
+            @RequestParam String name,
+            @RequestParam(required = false) String description,
+            @RequestParam Boolean isActive,
+            RedirectAttributes redirectAttributes
+    ) {
+        var command = menuReferenceMapper.toUpdateAdminMenuItemCommand(
+                menuItemId,
+                new UpdateAdminMenuItemRequest(name, description, isActive)
+        );
+        menuAdminReferenceService.updateMenuItem(command);
+        redirectAttributes.addFlashAttribute("message", "메뉴 정보가 저장되었습니다.");
+
+        return "redirect:/admin/menu-items/" + menuItemId;
+    }
+
+    @PostMapping("/{menuItemId}/references")
+    public String updateMenuItemReferences(
+            @PathVariable Long menuItemId,
+            @RequestParam(required = false) List<Long> attributeCategoryIds,
+            @RequestParam(required = false) List<Long> ingredientIds,
+            RedirectAttributes redirectAttributes
+    ) {
+        var request = new UpdateAdminMenuItemReferencesRequest(
+                emptyIfNull(attributeCategoryIds),
+                emptyIfNull(ingredientIds)
+        );
+        var command = menuReferenceMapper.toUpdateAdminMenuItemReferencesCommand(menuItemId, request);
+        menuAdminReferenceService.updateMenuItemReferences(command);
+        redirectAttributes.addFlashAttribute("message", "메뉴 연결 정보가 저장되었습니다.");
+
+        return "redirect:/admin/menu-items/" + menuItemId;
     }
 
     @PostMapping(value = "/{menuItemId}/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -37,5 +126,25 @@ public class MenuImageAdminPageController {
         redirectAttributes.addFlashAttribute("message", "메뉴 이미지가 업로드되었습니다.");
 
         return "redirect:/admin/menu-items/" + menuItemId;
+    }
+
+    @PostMapping("/{menuItemId}/images/primary/delete")
+    public String deletePrimaryMenuImage(
+            @PathVariable Long menuItemId,
+            RedirectAttributes redirectAttributes
+    ) {
+        menuImageAdminService.deletePrimaryImage(menuItemId);
+        redirectAttributes.addFlashAttribute("message", "메뉴 이미지 연결이 제거되었습니다.");
+
+        return "redirect:/admin/menu-items/" + menuItemId;
+    }
+
+    private void addReferenceData(Model model) {
+        model.addAttribute("attributeCategories", menuAdminReferenceService.getAttributeCategories());
+        model.addAttribute("ingredients", menuAdminReferenceService.getIngredients());
+    }
+
+    private List<Long> emptyIfNull(List<Long> ids) {
+        return ids == null ? List.of() : ids;
     }
 }

--- a/src/main/java/matchuri/backend/api/menu/dto/docs/AdminMenuItemDetailApiResponse.java
+++ b/src/main/java/matchuri/backend/api/menu/dto/docs/AdminMenuItemDetailApiResponse.java
@@ -1,0 +1,18 @@
+package matchuri.backend.api.menu.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.menu.dto.response.AdminMenuItemDetailResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "관리자 메뉴 상세 API의 공통 응답 envelope입니다.")
+public record AdminMenuItemDetailApiResponse(
+        @Schema(description = "요청 성공 여부입니다.", example = "true")
+        boolean success,
+
+        @Schema(description = "성공 시 반환되는 관리자 메뉴 상세 정보입니다.")
+        AdminMenuItemDetailResponse data,
+
+        @Schema(description = "실패 시 반환되는 에러 정보입니다.")
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/menu/dto/request/CreateAdminMenuItemRequest.java
+++ b/src/main/java/matchuri/backend/api/menu/dto/request/CreateAdminMenuItemRequest.java
@@ -1,0 +1,33 @@
+package matchuri.backend.api.menu.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import matchuri.backend.domain.menu.entity.MenuItem;
+
+public record CreateAdminMenuItemRequest(
+        @Schema(description = "메뉴 코드입니다. 생성 이후 수정하지 않는 비즈니스 키입니다.", example = "KIMCHI_FRIED_RICE")
+        @NotBlank(message = "code는 필수입니다.")
+        @Size(max = 50, message = "code는 최대 50자입니다.")
+        String code,
+
+        @Schema(description = "메뉴 표시 이름입니다.", example = "김치볶음밥")
+        @NotBlank(message = "name은 필수입니다.")
+        @Size(max = MenuItem.NAME_MAX_LENGTH, message = "name은 최대 120자입니다.")
+        String name,
+
+        @Schema(description = "메뉴 설명입니다.", example = "김치와 밥을 볶은 한식 메뉴입니다.")
+        @Size(max = MenuItem.DESCRIPTION_MAX_LENGTH, message = "description은 최대 500자입니다.")
+        String description,
+
+        @Schema(description = "메뉴에 연결할 활성 attribute category ID 목록입니다.")
+        @NotNull(message = "attributeCategoryIds는 필수입니다.")
+        List<@NotNull(message = "attributeCategoryIds 항목은 null일 수 없습니다.") Long> attributeCategoryIds,
+
+        @Schema(description = "메뉴에 연결할 활성 ingredient ID 목록입니다.")
+        @NotNull(message = "ingredientIds는 필수입니다.")
+        List<@NotNull(message = "ingredientIds 항목은 null일 수 없습니다.") Long> ingredientIds
+) {
+}

--- a/src/main/java/matchuri/backend/api/menu/dto/request/UpdateAdminMenuItemReferencesRequest.java
+++ b/src/main/java/matchuri/backend/api/menu/dto/request/UpdateAdminMenuItemReferencesRequest.java
@@ -1,0 +1,16 @@
+package matchuri.backend.api.menu.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record UpdateAdminMenuItemReferencesRequest(
+        @Schema(description = "메뉴에 연결할 활성 attribute category ID 목록입니다. 빈 배열이면 연결을 모두 제거합니다.")
+        @NotNull(message = "attributeCategoryIds는 필수입니다.")
+        List<@NotNull(message = "attributeCategoryIds 항목은 null일 수 없습니다.") Long> attributeCategoryIds,
+
+        @Schema(description = "메뉴에 연결할 활성 ingredient ID 목록입니다. 빈 배열이면 연결을 모두 제거합니다.")
+        @NotNull(message = "ingredientIds는 필수입니다.")
+        List<@NotNull(message = "ingredientIds 항목은 null일 수 없습니다.") Long> ingredientIds
+) {
+}

--- a/src/main/java/matchuri/backend/api/menu/dto/response/AdminMenuItemDetailResponse.java
+++ b/src/main/java/matchuri/backend/api/menu/dto/response/AdminMenuItemDetailResponse.java
@@ -1,0 +1,31 @@
+package matchuri.backend.api.menu.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record AdminMenuItemDetailResponse(
+        @Schema(description = "메뉴 ID입니다.", example = "1001")
+        Long id,
+
+        @Schema(description = "메뉴 코드입니다.", example = "PORK_CUTLET")
+        String code,
+
+        @Schema(description = "메뉴 표시 이름입니다.", example = "돈까스")
+        String name,
+
+        @Schema(description = "메뉴 설명입니다.", example = "돼지고기를 튀겨 소스와 함께 먹는 바삭한 메뉴입니다.")
+        String description,
+
+        @Schema(description = "운영 기준 활성 여부입니다.", example = "true")
+        boolean isActive,
+
+        @Schema(description = "대표 이미지 공개 URL입니다. 이미지가 없으면 null입니다.")
+        String thumbnailUrl,
+
+        @Schema(description = "메뉴에 연결된 attribute category 목록입니다.")
+        List<AdminAttributeCategoryResponse> attributeCategories,
+
+        @Schema(description = "메뉴에 연결된 ingredient 목록입니다.")
+        List<AdminIngredientResponse> ingredients
+) {
+}

--- a/src/main/java/matchuri/backend/api/menu/mapper/MenuReferenceMapper.java
+++ b/src/main/java/matchuri/backend/api/menu/mapper/MenuReferenceMapper.java
@@ -3,11 +3,14 @@ package matchuri.backend.api.menu.mapper;
 import java.util.List;
 import matchuri.backend.api.menu.dto.request.CreateAdminAttributeCategoryRequest;
 import matchuri.backend.api.menu.dto.request.CreateAdminIngredientRequest;
+import matchuri.backend.api.menu.dto.request.CreateAdminMenuItemRequest;
 import matchuri.backend.api.menu.dto.request.UpdateAdminAttributeCategoryRequest;
 import matchuri.backend.api.menu.dto.request.UpdateAdminIngredientRequest;
 import matchuri.backend.api.menu.dto.request.UpdateAdminMenuItemRequest;
+import matchuri.backend.api.menu.dto.request.UpdateAdminMenuItemReferencesRequest;
 import matchuri.backend.api.menu.dto.response.AdminAttributeCategoryResponse;
 import matchuri.backend.api.menu.dto.response.AdminIngredientResponse;
+import matchuri.backend.api.menu.dto.response.AdminMenuItemDetailResponse;
 import matchuri.backend.api.menu.dto.response.AdminMenuItemResponse;
 import matchuri.backend.api.menu.dto.response.AttributeCategoryResponse;
 import matchuri.backend.api.menu.dto.response.MenuItemDetailResponse;
@@ -15,15 +18,18 @@ import matchuri.backend.api.menu.dto.response.MenuItemSummaryResponse;
 import matchuri.backend.api.menu.dto.response.RestrictionIngredientResponse;
 import matchuri.backend.domain.menu.command.CreateAdminAttributeCategoryCommand;
 import matchuri.backend.domain.menu.command.CreateAdminIngredientCommand;
+import matchuri.backend.domain.menu.command.CreateAdminMenuItemCommand;
 import matchuri.backend.domain.menu.command.GetAttributeCategoriesCommand;
 import matchuri.backend.domain.menu.command.GetRestrictionIngredientsCommand;
 import matchuri.backend.domain.menu.command.SearchMenuItemsCommand;
 import matchuri.backend.domain.menu.command.UpdateAdminAttributeCategoryCommand;
 import matchuri.backend.domain.menu.command.UpdateAdminIngredientCommand;
 import matchuri.backend.domain.menu.command.UpdateAdminMenuItemCommand;
+import matchuri.backend.domain.menu.command.UpdateAdminMenuItemReferencesCommand;
 import matchuri.backend.domain.menu.entity.CategoryType;
 import matchuri.backend.domain.menu.result.AdminAttributeCategoryResult;
 import matchuri.backend.domain.menu.result.AdminIngredientResult;
+import matchuri.backend.domain.menu.result.AdminMenuItemDetailResult;
 import matchuri.backend.domain.menu.result.AdminMenuItemResult;
 import matchuri.backend.domain.menu.result.AttributeCategoryResult;
 import matchuri.backend.domain.menu.result.MenuItemDetailResult;
@@ -51,6 +57,16 @@ public class MenuReferenceMapper {
                 request.name().trim(),
                 request.allergen(),
                 request.sortOrder()
+        );
+    }
+
+    public CreateAdminMenuItemCommand toCreateAdminMenuItemCommand(CreateAdminMenuItemRequest request) {
+        return new CreateAdminMenuItemCommand(
+                request.code().trim(),
+                request.name().trim(),
+                trimNullable(request.description()),
+                request.attributeCategoryIds(),
+                request.ingredientIds()
         );
     }
 
@@ -88,6 +104,17 @@ public class MenuReferenceMapper {
                 trimNullable(request.name()),
                 trimNullable(request.description()),
                 request.isActive()
+        );
+    }
+
+    public UpdateAdminMenuItemReferencesCommand toUpdateAdminMenuItemReferencesCommand(
+            Long menuItemId,
+            UpdateAdminMenuItemReferencesRequest request
+    ) {
+        return new UpdateAdminMenuItemReferencesCommand(
+                menuItemId,
+                request.attributeCategoryIds(),
+                request.ingredientIds()
         );
     }
 
@@ -200,6 +227,19 @@ public class MenuReferenceMapper {
                 result.name(),
                 result.description(),
                 result.isActive()
+        );
+    }
+
+    public AdminMenuItemDetailResponse toAdminMenuItemDetailResponse(AdminMenuItemDetailResult result) {
+        return new AdminMenuItemDetailResponse(
+                result.id(),
+                result.code(),
+                result.name(),
+                result.description(),
+                result.isActive(),
+                result.thumbnailUrl(),
+                toAdminAttributeCategoryResponses(result.attributeCategories()),
+                toAdminIngredientResponses(result.ingredients())
         );
     }
 

--- a/src/main/java/matchuri/backend/domain/menu/MenuErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/menu/MenuErrorCode.java
@@ -10,10 +10,15 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum MenuErrorCode implements ErrorCode {
     NOT_FOUND(HttpStatus.NOT_FOUND, "메뉴를 찾을 수 없습니다. menuId : {0}"),
+    DUPLICATE(HttpStatus.CONFLICT, "메뉴가 이미 존재합니다. code : {0}"),
     ATTRIBUTE_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "속성 카테고리를 찾을 수 없습니다. attributeCategoryId : {0}"),
     ATTRIBUTE_CATEGORY_DUPLICATE(HttpStatus.CONFLICT, "속성 카테고리가 이미 존재합니다. categoryType : {0}, code : {1}"),
     INGREDIENT_NOT_FOUND(HttpStatus.NOT_FOUND, "재료를 찾을 수 없습니다. ingredientId : {0}"),
     INGREDIENT_DUPLICATE(HttpStatus.CONFLICT, "재료가 이미 존재합니다. code : {0}"),
+    DUPLICATE_MENU_ATTRIBUTE_CATEGORY(HttpStatus.BAD_REQUEST, "중복된 attribute category ID가 포함되어 있습니다. attributeCategoryIds : {0}"),
+    INVALID_MENU_ATTRIBUTE_CATEGORY(HttpStatus.BAD_REQUEST, "유효하지 않거나 비활성화된 attribute category ID가 포함되어 있습니다. attributeCategoryIds : {0}"),
+    DUPLICATE_MENU_INGREDIENT(HttpStatus.BAD_REQUEST, "중복된 ingredient ID가 포함되어 있습니다. ingredientIds : {0}"),
+    INVALID_MENU_INGREDIENT(HttpStatus.BAD_REQUEST, "유효하지 않거나 비활성화된 ingredient ID가 포함되어 있습니다. ingredientIds : {0}"),
     INVALID_FILTER(HttpStatus.BAD_REQUEST, "메뉴 검색 필터가 유효하지 않습니다. {0} : {1}");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/matchuri/backend/domain/menu/command/CreateAdminMenuItemCommand.java
+++ b/src/main/java/matchuri/backend/domain/menu/command/CreateAdminMenuItemCommand.java
@@ -1,0 +1,16 @@
+package matchuri.backend.domain.menu.command;
+
+import java.util.List;
+
+public record CreateAdminMenuItemCommand(
+        String code,
+        String name,
+        String description,
+        List<Long> attributeCategoryIds,
+        List<Long> ingredientIds
+) {
+    public CreateAdminMenuItemCommand {
+        attributeCategoryIds = attributeCategoryIds == null ? List.of() : List.copyOf(attributeCategoryIds);
+        ingredientIds = ingredientIds == null ? List.of() : List.copyOf(ingredientIds);
+    }
+}

--- a/src/main/java/matchuri/backend/domain/menu/command/UpdateAdminMenuItemReferencesCommand.java
+++ b/src/main/java/matchuri/backend/domain/menu/command/UpdateAdminMenuItemReferencesCommand.java
@@ -1,0 +1,14 @@
+package matchuri.backend.domain.menu.command;
+
+import java.util.List;
+
+public record UpdateAdminMenuItemReferencesCommand(
+        Long menuItemId,
+        List<Long> attributeCategoryIds,
+        List<Long> ingredientIds
+) {
+    public UpdateAdminMenuItemReferencesCommand {
+        attributeCategoryIds = attributeCategoryIds == null ? List.of() : List.copyOf(attributeCategoryIds);
+        ingredientIds = ingredientIds == null ? List.of() : List.copyOf(ingredientIds);
+    }
+}

--- a/src/main/java/matchuri/backend/domain/menu/repository/MenuAttributeCategoryRepository.java
+++ b/src/main/java/matchuri/backend/domain/menu/repository/MenuAttributeCategoryRepository.java
@@ -13,6 +13,10 @@ public interface MenuAttributeCategoryRepository extends JpaRepository<MenuAttri
 
     boolean existsByMenuAndAttributeCategory(MenuItem menu, AttributeCategory attributeCategory);
 
+    List<MenuAttributeCategory> findAllByMenuIdOrderByAttributeCategoryCategoryTypeAscAttributeCategorySortOrderAscAttributeCategoryIdAsc(
+            Long menuId
+    );
+
     List<MenuAttributeCategory> findAllByMenuIdAndAttributeCategoryActiveTrueOrderByAttributeCategoryCategoryTypeAscAttributeCategorySortOrderAscAttributeCategoryIdAsc(
             Long menuId
     );

--- a/src/main/java/matchuri/backend/domain/menu/repository/MenuIngredientRepository.java
+++ b/src/main/java/matchuri/backend/domain/menu/repository/MenuIngredientRepository.java
@@ -13,6 +13,8 @@ public interface MenuIngredientRepository extends JpaRepository<MenuIngredient, 
 
     boolean existsByMenuAndIngredient(MenuItem menu, Ingredient ingredient);
 
+    List<MenuIngredient> findAllByMenuIdOrderByIngredientSortOrderAscIngredientIdAsc(Long menuId);
+
     List<MenuIngredient> findAllByMenuIdAndIngredientActiveTrueOrderByIngredientSortOrderAscIngredientIdAsc(Long menuId);
 
     List<MenuIngredient> findAllByIngredientIdNotIn(Collection<Long> ingredientIds);

--- a/src/main/java/matchuri/backend/domain/menu/result/AdminMenuItemDetailResult.java
+++ b/src/main/java/matchuri/backend/domain/menu/result/AdminMenuItemDetailResult.java
@@ -1,11 +1,19 @@
 package matchuri.backend.domain.menu.result;
 
+import java.util.List;
+
 public record AdminMenuItemDetailResult(
         Long id,
         String code,
         String name,
         String description,
         boolean isActive,
-        String thumbnailUrl
+        String thumbnailUrl,
+        List<AdminAttributeCategoryResult> attributeCategories,
+        List<AdminIngredientResult> ingredients
 ) {
+    public AdminMenuItemDetailResult {
+        attributeCategories = attributeCategories == null ? List.of() : List.copyOf(attributeCategories);
+        ingredients = ingredients == null ? List.of() : List.copyOf(ingredients);
+    }
 }

--- a/src/main/java/matchuri/backend/domain/menu/service/MenuAdminReferenceService.java
+++ b/src/main/java/matchuri/backend/domain/menu/service/MenuAdminReferenceService.java
@@ -3,11 +3,14 @@ package matchuri.backend.domain.menu.service;
 import java.util.List;
 import matchuri.backend.domain.menu.command.CreateAdminAttributeCategoryCommand;
 import matchuri.backend.domain.menu.command.CreateAdminIngredientCommand;
+import matchuri.backend.domain.menu.command.CreateAdminMenuItemCommand;
 import matchuri.backend.domain.menu.command.UpdateAdminAttributeCategoryCommand;
 import matchuri.backend.domain.menu.command.UpdateAdminIngredientCommand;
 import matchuri.backend.domain.menu.command.UpdateAdminMenuItemCommand;
+import matchuri.backend.domain.menu.command.UpdateAdminMenuItemReferencesCommand;
 import matchuri.backend.domain.menu.result.AdminAttributeCategoryResult;
 import matchuri.backend.domain.menu.result.AdminIngredientResult;
+import matchuri.backend.domain.menu.result.AdminMenuItemDetailResult;
 import matchuri.backend.domain.menu.result.AdminMenuItemResult;
 
 public interface MenuAdminReferenceService {
@@ -18,15 +21,21 @@ public interface MenuAdminReferenceService {
 
     List<AdminMenuItemResult> getMenuItems();
 
+    AdminMenuItemDetailResult getMenuItemDetail(Long menuItemId);
+
     AdminAttributeCategoryResult createAttributeCategory(CreateAdminAttributeCategoryCommand command);
 
     AdminIngredientResult createIngredient(CreateAdminIngredientCommand command);
+
+    AdminMenuItemDetailResult createMenuItem(CreateAdminMenuItemCommand command);
 
     AdminAttributeCategoryResult updateAttributeCategory(UpdateAdminAttributeCategoryCommand command);
 
     AdminIngredientResult updateIngredient(UpdateAdminIngredientCommand command);
 
     AdminMenuItemResult updateMenuItem(UpdateAdminMenuItemCommand command);
+
+    AdminMenuItemDetailResult updateMenuItemReferences(UpdateAdminMenuItemReferencesCommand command);
 
     AdminMenuItemResult deactivateMenuItem(Long menuItemId);
 

--- a/src/main/java/matchuri/backend/domain/menu/service/MenuAdminReferenceServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/menu/service/MenuAdminReferenceServiceImpl.java
@@ -1,22 +1,33 @@
 package matchuri.backend.domain.menu.service;
 
 import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.domain.menu.MenuErrorCode;
 import matchuri.backend.domain.menu.command.CreateAdminAttributeCategoryCommand;
 import matchuri.backend.domain.menu.command.CreateAdminIngredientCommand;
+import matchuri.backend.domain.menu.command.CreateAdminMenuItemCommand;
 import matchuri.backend.domain.menu.command.UpdateAdminAttributeCategoryCommand;
 import matchuri.backend.domain.menu.command.UpdateAdminIngredientCommand;
 import matchuri.backend.domain.menu.command.UpdateAdminMenuItemCommand;
+import matchuri.backend.domain.menu.command.UpdateAdminMenuItemReferencesCommand;
 import matchuri.backend.domain.menu.entity.AttributeCategory;
 import matchuri.backend.domain.menu.entity.Ingredient;
+import matchuri.backend.domain.menu.entity.MenuAttributeCategory;
+import matchuri.backend.domain.menu.entity.MenuIngredient;
 import matchuri.backend.domain.menu.entity.MenuItem;
 import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
 import matchuri.backend.domain.menu.repository.IngredientRepository;
+import matchuri.backend.domain.menu.repository.MenuAttributeCategoryRepository;
+import matchuri.backend.domain.menu.repository.MenuIngredientRepository;
 import matchuri.backend.domain.menu.repository.MenuItemRepository;
 import matchuri.backend.domain.menu.result.AdminAttributeCategoryResult;
 import matchuri.backend.domain.menu.result.AdminIngredientResult;
+import matchuri.backend.domain.menu.result.AdminMenuItemDetailResult;
 import matchuri.backend.domain.menu.result.AdminMenuItemResult;
+import matchuri.backend.domain.menu.support.MenuThumbnailUrlResolver;
 import matchuri.backend.global.exception.BusinessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +40,9 @@ public class MenuAdminReferenceServiceImpl implements MenuAdminReferenceService 
     private final AttributeCategoryRepository attributeCategoryRepository;
     private final IngredientRepository ingredientRepository;
     private final MenuItemRepository menuItemRepository;
+    private final MenuAttributeCategoryRepository menuAttributeCategoryRepository;
+    private final MenuIngredientRepository menuIngredientRepository;
+    private final MenuThumbnailUrlResolver menuThumbnailUrlResolver;
 
     @Override
     public List<AdminAttributeCategoryResult> getAttributeCategories() {
@@ -49,6 +63,13 @@ public class MenuAdminReferenceServiceImpl implements MenuAdminReferenceService 
         return menuItemRepository.findAllByOrderByIdAsc().stream()
                 .map(AdminMenuItemResult::from)
                 .toList();
+    }
+
+    @Override
+    public AdminMenuItemDetailResult getMenuItemDetail(Long menuItemId) {
+        MenuItem menuItem = getMenuItem(menuItemId);
+
+        return toAdminMenuItemDetailResult(menuItem);
     }
 
     @Override
@@ -78,6 +99,29 @@ public class MenuAdminReferenceServiceImpl implements MenuAdminReferenceService 
         );
 
         return AdminIngredientResult.from(ingredient);
+    }
+
+    @Override
+    @Transactional
+    public AdminMenuItemDetailResult createMenuItem(CreateAdminMenuItemCommand command) {
+        validateNoDuplicateIds(command.attributeCategoryIds(), MenuErrorCode.DUPLICATE_MENU_ATTRIBUTE_CATEGORY);
+        validateNoDuplicateIds(command.ingredientIds(), MenuErrorCode.DUPLICATE_MENU_INGREDIENT);
+
+        if (menuItemRepository.existsByCode(command.code())) {
+            throw new BusinessException(MenuErrorCode.DUPLICATE, command.code());
+        }
+
+        List<AttributeCategory> attributeCategories = loadActiveAttributeCategories(command.attributeCategoryIds());
+        List<Ingredient> ingredients = loadActiveIngredients(command.ingredientIds());
+
+        MenuItem menuItem = menuItemRepository.saveAndFlush(
+                new MenuItem(command.code(), command.name(), command.description())
+        );
+
+        saveMenuAttributeCategories(menuItem, attributeCategories);
+        saveMenuIngredients(menuItem, ingredients);
+
+        return toAdminMenuItemDetailResult(menuItem);
     }
 
     @Override
@@ -143,8 +187,7 @@ public class MenuAdminReferenceServiceImpl implements MenuAdminReferenceService 
     @Override
     @Transactional
     public AdminMenuItemResult updateMenuItem(UpdateAdminMenuItemCommand command) {
-        MenuItem menuItem = menuItemRepository.findById(command.menuItemId())
-                .orElseThrow(() -> new BusinessException(MenuErrorCode.NOT_FOUND, command.menuItemId()));
+        MenuItem menuItem = getMenuItem(command.menuItemId());
 
         if (command.name() != null) {
             menuItem.updateName(command.name());
@@ -167,9 +210,24 @@ public class MenuAdminReferenceServiceImpl implements MenuAdminReferenceService 
 
     @Override
     @Transactional
+    public AdminMenuItemDetailResult updateMenuItemReferences(UpdateAdminMenuItemReferencesCommand command) {
+        validateNoDuplicateIds(command.attributeCategoryIds(), MenuErrorCode.DUPLICATE_MENU_ATTRIBUTE_CATEGORY);
+        validateNoDuplicateIds(command.ingredientIds(), MenuErrorCode.DUPLICATE_MENU_INGREDIENT);
+
+        MenuItem menuItem = getMenuItem(command.menuItemId());
+        List<AttributeCategory> attributeCategories = loadActiveAttributeCategories(command.attributeCategoryIds());
+        List<Ingredient> ingredients = loadActiveIngredients(command.ingredientIds());
+
+        replaceMenuAttributeCategories(menuItem, attributeCategories);
+        replaceMenuIngredients(menuItem, ingredients);
+
+        return toAdminMenuItemDetailResult(menuItem);
+    }
+
+    @Override
+    @Transactional
     public AdminMenuItemResult deactivateMenuItem(Long menuItemId) {
-        MenuItem menuItem = menuItemRepository.findById(menuItemId)
-                .orElseThrow(() -> new BusinessException(MenuErrorCode.NOT_FOUND, menuItemId));
+        MenuItem menuItem = getMenuItem(menuItemId);
 
         if (menuItem.isActive()) {
             menuItem.deactivate();
@@ -205,5 +263,111 @@ public class MenuAdminReferenceServiceImpl implements MenuAdminReferenceService 
         }
 
         return AdminIngredientResult.from(ingredient);
+    }
+
+    private MenuItem getMenuItem(Long menuItemId) {
+        return menuItemRepository.findById(menuItemId)
+                .orElseThrow(() -> new BusinessException(MenuErrorCode.NOT_FOUND, menuItemId));
+    }
+
+    private AdminMenuItemDetailResult toAdminMenuItemDetailResult(MenuItem menuItem) {
+        List<AdminAttributeCategoryResult> attributeCategories = menuAttributeCategoryRepository
+                .findAllByMenuIdOrderByAttributeCategoryCategoryTypeAscAttributeCategorySortOrderAscAttributeCategoryIdAsc(
+                        menuItem.getId())
+                .stream()
+                .map(MenuAttributeCategory::getAttributeCategory)
+                .map(AdminAttributeCategoryResult::from)
+                .toList();
+
+        List<AdminIngredientResult> ingredients = menuIngredientRepository
+                .findAllByMenuIdOrderByIngredientSortOrderAscIngredientIdAsc(menuItem.getId())
+                .stream()
+                .map(MenuIngredient::getIngredient)
+                .map(AdminIngredientResult::from)
+                .toList();
+
+        return new AdminMenuItemDetailResult(
+                menuItem.getId(),
+                menuItem.getCode(),
+                menuItem.getName(),
+                menuItem.getDescription(),
+                menuItem.isActive(),
+                menuThumbnailUrlResolver.resolve(menuItem.getId()),
+                attributeCategories,
+                ingredients
+        );
+    }
+
+    private List<AttributeCategory> loadActiveAttributeCategories(List<Long> attributeCategoryIds) {
+        if (attributeCategoryIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<AttributeCategory> attributeCategories = attributeCategoryRepository.findAllByIdInAndActiveTrue(
+                attributeCategoryIds);
+        if (attributeCategories.size() != attributeCategoryIds.size()) {
+            throw new BusinessException(MenuErrorCode.INVALID_MENU_ATTRIBUTE_CATEGORY, attributeCategoryIds);
+        }
+
+        return sortByRequestedIdOrder(attributeCategories, attributeCategoryIds, AttributeCategory::getId);
+    }
+
+    private List<Ingredient> loadActiveIngredients(List<Long> ingredientIds) {
+        if (ingredientIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<Ingredient> ingredients = ingredientRepository.findAllByIdInAndActiveTrue(ingredientIds);
+        if (ingredients.size() != ingredientIds.size()) {
+            throw new BusinessException(MenuErrorCode.INVALID_MENU_INGREDIENT, ingredientIds);
+        }
+
+        return sortByRequestedIdOrder(ingredients, ingredientIds, Ingredient::getId);
+    }
+
+    private <T> List<T> sortByRequestedIdOrder(List<T> values, List<Long> ids, Function<T, Long> idGetter) {
+        var valuesById = values.stream()
+                .collect(Collectors.toMap(idGetter, Function.identity()));
+
+        return ids.stream()
+                .map(valuesById::get)
+                .toList();
+    }
+
+    private void validateNoDuplicateIds(List<Long> ids, MenuErrorCode errorCode) {
+        Set<Long> distinctIds = ids.stream().collect(Collectors.toSet());
+        if (distinctIds.size() != ids.size()) {
+            throw new BusinessException(errorCode, ids);
+        }
+    }
+
+    private void replaceMenuAttributeCategories(MenuItem menuItem, List<AttributeCategory> attributeCategories) {
+        List<MenuAttributeCategory> currentMappings = menuAttributeCategoryRepository.findAllByMenuIdOrderByAttributeCategoryCategoryTypeAscAttributeCategorySortOrderAscAttributeCategoryIdAsc(
+                menuItem.getId());
+        menuAttributeCategoryRepository.deleteAll(currentMappings);
+        menuAttributeCategoryRepository.flush();
+
+        saveMenuAttributeCategories(menuItem, attributeCategories);
+    }
+
+    private void replaceMenuIngredients(MenuItem menuItem, List<Ingredient> ingredients) {
+        List<MenuIngredient> currentMappings = menuIngredientRepository.findAllByMenuIdOrderByIngredientSortOrderAscIngredientIdAsc(
+                menuItem.getId());
+        menuIngredientRepository.deleteAll(currentMappings);
+        menuIngredientRepository.flush();
+
+        saveMenuIngredients(menuItem, ingredients);
+    }
+
+    private void saveMenuAttributeCategories(MenuItem menuItem, List<AttributeCategory> attributeCategories) {
+        menuAttributeCategoryRepository.saveAll(attributeCategories.stream()
+                .map(attributeCategory -> new MenuAttributeCategory(menuItem, attributeCategory))
+                .toList());
+    }
+
+    private void saveMenuIngredients(MenuItem menuItem, List<Ingredient> ingredients) {
+        menuIngredientRepository.saveAll(ingredients.stream()
+                .map(ingredient -> new MenuIngredient(menuItem, ingredient))
+                .toList());
     }
 }

--- a/src/main/java/matchuri/backend/domain/menu/service/MenuImageAdminServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/menu/service/MenuImageAdminServiceImpl.java
@@ -1,5 +1,6 @@
 package matchuri.backend.domain.menu.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import matchuri.backend.domain.image.entity.ImageAsset;
@@ -60,7 +61,9 @@ public class MenuImageAdminServiceImpl implements MenuImageAdminService {
                 menuItem.getName(),
                 menuItem.getDescription(),
                 menuItem.isActive(),
-                thumbnailUrl
+                thumbnailUrl,
+                List.of(),
+                List.of()
         );
     }
 

--- a/src/main/java/matchuri/backend/global/config/SecurityConfig.java
+++ b/src/main/java/matchuri/backend/global/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import matchuri.backend.global.security.RequiredAgreementAccessFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -38,6 +39,31 @@ public class SecurityConfig {
     private final RequiredAgreementAccessFilter requiredAgreementAccessFilter;
 
     @Bean
+    @Order(1)
+    public SecurityFilterChain adminSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher("/admin/**")
+                .csrf(Customizer.withDefaults())
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(formLogin -> formLogin
+                        .loginPage("/admin/login")
+                        .defaultSuccessUrl("/admin", true)
+                        .permitAll())
+                .logout(logout -> logout
+                        .logoutUrl("/admin/logout")
+                        .logoutSuccessUrl("/admin/login?logout")
+                        .permitAll())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/admin/login").permitAll()
+                        .anyRequest().hasRole("ADMIN")
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    @Order(2)
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         Auth authProps = matchuriProperties.getAuth();
 
@@ -60,7 +86,6 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.OPTIONS,
                                 authProps.getPublicOptionsApiPatterns().toArray(String[]::new)).permitAll()
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
-                        .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/matchuri/backend/global/security/AdminUserDetailsService.java
+++ b/src/main/java/matchuri/backend/global/security/AdminUserDetailsService.java
@@ -1,0 +1,41 @@
+package matchuri.backend.global.security;
+
+import lombok.RequiredArgsConstructor;
+import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.entity.MemberRole;
+import matchuri.backend.domain.member.entity.MemberStatus;
+import matchuri.backend.domain.member.repository.MemberRepository;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String username) {
+        Member member = memberRepository.findByLoginId(username)
+                .filter(this::isLoginPasswordAdmin)
+                .orElseThrow(() -> new UsernameNotFoundException("Admin member not found."));
+
+        return User.withUsername(member.getLoginId())
+                .password(member.getPasswordHash())
+                .roles(member.getMemberRole().name())
+                .build();
+    }
+
+    private boolean isLoginPasswordAdmin(Member member) {
+        return member.getMemberRole() == MemberRole.ADMIN
+                && member.getStatus() == MemberStatus.ACTIVE
+                && !member.isSocial()
+                && member.getPasswordHash() != null
+                && !member.getPasswordHash().isBlank();
+    }
+}

--- a/src/main/resources/templates/admin/attribute-categories.html
+++ b/src/main/resources/templates/admin/attribute-categories.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>카테고리 관리 - Matchuri Admin</title>
+    <style>
+        body { color: #1f2933; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; }
+        header { align-items: center; border-bottom: 1px solid #d9e2ec; display: flex; gap: 18px; justify-content: space-between; padding: 16px 24px; }
+        nav { display: flex; flex-wrap: wrap; gap: 10px; }
+        nav a { background: #eef2ff; border: 1px solid #c7d2fe; border-radius: 6px; color: #1e3a8a; font-weight: 700; padding: 8px 11px; text-decoration: none; }
+        main { margin: 24px auto; max-width: 1120px; padding: 0 20px; }
+        .message { background: #e0f2fe; border-radius: 6px; margin-bottom: 16px; padding: 12px; }
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border-bottom: 1px solid #d9e2ec; padding: 10px; text-align: left; vertical-align: top; }
+        th { background: #f5f7fa; color: #52606d; font-size: 13px; }
+        input, select { border: 1px solid #bcccdc; border-radius: 6px; box-sizing: border-box; padding: 8px; width: 100%; }
+        button { background: #2563eb; border: 0; border-radius: 6px; color: #ffffff; cursor: pointer; font-weight: 700; padding: 9px 12px; }
+        .danger { background: #b91c1c; }
+        .create { border: 1px solid #d9e2ec; border-radius: 8px; margin-bottom: 24px; padding: 16px; }
+        .create-grid { display: grid; gap: 10px; grid-template-columns: 1.2fr 1fr 1.4fr .7fr auto; }
+        .logout { background: transparent; color: #52606d; padding: 0; }
+    </style>
+</head>
+<body>
+<header>
+    <strong>Matchuri Admin</strong>
+    <nav>
+        <a th:href="@{/admin/menu-items}">Menus</a>
+        <a th:href="@{/admin/attribute-categories}">Categories</a>
+        <a th:href="@{/admin/ingredients}">Ingredients</a>
+    </nav>
+    <form th:action="@{/admin/logout}" method="post">
+        <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+        <button class="logout" type="submit">Logout</button>
+    </form>
+</header>
+<main>
+    <div class="message" th:if="${message}" th:text="${message}"></div>
+    <h1>속성 카테고리 관리</h1>
+    <form class="create" th:action="@{/admin/attribute-categories}" method="post">
+        <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+        <div class="create-grid">
+            <select name="categoryType" required>
+                <option th:each="categoryType : ${categoryTypes}" th:value="${categoryType}" th:text="${categoryType}">FLAVOR</option>
+            </select>
+            <input name="code" placeholder="Code" required>
+            <input name="name" placeholder="Name" required>
+            <input name="sortOrder" type="number" placeholder="Sort" required>
+            <button type="submit">생성</button>
+        </div>
+    </form>
+    <table>
+        <thead>
+        <tr>
+            <th>ID</th>
+            <th>Type</th>
+            <th>Code</th>
+            <th>Name</th>
+            <th>Sort</th>
+            <th>Status</th>
+            <th>Action</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="category : ${attributeCategories}">
+            <form th:action="@{'/admin/attribute-categories/' + ${category.id()}}" method="post">
+                <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                <td th:text="${category.id()}">1</td>
+                <td th:text="${category.categoryType()}">FLAVOR</td>
+                <td th:text="${category.code()}">SPICY</td>
+                <td><input name="name" th:value="${category.name()}" required></td>
+                <td><input name="sortOrder" type="number" th:value="${category.sortOrder()}" required></td>
+                <td>
+                    <select name="isActive">
+                        <option value="true" th:selected="${category.isActive()}">활성</option>
+                        <option value="false" th:selected="${!category.isActive()}">비활성</option>
+                    </select>
+                </td>
+                <td><button type="submit">저장</button></td>
+            </form>
+        </tr>
+        </tbody>
+    </table>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/admin/ingredients.html
+++ b/src/main/resources/templates/admin/ingredients.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>재료 관리 - Matchuri Admin</title>
+    <style>
+        body { color: #1f2933; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; }
+        header { align-items: center; border-bottom: 1px solid #d9e2ec; display: flex; gap: 18px; justify-content: space-between; padding: 16px 24px; }
+        nav { display: flex; flex-wrap: wrap; gap: 10px; }
+        nav a { background: #eef2ff; border: 1px solid #c7d2fe; border-radius: 6px; color: #1e3a8a; font-weight: 700; padding: 8px 11px; text-decoration: none; }
+        main { margin: 24px auto; max-width: 1120px; padding: 0 20px; }
+        .message { background: #e0f2fe; border-radius: 6px; margin-bottom: 16px; padding: 12px; }
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border-bottom: 1px solid #d9e2ec; padding: 10px; text-align: left; vertical-align: top; }
+        th { background: #f5f7fa; color: #52606d; font-size: 13px; }
+        input, select { border: 1px solid #bcccdc; border-radius: 6px; box-sizing: border-box; padding: 8px; width: 100%; }
+        button { background: #2563eb; border: 0; border-radius: 6px; color: #ffffff; cursor: pointer; font-weight: 700; padding: 9px 12px; }
+        .create { border: 1px solid #d9e2ec; border-radius: 8px; margin-bottom: 24px; padding: 16px; }
+        .create-grid { display: grid; gap: 10px; grid-template-columns: 1fr 1.4fr .8fr .7fr auto; }
+        .logout { background: transparent; color: #52606d; padding: 0; }
+    </style>
+</head>
+<body>
+<header>
+    <strong>Matchuri Admin</strong>
+    <nav>
+        <a th:href="@{/admin/menu-items}">Menus</a>
+        <a th:href="@{/admin/attribute-categories}">Categories</a>
+        <a th:href="@{/admin/ingredients}">Ingredients</a>
+    </nav>
+    <form th:action="@{/admin/logout}" method="post">
+        <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+        <button class="logout" type="submit">Logout</button>
+    </form>
+</header>
+<main>
+    <div class="message" th:if="${message}" th:text="${message}"></div>
+    <h1>재료 관리</h1>
+    <form class="create" th:action="@{/admin/ingredients}" method="post">
+        <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+        <div class="create-grid">
+            <input name="code" placeholder="Code" required>
+            <input name="name" placeholder="Name" required>
+            <select name="allergen">
+                <option value="false">일반</option>
+                <option value="true">알레르기</option>
+            </select>
+            <input name="sortOrder" type="number" placeholder="Sort" required>
+            <button type="submit">생성</button>
+        </div>
+    </form>
+    <table>
+        <thead>
+        <tr>
+            <th>ID</th>
+            <th>Code</th>
+            <th>Name</th>
+            <th>Allergen</th>
+            <th>Sort</th>
+            <th>Status</th>
+            <th>Action</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="ingredient : ${ingredients}">
+            <form th:action="@{'/admin/ingredients/' + ${ingredient.id()}}" method="post">
+                <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                <td th:text="${ingredient.id()}">1</td>
+                <td th:text="${ingredient.code()}">PEANUT</td>
+                <td><input name="name" th:value="${ingredient.name()}" required></td>
+                <td>
+                    <select name="allergen">
+                        <option value="false" th:selected="${!ingredient.allergen()}">일반</option>
+                        <option value="true" th:selected="${ingredient.allergen()}">알레르기</option>
+                    </select>
+                </td>
+                <td><input name="sortOrder" type="number" th:value="${ingredient.sortOrder()}" required></td>
+                <td>
+                    <select name="isActive">
+                        <option value="true" th:selected="${ingredient.isActive()}">활성</option>
+                        <option value="false" th:selected="${!ingredient.isActive()}">비활성</option>
+                    </select>
+                </td>
+                <td><button type="submit">저장</button></td>
+            </form>
+        </tr>
+        </tbody>
+    </table>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/admin/login.html
+++ b/src/main/resources/templates/admin/login.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Matchuri Admin Login</title>
+    <style>
+        body {
+            background: #f5f7fa;
+            color: #1f2933;
+            font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            margin: 0;
+        }
+
+        main {
+            margin: 80px auto;
+            max-width: 360px;
+            padding: 0 20px;
+        }
+
+        form {
+            background: #ffffff;
+            border: 1px solid #d9e2ec;
+            border-radius: 8px;
+            padding: 24px;
+        }
+
+        label {
+            color: #52606d;
+            display: block;
+            font-size: 13px;
+            font-weight: 700;
+            margin-top: 14px;
+        }
+
+        input {
+            border: 1px solid #bcccdc;
+            border-radius: 6px;
+            box-sizing: border-box;
+            font-size: 15px;
+            margin-top: 6px;
+            padding: 10px;
+            width: 100%;
+        }
+
+        button {
+            background: #2563eb;
+            border: 0;
+            border-radius: 6px;
+            color: #ffffff;
+            cursor: pointer;
+            font-weight: 700;
+            margin-top: 20px;
+            padding: 11px 14px;
+            width: 100%;
+        }
+
+        .message {
+            border-radius: 6px;
+            margin-bottom: 14px;
+            padding: 10px;
+        }
+
+        .error {
+            background: #fee2e2;
+            color: #991b1b;
+        }
+
+        .success {
+            background: #dcfce7;
+            color: #166534;
+        }
+    </style>
+</head>
+<body>
+<main>
+    <h1>Matchuri Admin</h1>
+    <div class="message error" th:if="${param.error}">로그인 정보를 확인해주세요.</div>
+    <div class="message success" th:if="${param.logout}">로그아웃되었습니다.</div>
+    <form th:action="@{/admin/login}" method="post">
+        <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+        <label for="username">Login ID</label>
+        <input id="username" name="username" autocomplete="username" required>
+        <label for="password">Password</label>
+        <input id="password" name="password" type="password" autocomplete="current-password" required>
+        <button type="submit">Login</button>
+    </form>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/admin/menu-item-detail.html
+++ b/src/main/resources/templates/admin/menu-item-detail.html
@@ -3,86 +3,124 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title th:text="${menuItem.name()} + ' - 메뉴 상세'">메뉴 상세</title>
+    <title th:text="${menuItem.name()} + ' - Matchuri Admin'">메뉴 상세</title>
     <style>
-        body {
-            color: #1f2933;
-            font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-            margin: 32px auto;
-            max-width: 760px;
-            padding: 0 20px;
-        }
-
-        .summary {
-            border: 1px solid #d9e2ec;
-            border-radius: 8px;
-            padding: 20px;
-        }
-
-        .field {
-            margin: 10px 0;
-        }
-
-        .label {
-            color: #52606d;
-            display: inline-block;
-            font-size: 14px;
-            width: 120px;
-        }
-
-        img {
-            border: 1px solid #d9e2ec;
-            border-radius: 8px;
-            display: block;
-            max-height: 360px;
-            max-width: 100%;
-            object-fit: contain;
-        }
-
-        form {
-            margin-top: 24px;
-        }
-
-        button {
-            background: #2563eb;
-            border: 0;
-            border-radius: 6px;
-            color: white;
-            cursor: pointer;
-            font-weight: 600;
-            margin-top: 12px;
-            padding: 10px 16px;
-        }
-
-        .message {
-            background: #e0f2fe;
-            border-radius: 6px;
-            margin-bottom: 16px;
-            padding: 12px;
-        }
+        body { color: #1f2933; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; }
+        header { align-items: center; border-bottom: 1px solid #d9e2ec; display: flex; gap: 18px; justify-content: space-between; padding: 16px 24px; }
+        nav { display: flex; flex-wrap: wrap; gap: 10px; }
+        nav a { background: #eef2ff; border: 1px solid #c7d2fe; border-radius: 6px; color: #1e3a8a; font-weight: 700; padding: 8px 11px; text-decoration: none; }
+        main { margin: 24px auto; max-width: 1080px; padding: 0 20px; }
+        section { border-top: 1px solid #d9e2ec; margin-top: 24px; padding-top: 20px; }
+        label { color: #52606d; display: block; font-size: 13px; font-weight: 700; margin-top: 12px; }
+        input[type="text"], textarea, select { border: 1px solid #bcccdc; border-radius: 6px; box-sizing: border-box; font-size: 15px; margin-top: 6px; padding: 10px; width: 100%; }
+        textarea { min-height: 92px; resize: vertical; }
+        img { border: 1px solid #d9e2ec; border-radius: 8px; display: block; max-height: 360px; max-width: 100%; object-fit: contain; }
+        fieldset { border: 1px solid #d9e2ec; border-radius: 8px; margin-top: 14px; padding: 14px; }
+        legend { color: #334e68; font-weight: 800; }
+        .grid { display: grid; gap: 8px 14px; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); }
+        .check { align-items: center; display: flex; gap: 7px; }
+        .message { background: #e0f2fe; border-radius: 6px; margin-bottom: 16px; padding: 12px; }
+        .row { display: grid; gap: 14px; grid-template-columns: 1fr 180px; }
+        button { background: #2563eb; border: 0; border-radius: 6px; color: #ffffff; cursor: pointer; font-weight: 700; margin-top: 14px; padding: 10px 14px; }
+        .danger { background: #b91c1c; }
+        .muted { color: #627d98; }
+        .logout { background: transparent; color: #52606d; margin-top: 0; padding: 0; }
     </style>
 </head>
 <body>
-<div class="message" th:if="${message}" th:text="${message}"></div>
+<header>
+    <strong>Matchuri Admin</strong>
+    <nav>
+        <a th:href="@{/admin/menu-items}">Menus</a>
+        <a th:href="@{/admin/attribute-categories}">Categories</a>
+        <a th:href="@{/admin/ingredients}">Ingredients</a>
+    </nav>
+    <form th:action="@{/admin/logout}" method="post">
+        <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+        <button class="logout" type="submit">Logout</button>
+    </form>
+</header>
+<main>
+    <div class="message" th:if="${message}" th:text="${message}"></div>
+    <p><a th:href="@{/admin/menu-items}">← 메뉴 목록</a></p>
+    <h1 th:text="${menuItem.name()}">메뉴명</h1>
+    <p class="muted" th:text="${menuItem.code()}">CODE</p>
 
-<h1 th:text="${menuItem.name()}">메뉴명</h1>
+    <section>
+        <h2>기본 정보</h2>
+        <form th:action="@{'/admin/menu-items/' + ${menuItem.id()}}" method="post">
+            <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+            <div class="row">
+                <div>
+                    <label for="name">Name</label>
+                    <input id="name" name="name" type="text" th:value="${menuItem.name()}" required>
+                </div>
+                <div>
+                    <label for="isActive">Status</label>
+                    <select id="isActive" name="isActive">
+                        <option value="true" th:selected="${menuItem.isActive()}">활성</option>
+                        <option value="false" th:selected="${!menuItem.isActive()}">비활성</option>
+                    </select>
+                </div>
+            </div>
+            <label for="description">Description</label>
+            <textarea id="description" name="description" th:text="${menuItem.description()}"></textarea>
+            <button type="submit">기본 정보 저장</button>
+        </form>
+        <form th:if="${menuItem.isActive()}" th:action="@{'/admin/menu-items/' + ${menuItem.id()}}" method="post">
+            <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+            <input type="hidden" name="name" th:value="${menuItem.name()}">
+            <input type="hidden" name="description" th:value="${menuItem.description()}">
+            <input type="hidden" name="isActive" value="false">
+            <button class="danger" type="submit">비활성화</button>
+        </form>
+    </section>
 
-<section class="summary">
-    <div class="field"><span class="label">ID</span><span th:text="${menuItem.id()}">1001</span></div>
-    <div class="field"><span class="label">Code</span><span th:text="${menuItem.code()}">PORK_CUTLET</span></div>
-    <div class="field"><span class="label">Description</span><span th:text="${menuItem.description()}">설명</span></div>
-    <div class="field"><span class="label">Active</span><span th:text="${menuItem.isActive()}">true</span></div>
-</section>
+    <section>
+        <h2>대표 이미지</h2>
+        <img th:if="${menuItem.thumbnailUrl()}" th:src="${menuItem.thumbnailUrl()}" alt="메뉴 이미지">
+        <p th:unless="${menuItem.thumbnailUrl()}">등록된 이미지가 없습니다.</p>
+        <form th:action="@{'/admin/menu-items/' + ${menuItem.id()} + '/images'}" method="post" enctype="multipart/form-data">
+            <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+            <label for="file">Image file</label>
+            <input id="file" type="file" name="file" accept="image/jpeg,image/png,image/webp" required>
+            <button type="submit">이미지 업로드</button>
+        </form>
+        <form th:if="${menuItem.thumbnailUrl()}" th:action="@{'/admin/menu-items/' + ${menuItem.id()} + '/images/primary/delete'}" method="post">
+            <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+            <button class="danger" type="submit">이미지 연결 제거</button>
+        </form>
+    </section>
 
-<h2>Image</h2>
-<img th:if="${menuItem.thumbnailUrl()}" th:src="${menuItem.thumbnailUrl()}" alt="메뉴 이미지">
-<p th:unless="${menuItem.thumbnailUrl()}">등록된 이미지가 없습니다.</p>
-
-<form th:action="@{'/admin/menu-items/' + ${menuItem.id()} + '/images'}" method="post"
-      enctype="multipart/form-data">
-    <input type="file" name="file" accept="image/jpeg,image/png,image/webp" required>
-    <br>
-    <button type="submit">Upload</button>
-</form>
+    <section>
+        <h2>추천 기준 연결</h2>
+        <form th:action="@{'/admin/menu-items/' + ${menuItem.id()} + '/references'}" method="post">
+            <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+            <fieldset>
+                <legend>Attribute categories</legend>
+                <div class="grid">
+                    <label class="check" th:each="category : ${attributeCategories}">
+                        <input type="checkbox" name="attributeCategoryIds" th:value="${category.id()}"
+                               th:checked="${#lists.contains(selectedAttributeCategoryIds, category.id())}"
+                               th:disabled="${!category.isActive() and !#lists.contains(selectedAttributeCategoryIds, category.id())}">
+                        <span th:text="${category.categoryType() + ' / ' + category.name()}">FLAVOR / 매운맛</span>
+                    </label>
+                </div>
+            </fieldset>
+            <fieldset>
+                <legend>Ingredients</legend>
+                <div class="grid">
+                    <label class="check" th:each="ingredient : ${ingredients}">
+                        <input type="checkbox" name="ingredientIds" th:value="${ingredient.id()}"
+                               th:checked="${#lists.contains(selectedIngredientIds, ingredient.id())}"
+                               th:disabled="${!ingredient.isActive() and !#lists.contains(selectedIngredientIds, ingredient.id())}">
+                        <span th:text="${ingredient.name()}">재료</span>
+                    </label>
+                </div>
+            </fieldset>
+            <button type="submit">연결 정보 저장</button>
+        </form>
+    </section>
+</main>
 </body>
 </html>

--- a/src/main/resources/templates/admin/menu-item-form.html
+++ b/src/main/resources/templates/admin/menu-item-form.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>새 메뉴 - Matchuri Admin</title>
+    <style>
+        body { color: #1f2933; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; }
+        header { align-items: center; border-bottom: 1px solid #d9e2ec; display: flex; gap: 18px; justify-content: space-between; padding: 16px 24px; }
+        nav { display: flex; flex-wrap: wrap; gap: 10px; }
+        nav a { background: #eef2ff; border: 1px solid #c7d2fe; border-radius: 6px; color: #1e3a8a; font-weight: 700; padding: 8px 11px; text-decoration: none; }
+        main { margin: 24px auto; max-width: 900px; padding: 0 20px; }
+        label { color: #52606d; display: block; font-size: 13px; font-weight: 700; margin-top: 14px; }
+        input[type="text"], textarea { border: 1px solid #bcccdc; border-radius: 6px; box-sizing: border-box; font-size: 15px; margin-top: 6px; padding: 10px; width: 100%; }
+        textarea { min-height: 92px; resize: vertical; }
+        fieldset { border: 1px solid #d9e2ec; border-radius: 8px; margin-top: 18px; padding: 14px; }
+        legend { color: #334e68; font-weight: 800; }
+        .grid { display: grid; gap: 8px 14px; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); }
+        .check { align-items: center; display: flex; gap: 7px; }
+        button { background: #2563eb; border: 0; border-radius: 6px; color: #ffffff; cursor: pointer; font-weight: 700; margin-top: 18px; padding: 10px 14px; }
+        .logout { background: transparent; color: #52606d; margin-top: 0; padding: 0; }
+    </style>
+</head>
+<body>
+<header>
+    <strong>Matchuri Admin</strong>
+    <nav>
+        <a th:href="@{/admin/menu-items}">Menus</a>
+        <a th:href="@{/admin/attribute-categories}">Categories</a>
+        <a th:href="@{/admin/ingredients}">Ingredients</a>
+    </nav>
+    <form th:action="@{/admin/logout}" method="post">
+        <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+        <button class="logout" type="submit">Logout</button>
+    </form>
+</header>
+<main>
+    <h1>새 메뉴</h1>
+    <form th:action="@{/admin/menu-items}" method="post">
+        <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+        <label for="code">Code</label>
+        <input id="code" name="code" type="text" required>
+        <label for="name">Name</label>
+        <input id="name" name="name" type="text" required>
+        <label for="description">Description</label>
+        <textarea id="description" name="description"></textarea>
+        <fieldset>
+            <legend>Attribute categories</legend>
+            <div class="grid">
+                <label class="check" th:each="category : ${attributeCategories}">
+                    <input type="checkbox" name="attributeCategoryIds" th:value="${category.id()}" th:disabled="${!category.isActive()}">
+                    <span th:text="${category.categoryType() + ' / ' + category.name()}">FLAVOR / 매운맛</span>
+                </label>
+            </div>
+        </fieldset>
+        <fieldset>
+            <legend>Ingredients</legend>
+            <div class="grid">
+                <label class="check" th:each="ingredient : ${ingredients}">
+                    <input type="checkbox" name="ingredientIds" th:value="${ingredient.id()}" th:disabled="${!ingredient.isActive()}">
+                    <span th:text="${ingredient.name()}">재료</span>
+                </label>
+            </div>
+        </fieldset>
+        <button type="submit">저장</button>
+    </form>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/admin/menu-items.html
+++ b/src/main/resources/templates/admin/menu-items.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>메뉴 관리 - Matchuri Admin</title>
+    <style>
+        body { color: #1f2933; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; }
+        header { align-items: center; border-bottom: 1px solid #d9e2ec; display: flex; gap: 18px; justify-content: space-between; padding: 16px 24px; }
+        nav { display: flex; flex-wrap: wrap; gap: 10px; }
+        nav a, .button { background: #eef2ff; border: 1px solid #c7d2fe; border-radius: 6px; color: #1e3a8a; font-weight: 700; padding: 8px 11px; text-decoration: none; }
+        main { margin: 24px auto; max-width: 1120px; padding: 0 20px; }
+        .message { background: #e0f2fe; border-radius: 6px; margin-bottom: 16px; padding: 12px; }
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border-bottom: 1px solid #d9e2ec; padding: 10px; text-align: left; vertical-align: top; }
+        th { background: #f5f7fa; color: #52606d; font-size: 13px; }
+        .inactive { color: #991b1b; font-weight: 700; }
+        .active { color: #166534; font-weight: 700; }
+        .actions { align-items: center; display: flex; gap: 8px; justify-content: space-between; margin-bottom: 14px; }
+        .logout { background: transparent; border: 0; color: #52606d; cursor: pointer; font-weight: 700; }
+    </style>
+</head>
+<body>
+<header>
+    <strong>Matchuri Admin</strong>
+    <nav>
+        <a th:href="@{/admin/menu-items}">Menus</a>
+        <a th:href="@{/admin/attribute-categories}">Categories</a>
+        <a th:href="@{/admin/ingredients}">Ingredients</a>
+    </nav>
+    <form th:action="@{/admin/logout}" method="post">
+        <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+        <button class="logout" type="submit">Logout</button>
+    </form>
+</header>
+<main>
+    <div class="message" th:if="${message}" th:text="${message}"></div>
+    <div class="actions">
+        <h1>메뉴 관리</h1>
+        <a class="button" th:href="@{/admin/menu-items/new}">새 메뉴</a>
+    </div>
+    <table>
+        <thead>
+        <tr>
+            <th>ID</th>
+            <th>Code</th>
+            <th>Name</th>
+            <th>Description</th>
+            <th>Status</th>
+            <th>Action</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="menuItem : ${menuItems}">
+            <td th:text="${menuItem.id()}">1</td>
+            <td th:text="${menuItem.code()}">CODE</td>
+            <td th:text="${menuItem.name()}">메뉴</td>
+            <td th:text="${menuItem.description()}">설명</td>
+            <td>
+                <span class="active" th:if="${menuItem.isActive()}">활성</span>
+                <span class="inactive" th:unless="${menuItem.isActive()}">비활성</span>
+            </td>
+            <td><a th:href="@{'/admin/menu-items/' + ${menuItem.id()}}">편집</a></td>
+        </tr>
+        </tbody>
+    </table>
+</main>
+</body>
+</html>

--- a/src/test/java/matchuri/backend/api/menu/AdminPageSecurityIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/menu/AdminPageSecurityIntegrationTest.java
@@ -1,0 +1,131 @@
+package matchuri.backend.api.menu;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.entity.MemberRole;
+import matchuri.backend.domain.member.entity.MemberStatus;
+import matchuri.backend.domain.member.repository.MemberRepository;
+import matchuri.backend.domain.menu.entity.AttributeCategory;
+import matchuri.backend.domain.menu.entity.CategoryType;
+import matchuri.backend.domain.menu.entity.Ingredient;
+import matchuri.backend.domain.menu.entity.MenuItem;
+import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
+import matchuri.backend.domain.menu.repository.IngredientRepository;
+import matchuri.backend.domain.menu.repository.MenuItemRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AdminPageSecurityIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private MenuItemRepository menuItemRepository;
+
+    @Autowired
+    private AttributeCategoryRepository attributeCategoryRepository;
+
+    @Autowired
+    private IngredientRepository ingredientRepository;
+
+    @BeforeEach
+    void setUp() {
+        menuItemRepository.deleteAll();
+        attributeCategoryRepository.deleteAll();
+        ingredientRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("미인증 사용자는 admin 화면 접근 시 로그인 화면으로 이동한다")
+    void adminPageRedirectsAnonymousUserToLogin() throws Exception {
+        mockMvc.perform(get("/admin"))
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrl("/admin/login"));
+    }
+
+    @Test
+    @DisplayName("DB에 저장된 활성 ADMIN 계정은 admin 화면에 로그인할 수 있다")
+    void adminCanLoginWithDbAccount() throws Exception {
+        createAdmin();
+
+        loginAsAdmin()
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrl("/admin"));
+    }
+
+    @Test
+    @DisplayName("ADMIN 세션은 주요 admin 화면을 렌더링할 수 있다")
+    void adminSessionCanRenderAdminPages() throws Exception {
+        createAdmin();
+        MenuItem menuItem = menuItemRepository.save(new MenuItem("BIBIMBAP", "비빔밥", "밥과 나물 메뉴"));
+        attributeCategoryRepository.save(new AttributeCategory(CategoryType.FOOD_CATEGORY, "KOREAN", "한식", 10));
+        ingredientRepository.save(new Ingredient("EGG", "달걀", true, 10));
+
+        MockHttpSession session = (MockHttpSession) loginAsAdmin()
+                .andReturn()
+                .getRequest()
+                .getSession(false);
+
+        mockMvc.perform(get("/admin/menu-items").session(session))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/admin/menu-items/new").session(session))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/admin/menu-items/{menuItemId}", menuItem.getId()).session(session))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/admin/attribute-categories").session(session))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/admin/ingredients").session(session))
+                .andExpect(status().isOk());
+    }
+
+    private void createAdmin() {
+        memberRepository.save(new Member(
+                "admin01",
+                passwordEncoder.encode("P@ssw0rd!"),
+                "admin@example.com",
+                false,
+                null,
+                null,
+                MemberRole.ADMIN,
+                MemberStatus.ACTIVE
+        ));
+    }
+
+    private org.springframework.test.web.servlet.ResultActions loginAsAdmin() throws Exception {
+        var loginPage = mockMvc.perform(get("/admin/login"))
+                .andExpect(status().isOk())
+                .andReturn();
+        CsrfToken csrfToken = (CsrfToken) loginPage.getRequest().getAttribute(CsrfToken.class.getName());
+        MockHttpSession session = (MockHttpSession) loginPage.getRequest().getSession(false);
+
+        return mockMvc.perform(post("/admin/login")
+                .session(session)
+                .param("username", "admin01")
+                .param("password", "P@ssw0rd!")
+                .param(csrfToken.getParameterName(), csrfToken.getToken()));
+    }
+}

--- a/src/test/java/matchuri/backend/api/menu/MenuAdminReferenceIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/menu/MenuAdminReferenceIntegrationTest.java
@@ -23,9 +23,13 @@ import matchuri.backend.domain.member.support.agreement.RequiredAgreementVersion
 import matchuri.backend.domain.menu.entity.AttributeCategory;
 import matchuri.backend.domain.menu.entity.CategoryType;
 import matchuri.backend.domain.menu.entity.Ingredient;
+import matchuri.backend.domain.menu.entity.MenuAttributeCategory;
+import matchuri.backend.domain.menu.entity.MenuIngredient;
 import matchuri.backend.domain.menu.entity.MenuItem;
 import matchuri.backend.domain.menu.repository.AttributeCategoryRepository;
 import matchuri.backend.domain.menu.repository.IngredientRepository;
+import matchuri.backend.domain.menu.repository.MenuAttributeCategoryRepository;
+import matchuri.backend.domain.menu.repository.MenuIngredientRepository;
 import matchuri.backend.domain.menu.repository.MenuItemRepository;
 import matchuri.backend.global.config.MatchuriProperties;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,6 +61,12 @@ class MenuAdminReferenceIntegrationTest {
     private MenuItemRepository menuItemRepository;
 
     @Autowired
+    private MenuAttributeCategoryRepository menuAttributeCategoryRepository;
+
+    @Autowired
+    private MenuIngredientRepository menuIngredientRepository;
+
+    @Autowired
     private MemberRepository memberRepository;
 
     @Autowired
@@ -64,6 +74,8 @@ class MenuAdminReferenceIntegrationTest {
 
     @BeforeEach
     void setUp() {
+        menuAttributeCategoryRepository.deleteAll();
+        menuIngredientRepository.deleteAll();
         menuItemRepository.deleteAll();
         attributeCategoryRepository.deleteAll();
         ingredientRepository.deleteAll();
@@ -181,6 +193,135 @@ class MenuAdminReferenceIntegrationTest {
                 .andExpect(jsonPath("$.data[1].id").value(sushi.getId()))
                 .andExpect(jsonPath("$.data[1].code").value("SUSHI"))
                 .andExpect(jsonPath("$.data[1].isActive").value(false));
+    }
+
+    @Test
+    @DisplayName("관리자는 메뉴를 생성하면서 attribute category와 ingredient를 연결할 수 있다")
+    void createAdminMenuItemWithReferences() throws Exception {
+        Member admin = memberRepository.save(new Member(
+                "admin-menu-create-user",
+                "hashed-password",
+                null,
+                false,
+                null,
+                null,
+                MemberRole.ADMIN,
+                MemberStatus.ACTIVE
+        ));
+        AttributeCategory spicy = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 10));
+        Ingredient kimchi = ingredientRepository.save(new Ingredient("KIMCHI", "김치", false, 10));
+
+        mockMvc.perform(post("/api/v1/admin/menu-items")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(admin)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "code": "KIMCHI_FRIED_RICE",
+                                  "name": "김치볶음밥",
+                                  "description": "김치와 밥을 볶은 한식 메뉴입니다.",
+                                  "attributeCategoryIds": [%d],
+                                  "ingredientIds": [%d]
+                                }
+                                """.formatted(spicy.getId(), kimchi.getId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.code").value("KIMCHI_FRIED_RICE"))
+                .andExpect(jsonPath("$.data.isActive").value(true))
+                .andExpect(jsonPath("$.data.attributeCategories.length()").value(1))
+                .andExpect(jsonPath("$.data.attributeCategories[0].id").value(spicy.getId()))
+                .andExpect(jsonPath("$.data.ingredients.length()").value(1))
+                .andExpect(jsonPath("$.data.ingredients[0].id").value(kimchi.getId()));
+
+        MenuItem menuItem = menuItemRepository.findByCode("KIMCHI_FRIED_RICE").orElseThrow();
+        assertThat(menuAttributeCategoryRepository.findAllByMenuIdOrderByAttributeCategoryCategoryTypeAscAttributeCategorySortOrderAscAttributeCategoryIdAsc(
+                menuItem.getId())).hasSize(1);
+        assertThat(menuIngredientRepository.findAllByMenuIdOrderByIngredientSortOrderAscIngredientIdAsc(
+                menuItem.getId())).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("관리자는 메뉴 상세에서 attribute category와 ingredient 연결을 조회할 수 있다")
+    void getAdminMenuItemReturnsReferences() throws Exception {
+        Member admin = memberRepository.save(new Member(
+                "admin-menu-detail-user",
+                "hashed-password",
+                null,
+                false,
+                null,
+                null,
+                MemberRole.ADMIN,
+                MemberStatus.ACTIVE
+        ));
+        MenuItem menuItem = menuItemRepository.save(new MenuItem("BIBIMBAP", "비빔밥", "밥과 나물을 비빈 메뉴"));
+        AttributeCategory korean = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.FOOD_CATEGORY, "KOREAN", "한식", 10));
+        Ingredient egg = ingredientRepository.save(new Ingredient("EGG", "달걀", true, 10));
+        menuAttributeCategoryRepository.save(new MenuAttributeCategory(menuItem, korean));
+        menuIngredientRepository.save(new MenuIngredient(menuItem, egg));
+
+        mockMvc.perform(get("/api/v1/admin/menu-items/{menuItemId}", menuItem.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(admin)))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(menuItem.getId()))
+                .andExpect(jsonPath("$.data.thumbnailUrl").value(nullValue()))
+                .andExpect(jsonPath("$.data.attributeCategories[0].code").value("KOREAN"))
+                .andExpect(jsonPath("$.data.ingredients[0].code").value("EGG"));
+    }
+
+    @Test
+    @DisplayName("관리자는 메뉴 attribute category와 ingredient 연결을 최신 입력 기준으로 전체 교체할 수 있다")
+    void updateAdminMenuItemReferencesReplacesMappings() throws Exception {
+        Member admin = memberRepository.save(new Member(
+                "admin-menu-reference-user",
+                "hashed-password",
+                null,
+                false,
+                null,
+                null,
+                MemberRole.ADMIN,
+                MemberStatus.ACTIVE
+        ));
+        MenuItem menuItem = menuItemRepository.save(new MenuItem("NOODLE", "국수", "면 메뉴"));
+        AttributeCategory oldCategory = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.FOOD_CATEGORY, "KOREAN", "한식", 10));
+        AttributeCategory newCategory = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.TEXTURE, "SOFT", "부드러운", 20));
+        Ingredient oldIngredient = ingredientRepository.save(new Ingredient("PORK", "돼지고기", false, 10));
+        Ingredient newIngredient = ingredientRepository.save(new Ingredient("BEEF", "소고기", false, 20));
+        menuAttributeCategoryRepository.save(new MenuAttributeCategory(menuItem, oldCategory));
+        menuIngredientRepository.save(new MenuIngredient(menuItem, oldIngredient));
+
+        mockMvc.perform(patch("/api/v1/admin/menu-items/{menuItemId}/references", menuItem.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(admin)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "attributeCategoryIds": [%d],
+                                  "ingredientIds": [%d]
+                                }
+                                """.formatted(newCategory.getId(), newIngredient.getId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.attributeCategories.length()").value(1))
+                .andExpect(jsonPath("$.data.attributeCategories[0].id").value(newCategory.getId()))
+                .andExpect(jsonPath("$.data.ingredients.length()").value(1))
+                .andExpect(jsonPath("$.data.ingredients[0].id").value(newIngredient.getId()));
+
+        assertThat(menuAttributeCategoryRepository.findAllByMenuIdOrderByAttributeCategoryCategoryTypeAscAttributeCategorySortOrderAscAttributeCategoryIdAsc(
+                menuItem.getId()))
+                .singleElement()
+                .extracting(mapping -> mapping.getAttributeCategory().getId())
+                .isEqualTo(newCategory.getId());
+        assertThat(menuIngredientRepository.findAllByMenuIdOrderByIngredientSortOrderAscIngredientIdAsc(
+                menuItem.getId()))
+                .singleElement()
+                .extracting(mapping -> mapping.getIngredient().getId())
+                .isEqualTo(newIngredient.getId());
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
Closes #300

## 📝 작업 내용
- 백엔드 내장 Admin 화면을 추가했습니다.
    - `/admin/login`
    - `/admin/menu-items`
    - `/admin/menu-items/new`
    - `/admin/menu-items/{menuItemId}`
    - `/admin/attribute-categories`
    - `/admin/ingredients`
- `/admin/**` 전용 세션 기반 Spring Security form login을 추가했습니다.
    - 기존 `/api/**` JWT/stateless 인증 흐름은 유지했습니다.
    - DB에 저장된 `ADMIN` + `ACTIVE` + local password 계정만 Admin 화면에 로그인할 수 있습니다.
- 관리자 메뉴 운영 API를 보강했습니다.
    - 관리자 메뉴 상세 조회
    - 관리자 메뉴 생성
    - 관리자 메뉴 attribute category / ingredient 연결 전체 교체
- 기존 메뉴 대표 이미지 업로드 화면을 메뉴 상세 Admin 화면에 통합했습니다.
- API/data/실행 계획 문서를 최신 구현 기준으로 갱신했습니다.

이 변경은 운영자가 DB 직접 수정 없이 메뉴, 카테고리, 재료, 메뉴 이미지, 추천 기준 매핑을 안전하게 관리하기 위해 필요합니다.

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
    - `/admin/**` 전용 세션 기반 SecurityFilterChain이 기존 `/api/**` JWT 인증 흐름에 영향을 주지 않는지
    - 메뉴 생성/연결 편집 API의 검증 기준이 적절한지
    - 메뉴-attribute category / ingredient 연결을 전체 교체 방식으로 처리한 것이 운영 흐름에 맞는지
    - Admin 화면에서 “삭제”가 아닌 “비활성화” 의미가 충분히 명확한지

- 알려진 제한 사항:
    - 소셜 로그인은 Admin에 붙이지 않았습니다.
    - 변경 이력/audit log, `createdBy`/`updatedBy`는 이번 범위에서 제외했습니다.
    - 운영 배포 시 `/admin/**`은 IP allowlist, Cloudflare Access, WAF/rate limit 같은 앞단 보호 적용을 권장합니다.
    - DB 구조 변경은 없으며 기존 `members`, `menu_items`, `menu_attribute_categories`, `menu_ingredients`, 이미지 관련 테이블을 재사용합니다.