### PR TITLE
[Refactor] 스케줄러 제거 및 만료 컨텐츠에 대한 필터링 적용

### DIFF
--- a/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/group/exception/GroupErrorCode.java
@@ -36,6 +36,7 @@ public enum GroupErrorCode implements ErrorCode {
     RECOMMENDATION_OPEN_EXISTS(HttpStatus.CONFLICT, "이미 열린 그룹 추천이 있습니다. groupId : {0}"),
     RECOMMENDATION_ACTIVE_EXISTS(HttpStatus.CONFLICT, "이미 진행 중인 그룹 추천이 있습니다. groupId : {0}"),
     RECOMMENDATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 그룹 추천을 찾을 수 없습니다. sessionId : {0}"),
+    RECOMMENDATION_EXPIRED(HttpStatus.CONFLICT, "만료된 그룹 추천입니다. sessionId : {0}"),
     RECOMMENDATION_NOT_OPEN(HttpStatus.CONFLICT, "열린 상태의 그룹 추천이 아닙니다. sessionId : {0}"),
     RECOMMENDATION_NOT_PREPARING(HttpStatus.CONFLICT, "준비 중인 그룹 추천이 아닙니다. sessionId : {0}"),
     RECOMMENDATION_REROLL_DISABLED(HttpStatus.GONE, "그룹 추천 재요청은 현재 MVP에서 지원하지 않습니다."),

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupInviteRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupInviteRepository.java
@@ -1,5 +1,6 @@
 package matchuri.backend.domain.group.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import matchuri.backend.domain.group.entity.GroupInvite;
 import matchuri.backend.domain.group.entity.GroupInviteStatus;
@@ -23,6 +24,7 @@ public interface GroupInviteRepository extends JpaRepository<GroupInvite, Long> 
                     join fetch invite.requestMember requestMember
                     where invite.targetMember.id = :targetMemberId
                       and (:status is null or invite.status = :status)
+                      and invite.expiresAt > :now
                     order by invite.createdAt desc, invite.id desc
                     """,
             countQuery = """
@@ -30,11 +32,13 @@ public interface GroupInviteRepository extends JpaRepository<GroupInvite, Long> 
                     from GroupInvite invite
                     where invite.targetMember.id = :targetMemberId
                       and (:status is null or invite.status = :status)
+                      and invite.expiresAt > :now
                     """
     )
     Page<GroupInvite> findMyInvites(
             @Param("targetMemberId") Long targetMemberId,
             @Param("status") GroupInviteStatus status,
+            @Param("now") LocalDateTime now,
             Pageable pageable
     );
 }

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationRepository.java
@@ -1,39 +1,46 @@
 package matchuri.backend.domain.group.repository;
 
-import java.util.Collection;
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.Collection;
 import java.util.Optional;
 import matchuri.backend.domain.group.entity.GroupRecommendation;
 import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface GroupRecommendationRepository extends JpaRepository<GroupRecommendation, Long> {
 
-    boolean existsByRoomIdAndStatus(Long roomId, GroupRecommendationStatus status);
-
-    boolean existsByRoomIdAndStatusIn(Long roomId, Collection<GroupRecommendationStatus> statuses);
+    boolean existsByRoomIdAndStatusInAndStartedAtAfter(
+            Long roomId,
+            Collection<GroupRecommendationStatus> statuses,
+            LocalDateTime startedAt
+    );
 
     Optional<GroupRecommendation> findByIdAndRoomId(Long id, Long roomId);
 
-    Optional<GroupRecommendation> findFirstByRoomIdAndStatusOrderByStartedAtDesc(
+    Optional<GroupRecommendation> findFirstByRoomIdAndStatusInAndStartedAtAfterOrderByStartedAtDescIdDesc(
             Long roomId,
-            GroupRecommendationStatus status
-    );
-
-    Optional<GroupRecommendation> findFirstByRoomIdAndStatusInOrderByStartedAtDescIdDesc(
-            Long roomId,
-            Collection<GroupRecommendationStatus> statuses
-    );
-
-    Optional<GroupRecommendation> findFirstByRoomIdOrderByStartedAtDescIdDesc(Long roomId);
-
-    Page<GroupRecommendation> findByRoomIdOrderByStartedAtDescIdDesc(Long roomId, Pageable pageable);
-
-    List<GroupRecommendation> findByStatusInAndEndedAtIsNullAndStartedAtLessThanEqual(
             Collection<GroupRecommendationStatus> statuses,
             LocalDateTime startedAt
+    );
+
+    @Query("""
+            select recommendation
+            from GroupRecommendation recommendation
+            where recommendation.room.id = :roomId
+              and (
+                    recommendation.status not in :activeStatuses
+                    or recommendation.startedAt > :activeThreshold
+              )
+            order by recommendation.startedAt desc, recommendation.id desc
+            """)
+    Page<GroupRecommendation> findVisibleByRoomIdOrderByStartedAtDescIdDesc(
+            @Param("roomId") Long roomId,
+            @Param("activeStatuses") Collection<GroupRecommendationStatus> activeStatuses,
+            @Param("activeThreshold") LocalDateTime activeThreshold,
+            Pageable pageable
     );
 }

--- a/src/main/java/matchuri/backend/domain/group/service/GroupRecommendationExpirationService.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupRecommendationExpirationService.java
@@ -2,18 +2,11 @@ package matchuri.backend.domain.group.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import matchuri.backend.domain.group.entity.GroupRecommendation;
 import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
-import matchuri.backend.domain.group.repository.GroupRecommendationRepository;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
-@RequiredArgsConstructor
 public class GroupRecommendationExpirationService {
 
     static final long EXPIRATION_HOURS = 24;
@@ -22,37 +15,13 @@ public class GroupRecommendationExpirationService {
             GroupRecommendationStatus.OPEN
     );
 
-    private final GroupRecommendationRepository groupRecommendationRepository;
-
-    @Scheduled(fixedRateString = "PT1H")
-    public void expireActiveGroupRecommendationsOnSchedule() {
-        int expiredCount = expireActiveGroupRecommendations();
-        if (expiredCount > 0) {
-            log.info("Expired {} active group recommendations", expiredCount);
-        }
-    }
-
-    @Transactional
-    public int expireActiveGroupRecommendations() {
-        LocalDateTime now = LocalDateTime.now();
-        List<GroupRecommendation> targets = groupRecommendationRepository
-                .findByStatusInAndEndedAtIsNullAndStartedAtLessThanEqual(
-                        EXPIRABLE_STATUSES,
-                        expirationThreshold(now)
-                );
-
-        targets.forEach(recommendation -> recommendation.expire(now));
-
-        return targets.size();
-    }
-
     public boolean isExpired(GroupRecommendation recommendation, LocalDateTime now) {
         return EXPIRABLE_STATUSES.contains(recommendation.getStatus())
                 && recommendation.getEndedAt() == null
                 && !recommendation.getStartedAt().plusHours(EXPIRATION_HOURS).isAfter(now);
     }
 
-    private LocalDateTime expirationThreshold(LocalDateTime now) {
+    public LocalDateTime activeThreshold(LocalDateTime now) {
         return now.minusHours(EXPIRATION_HOURS);
     }
 }

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -66,6 +66,10 @@ public class GroupServiceImpl implements GroupService {
     private static final int NICKNAME_INVITE_EXPIRATION_HOURS = 24;
     private static final int GROUP_RECOMMENDATION_CANDIDATE_LIMIT = 3;
     private static final long RECENT_GROUP_SKIPPED_MENU_EXCLUSION_HOURS = 24;
+    private static final List<GroupRecommendationStatus> ACTIVE_RECOMMENDATION_STATUSES = List.of(
+            GroupRecommendationStatus.PREPARING,
+            GroupRecommendationStatus.OPEN
+    );
 
     private final ActiveMemberReader activeMemberReader;
     private final MemberRepository memberRepository;
@@ -122,8 +126,6 @@ public class GroupServiceImpl implements GroupService {
             throw new BusinessException(GroupErrorCode.RECOMMENDATION_CREATE_FORBIDDEN, room.getId());
         }
 
-        groupRecommendationExpirationService.expireActiveGroupRecommendations();
-
         if (hasActiveRecommendation(room.getId())) {
             throw new BusinessException(GroupErrorCode.RECOMMENDATION_ACTIVE_EXISTS, room.getId());
         }
@@ -177,9 +179,7 @@ public class GroupServiceImpl implements GroupService {
         GroupRecommendation sourceRecommendation = groupRecommendationRepository.findByIdAndRoomId(sessionId, groupId)
                 .orElseThrow(() -> new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_FOUND, sessionId));
 
-        if (sourceRecommendation.getStatus() != GroupRecommendationStatus.OPEN) {
-            throw new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_OPEN, sessionId);
-        }
+        validateGroupRecommendationOpen(sourceRecommendation, sessionId);
 
         LocalDateTime endedAt = LocalDateTime.now();
 
@@ -213,9 +213,10 @@ public class GroupServiceImpl implements GroupService {
     }
 
     private boolean hasActiveRecommendation(Long roomId) {
-        return groupRecommendationRepository.existsByRoomIdAndStatusIn(
+        return groupRecommendationRepository.existsByRoomIdAndStatusInAndStartedAtAfter(
                 roomId,
-                List.of(GroupRecommendationStatus.PREPARING, GroupRecommendationStatus.OPEN)
+                ACTIVE_RECOMMENDATION_STATUSES,
+                groupRecommendationExpirationService.activeThreshold(LocalDateTime.now())
         );
     }
 
@@ -319,9 +320,7 @@ public class GroupServiceImpl implements GroupService {
         GroupRecommendation recommendation = groupRecommendationRepository.findByIdAndRoomId(sessionId, groupId)
                 .orElseThrow(() -> new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_FOUND, sessionId));
 
-        if (recommendation.getStatus() != GroupRecommendationStatus.OPEN) {
-            throw new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_OPEN, sessionId);
-        }
+        validateGroupRecommendationOpen(recommendation, sessionId);
 
         return new GroupRecommendationCandidateListResult(
                 recommendation.getId(),
@@ -337,7 +336,12 @@ public class GroupServiceImpl implements GroupService {
         validateActiveMembership(room.getId(), member.getId());
 
         return groupRecommendationRepository
-                .findByRoomIdOrderByStartedAtDescIdDesc(room.getId(), PageRequest.of(page, size))
+                .findVisibleByRoomIdOrderByStartedAtDescIdDesc(
+                        room.getId(),
+                        ACTIVE_RECOMMENDATION_STATUSES,
+                        groupRecommendationExpirationService.activeThreshold(LocalDateTime.now()),
+                        PageRequest.of(page, size)
+                )
                 .map(GroupRecommendationSummaryResult::from);
     }
 
@@ -387,9 +391,7 @@ public class GroupServiceImpl implements GroupService {
         GroupRecommendation recommendation = groupRecommendationRepository.findByIdAndRoomId(sessionId, room.getId())
                 .orElseThrow(() -> new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_FOUND, sessionId));
 
-        if (recommendation.getStatus() != GroupRecommendationStatus.PREPARING) {
-            throw new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_PREPARING, sessionId);
-        }
+        validateGroupRecommendationPreparing(recommendation, sessionId);
 
         groupRecommendationReadinessRepository
                 .findByGroupRecommendationIdAndMemberId(recommendation.getId(), member.getId())
@@ -486,9 +488,7 @@ public class GroupServiceImpl implements GroupService {
         GroupRecommendation recommendation = groupRecommendationRepository.findByIdAndRoomId(sessionId, groupId)
                 .orElseThrow(() -> new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_FOUND, sessionId));
 
-        if (recommendation.getStatus() != GroupRecommendationStatus.OPEN) {
-            throw new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_OPEN, sessionId);
-        }
+        validateGroupRecommendationOpen(recommendation, sessionId);
 
         GroupRecommendationCandidate candidate = groupRecommendationCandidateRepository
                 .findByIdAndGroupRecommendationId(candidateId, recommendation.getId())
@@ -547,9 +547,7 @@ public class GroupServiceImpl implements GroupService {
         GroupRecommendation recommendation = groupRecommendationRepository.findByIdAndRoomId(sessionId, groupId)
                 .orElseThrow(() -> new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_FOUND, sessionId));
 
-        if (recommendation.getStatus() != GroupRecommendationStatus.OPEN) {
-            throw new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_OPEN, sessionId);
-        }
+        validateGroupRecommendationOpen(recommendation, sessionId);
 
         List<GroupRecommendationCandidate> candidates = groupRecommendationCandidateRepository
                 .findAllByGroupRecommendationIdOrderByRankNoAsc(recommendation.getId());
@@ -807,6 +805,7 @@ public class GroupServiceImpl implements GroupService {
         return groupInviteRepository.findMyInvites(
                 member.getId(),
                 status,
+                LocalDateTime.now(),
                 PageRequest.of(command.page(), command.size())).map(this::toInviteSummaryResult);
     }
 
@@ -870,9 +869,10 @@ public class GroupServiceImpl implements GroupService {
                 .map(membership -> toMemberSummaryResult(membership, member.getId()))
                 .toList();
         GroupRecommendationResult activeRecommendation = groupRecommendationRepository
-                .findFirstByRoomIdAndStatusInOrderByStartedAtDescIdDesc(
+                .findFirstByRoomIdAndStatusInAndStartedAtAfterOrderByStartedAtDescIdDesc(
                         groupId,
-                        List.of(GroupRecommendationStatus.PREPARING, GroupRecommendationStatus.OPEN)
+                        ACTIVE_RECOMMENDATION_STATUSES,
+                        groupRecommendationExpirationService.activeThreshold(LocalDateTime.now())
                 )
                 .map(this::toGroupRecommendationResult)
                 .orElse(null);
@@ -895,6 +895,29 @@ public class GroupServiceImpl implements GroupService {
     private GroupRoomMember validateActiveMembership(Long groupId, Long memberId) {
         return groupRoomMemberRepository.findActiveMembershipInNotDeletedRoom(groupId, memberId)
                 .orElseThrow(() -> new BusinessException(GroupErrorCode.ACCESS_DENIED, groupId));
+    }
+
+    private void validateGroupRecommendationPreparing(GroupRecommendation recommendation, Long sessionId) {
+        validateGroupRecommendationNotExpired(recommendation, sessionId);
+
+        if (recommendation.getStatus() != GroupRecommendationStatus.PREPARING) {
+            throw new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_PREPARING, sessionId);
+        }
+    }
+
+    private void validateGroupRecommendationOpen(GroupRecommendation recommendation, Long sessionId) {
+        validateGroupRecommendationNotExpired(recommendation, sessionId);
+
+        if (recommendation.getStatus() != GroupRecommendationStatus.OPEN) {
+            throw new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_OPEN, sessionId);
+        }
+    }
+
+    private void validateGroupRecommendationNotExpired(GroupRecommendation recommendation, Long sessionId) {
+        if (recommendation.getStatus() == GroupRecommendationStatus.EXPIRED
+                || groupRecommendationExpirationService.isExpired(recommendation, LocalDateTime.now())) {
+            throw new BusinessException(GroupErrorCode.RECOMMENDATION_EXPIRED, sessionId);
+        }
     }
 
     private GroupRecommendationResult toGroupRecommendationResult(GroupRecommendation recommendation) {
@@ -1125,11 +1148,22 @@ public class GroupServiceImpl implements GroupService {
                 room.getName(),
                 room.getStatus(),
                 activeMemberCounts.getOrDefault(room.getId(), 0L).intValue(),
-                groupRecommendationRepository.findFirstByRoomIdOrderByStartedAtDescIdDesc(room.getId())
-                        .map(GroupRecommendation::getStatus)
-                        .orElse(null),
+                latestVisibleRecommendationStatus(room.getId()),
                 room.getCreatedAt()
         );
+    }
+
+    private GroupRecommendationStatus latestVisibleRecommendationStatus(Long roomId) {
+        return groupRecommendationRepository.findVisibleByRoomIdOrderByStartedAtDescIdDesc(
+                        roomId,
+                        ACTIVE_RECOMMENDATION_STATUSES,
+                        groupRecommendationExpirationService.activeThreshold(LocalDateTime.now()),
+                        PageRequest.of(0, 1)
+                )
+                .stream()
+                .findFirst()
+                .map(GroupRecommendation::getStatus)
+                .orElse(null);
     }
 
     private GroupInviteSummaryResult toInviteSummaryResult(GroupInvite invite) {

--- a/src/main/java/matchuri/backend/domain/recommendation/repository/PersonalRecommendationRepository.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/repository/PersonalRecommendationRepository.java
@@ -1,31 +1,44 @@
 package matchuri.backend.domain.recommendation.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import java.time.LocalDateTime;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 @NullMarked
 public interface PersonalRecommendationRepository extends JpaRepository<PersonalRecommendation, Long> {
     List<PersonalRecommendation> findByMemberId(Long memberId);
 
     List<PersonalRecommendation> findByMemberIdOrderByRequestedAtDescIdDesc(Long memberId);
-    Page<PersonalRecommendation> findByMemberIdOrderByRequestedAtDescIdDesc(Long memberId, Pageable pageable);
 
     Optional<PersonalRecommendation> findByIdAndMemberId(Long id, Long memberId);
-
-    List<PersonalRecommendation> findByStatusAndSelectedCandidateIsNullAndClosedAtIsNullAndRequestedAtLessThanEqual(
-            PersonalRecommendationStatus status,
-            LocalDateTime requestedAt
-    );
 
     Optional<PersonalRecommendation> findFirstByMemberIdAndStatusAndSelectedCandidateIsNullAndClosedAtIsNullOrderByRequestedAtDescIdDesc(
             long memberId,
             PersonalRecommendationStatus status
+    );
+
+    @Query("""
+            select recommendation
+            from PersonalRecommendation recommendation
+            where recommendation.member.id = :memberId
+              and (
+                    recommendation.status <> :openStatus
+                    or recommendation.requestedAt > :activeThreshold
+              )
+            order by recommendation.requestedAt desc, recommendation.id desc
+            """)
+    Page<PersonalRecommendation> findVisibleByMemberIdOrderByRequestedAtDescIdDesc(
+            @Param("memberId") long memberId,
+            @Param("openStatus") PersonalRecommendationStatus openStatus,
+            @Param("activeThreshold") LocalDateTime activeThreshold,
+            Pageable pageable
     );
 }

--- a/src/main/java/matchuri/backend/domain/recommendation/service/PersonalRecommendationExpirationService.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/PersonalRecommendationExpirationService.java
@@ -1,46 +1,14 @@
 package matchuri.backend.domain.recommendation.service;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
-import matchuri.backend.domain.recommendation.repository.PersonalRecommendationRepository;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
-@RequiredArgsConstructor
 public class PersonalRecommendationExpirationService {
 
     static final long EXPIRATION_HOURS = 24;
-
-    private final PersonalRecommendationRepository personalRecommendationRepository;
-
-    @Scheduled(fixedRateString = "PT1H")
-    public void expireOpenPersonalRecommendationsOnSchedule() {
-        int expiredCount = expireOpenPersonalRecommendations();
-        if (expiredCount > 0) {
-            log.info("Expired {} open personal recommendations", expiredCount);
-        }
-    }
-
-    @Transactional
-    public int expireOpenPersonalRecommendations() {
-        LocalDateTime now = LocalDateTime.now();
-        List<PersonalRecommendation> targets = personalRecommendationRepository
-                .findByStatusAndSelectedCandidateIsNullAndClosedAtIsNullAndRequestedAtLessThanEqual(
-                        PersonalRecommendationStatus.OPEN,
-                        expirationThreshold(now)
-                );
-
-        targets.forEach(recommendation -> recommendation.expire(now));
-
-        return targets.size();
-    }
 
     public boolean isExpired(PersonalRecommendation recommendation, LocalDateTime now) {
         return recommendation.getStatus() == PersonalRecommendationStatus.OPEN
@@ -48,7 +16,7 @@ public class PersonalRecommendationExpirationService {
                 && !recommendation.getRequestedAt().plusHours(EXPIRATION_HOURS).isAfter(now);
     }
 
-    private LocalDateTime expirationThreshold(LocalDateTime now) {
+    public LocalDateTime activeThreshold(LocalDateTime now) {
         return now.minusHours(EXPIRATION_HOURS);
     }
 }

--- a/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
@@ -110,7 +110,7 @@ public class RecommendationServiceImpl implements RecommendationService {
         PersonalRecommendation sourceRecommendation = getOwnedPersonalRecommendation(sourcePersonalRecommendationId,
                 member.getId());
 
-        validatePersonalRecommendationOpen(sourceRecommendation);
+        validatePersonalRecommendationOpen(sourceRecommendation, LocalDateTime.now());
 
         if (rerollType == PersonalRecommendationRerollType.NOT_SATISFIED) {
             List<PersonalRecommendationCandidate> candidates =
@@ -271,9 +271,15 @@ public class RecommendationServiceImpl implements RecommendationService {
     @Transactional(readOnly = true)
     public Page<@NonNull PersonalRecommendationSummaryResult> getMyPersonalRecommendations(int page, int size) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        LocalDateTime activeThreshold = personalRecommendationExpirationService.activeThreshold(LocalDateTime.now());
 
         return personalRecommendationRepository
-                .findByMemberIdOrderByRequestedAtDescIdDesc(member.getId(), PageRequest.of(page, size))
+                .findVisibleByMemberIdOrderByRequestedAtDescIdDesc(
+                        member.getId(),
+                        PersonalRecommendationStatus.OPEN,
+                        activeThreshold,
+                        PageRequest.of(page, size)
+                )
                 .map(PersonalRecommendationSummaryResult::from);
     }
 
@@ -287,7 +293,7 @@ public class RecommendationServiceImpl implements RecommendationService {
         PersonalRecommendation personalRecommendation = getOwnedPersonalRecommendation(personalRecommendationId,
                 member.getId());
 
-        validatePersonalRecommendationOpen(personalRecommendation);
+        validatePersonalRecommendationOpen(personalRecommendation, LocalDateTime.now());
 
         PersonalRecommendationCandidate selectedCandidate = personalRecommendationCandidateRepository
                 .findByIdAndPersonalRecommendationId(selectedCandidateId, personalRecommendationId)
@@ -321,16 +327,19 @@ public class RecommendationServiceImpl implements RecommendationService {
                 continue;
             }
 
-            if (!personalRecommendationExpirationService.isExpired(recommendation, now)) {
-                throw new BusinessException(RecommendationErrorCode.OPEN_EXISTS, recommendation.getId());
+            if (personalRecommendationExpirationService.isExpired(recommendation, now)) {
+                continue;
             }
 
-            recommendation.expire(now);
+            if (recommendation.getSelectedCandidate() == null && recommendation.getClosedAt() == null) {
+                throw new BusinessException(RecommendationErrorCode.OPEN_EXISTS, recommendation.getId());
+            }
         }
     }
 
-    private void validatePersonalRecommendationOpen(PersonalRecommendation recommendation) {
-        if (recommendation.getStatus() == PersonalRecommendationStatus.EXPIRED) {
+    private void validatePersonalRecommendationOpen(PersonalRecommendation recommendation, LocalDateTime now) {
+        if (recommendation.getStatus() == PersonalRecommendationStatus.EXPIRED
+                || personalRecommendationExpirationService.isExpired(recommendation, now)) {
             throw new BusinessException(RecommendationErrorCode.EXPIRED, recommendation.getId());
         }
 

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -41,7 +41,6 @@ import matchuri.backend.domain.group.repository.GroupRecommendationRepository;
 import matchuri.backend.domain.group.repository.GroupRecommendationVoteRepository;
 import matchuri.backend.domain.group.repository.GroupRoomMemberRepository;
 import matchuri.backend.domain.group.repository.GroupRoomRepository;
-import matchuri.backend.domain.group.service.GroupRecommendationExpirationService;
 import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.entity.MemberRole;
 import matchuri.backend.domain.member.entity.MemberStatus;
@@ -123,9 +122,6 @@ class GroupIntegrationTest {
 
     @Autowired
     private GroupRecommendationVoteRepository groupRecommendationVoteRepository;
-
-    @Autowired
-    private GroupRecommendationExpirationService groupRecommendationExpirationService;
 
     @Autowired
     private MenuItemRepository menuItemRepository;
@@ -386,8 +382,8 @@ class GroupIntegrationTest {
     }
 
     @Test
-    @DisplayName("그룹 추천 시작은 24시간 지난 진행 중 추천을 만료하고 새 준비 세션을 생성한다")
-    void createGroupRecommendationExpiresOldActiveRecommendationAndCreatesPreparingSession() throws Exception {
+    @DisplayName("그룹 추천 시작은 시간상 만료된 진행 중 추천을 무시하고 새 준비 세션을 생성한다")
+    void createGroupRecommendationIgnoresExpiredActiveRecommendationAndCreatesPreparingSession() throws Exception {
         Member owner = saveMember("expired-active-group-owner", "만료추천방장");
         GroupRoom groupRoom = saveGroupOwnedBy(owner, "만료 추천 그룹");
         GroupRecommendation oldRecommendation = groupRecommendationRepository.save(GroupRecommendation.preparing(
@@ -407,16 +403,16 @@ class GroupIntegrationTest {
                 .andExpect(jsonPath("$.data.sessionId").value(org.hamcrest.Matchers.not(oldRecommendation.getId().intValue())))
                 .andExpect(jsonPath("$.data.status").value(GroupRecommendationStatus.PREPARING.name()));
 
-        GroupRecommendation expiredRecommendation = groupRecommendationRepository.findById(oldRecommendation.getId())
+        GroupRecommendation existingRecommendation = groupRecommendationRepository.findById(oldRecommendation.getId())
                 .orElseThrow();
-        assertThat(expiredRecommendation.getStatus()).isEqualTo(GroupRecommendationStatus.EXPIRED);
-        assertThat(expiredRecommendation.getEndedAt()).isNotNull();
+        assertThat(existingRecommendation.getStatus()).isEqualTo(GroupRecommendationStatus.PREPARING);
+        assertThat(existingRecommendation.getEndedAt()).isNull();
         assertThat(groupRecommendationRepository.count()).isEqualTo(2);
     }
 
     @Test
-    @DisplayName("그룹 추천 만료 서비스는 24시간 지난 PREPARING/OPEN 추천만 종료한다")
-    void expirationServiceClosesActiveGroupRecommendationsAfter24Hours() {
+    @DisplayName("그룹 추천 목록은 시간상 만료된 PREPARING/OPEN 추천을 제외한다")
+    void getGroupRecommendationsExcludesExpiredActiveRecommendations() throws Exception {
         Member owner = saveMember("group-expiration-service-owner", "그룹만료방장");
         GroupRoom groupRoom = saveGroupOwnedBy(owner, "그룹 만료 서비스");
         GroupRecommendation oldPreparing = groupRecommendationRepository.save(GroupRecommendation.preparing(
@@ -442,17 +438,17 @@ class GroupIntegrationTest {
         alreadyClosed.rerollWithoutSkip(LocalDateTime.now().minusHours(1));
         groupRecommendationRepository.save(alreadyClosed);
 
-        int expiredCount = groupRecommendationExpirationService.expireActiveGroupRecommendations();
+        mockMvc.perform(get("/api/v1/groups/{groupId}/recommendations", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content.length()").value(2))
+                .andExpect(jsonPath("$.data.content[0].sessionId").value(recentPreparing.getId()))
+                .andExpect(jsonPath("$.data.content[1].sessionId").value(alreadyClosed.getId()));
 
-        assertThat(expiredCount).isEqualTo(2);
         assertThat(groupRecommendationRepository.findById(oldPreparing.getId()).orElseThrow().getStatus())
-                .isEqualTo(GroupRecommendationStatus.EXPIRED);
-        assertThat(groupRecommendationRepository.findById(oldOpen.getId()).orElseThrow().getStatus())
-                .isEqualTo(GroupRecommendationStatus.EXPIRED);
-        assertThat(groupRecommendationRepository.findById(recentPreparing.getId()).orElseThrow().getStatus())
                 .isEqualTo(GroupRecommendationStatus.PREPARING);
-        assertThat(groupRecommendationRepository.findById(alreadyClosed.getId()).orElseThrow().getStatus())
-                .isEqualTo(GroupRecommendationStatus.REROLLED_WITHOUT_SKIP);
+        assertThat(groupRecommendationRepository.findById(oldOpen.getId()).orElseThrow().getStatus())
+                .isEqualTo(GroupRecommendationStatus.OPEN);
     }
 
     @Test
@@ -1075,19 +1071,19 @@ class GroupIntegrationTest {
         GroupRecommendation oldRecommendation = groupRecommendationRepository.save(new GroupRecommendation(
                 groupRoom,
                 "{}",
-                LocalDateTime.of(2026, 5, 26, 12, 0)
+                LocalDateTime.now().minusMinutes(30)
         ));
-        oldRecommendation.rerollWithoutSkip(LocalDateTime.of(2026, 5, 26, 12, 15));
+        oldRecommendation.rerollWithoutSkip(LocalDateTime.now().minusMinutes(20));
         groupRecommendationRepository.save(oldRecommendation);
         GroupRecommendation latestRecommendation = groupRecommendationRepository.save(GroupRecommendation.preparing(
                 groupRoom,
                 "{}",
-                LocalDateTime.of(2026, 5, 26, 12, 30)
+                LocalDateTime.now().minusMinutes(10)
         ));
         groupRecommendationRepository.save(new GroupRecommendation(
                 otherGroupRoom,
                 "{}",
-                LocalDateTime.of(2026, 5, 26, 13, 0)
+                LocalDateTime.now()
         ));
 
         mockMvc.perform(get("/api/v1/groups/{groupId}/recommendations", groupRoom.getId())
@@ -1099,7 +1095,7 @@ class GroupIntegrationTest {
                 .andExpect(jsonPath("$.data.content.length()").value(2))
                 .andExpect(jsonPath("$.data.content[0].sessionId").value(latestRecommendation.getId()))
                 .andExpect(jsonPath("$.data.content[0].status").value(GroupRecommendationStatus.PREPARING.name()))
-                .andExpect(jsonPath("$.data.content[0].startedAt").value("2026-05-26T12:30:00"))
+                .andExpect(jsonPath("$.data.content[0].startedAt").isNotEmpty())
                 .andExpect(jsonPath("$.data.content[0].endedAt").value(nullValue()))
                 .andExpect(jsonPath("$.data.content[0].finalCandidate").doesNotExist())
                 .andExpect(jsonPath("$.data.content[0].finalMenuName").doesNotExist())
@@ -1107,7 +1103,7 @@ class GroupIntegrationTest {
                 .andExpect(jsonPath("$.data.content[1].sessionId").value(oldRecommendation.getId()))
                 .andExpect(jsonPath("$.data.content[1].status")
                         .value(GroupRecommendationStatus.REROLLED_WITHOUT_SKIP.name()))
-                .andExpect(jsonPath("$.data.content[1].endedAt").value("2026-05-26T12:15:00"))
+                .andExpect(jsonPath("$.data.content[1].endedAt").isNotEmpty())
                 .andExpect(jsonPath("$.data.pageInfo.totalElements").value(2))
                 .andExpect(jsonPath("$.data.pageInfo.totalPages").value(1));
     }
@@ -1733,13 +1729,13 @@ class GroupIntegrationTest {
         GroupRecommendation oldRecommendation = groupRecommendationRepository.save(new GroupRecommendation(
                 groupRoom,
                 "{}",
-                LocalDateTime.of(2026, 5, 26, 12, 0)
+                LocalDateTime.now().minusMinutes(30)
         ));
-        oldRecommendation.rerollWithoutSkip(LocalDateTime.of(2026, 5, 26, 12, 10));
+        oldRecommendation.rerollWithoutSkip(LocalDateTime.now().minusMinutes(20));
         groupRecommendationRepository.save(GroupRecommendation.preparing(
                 groupRoom,
                 "{}",
-                LocalDateTime.of(2026, 5, 26, 12, 30)
+                LocalDateTime.now().minusMinutes(10)
         ));
 
         mockMvc.perform(get("/api/v1/groups")

--- a/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
@@ -48,7 +48,6 @@ import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 import matchuri.backend.domain.recommendation.repository.PersonalRecommendationCandidateRepository;
 import matchuri.backend.domain.recommendation.repository.PersonalRecommendationRepository;
-import matchuri.backend.domain.recommendation.service.PersonalRecommendationExpirationService;
 import matchuri.backend.global.config.MatchuriProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -118,9 +117,6 @@ class PersonalRecommendationIntegrationTest {
 
     @Autowired
     private MemberMenuActionRepository memberMenuActionRepository;
-
-    @Autowired
-    private PersonalRecommendationExpirationService personalRecommendationExpirationService;
 
     @BeforeEach
     void setUp() {
@@ -317,8 +313,8 @@ class PersonalRecommendationIntegrationTest {
     }
 
     @Test
-    @DisplayName("개인 추천 생성은 만료 대상 열린 추천을 즉시 종료하고 새 추천을 생성한다")
-    void createPersonalRecommendationExpiresOldOpenRecommendationAndCreatesNewOne() throws Exception {
+    @DisplayName("개인 추천 생성은 시간상 만료된 열린 추천을 무시하고 새 추천을 생성한다")
+    void createPersonalRecommendationIgnoresExpiredOpenRecommendationAndCreatesNewOne() throws Exception {
         Member member = saveMember("expired-open-user", "만료추천");
         String accessToken = accessToken(member);
         AttributeCategory spicy = attributeCategoryRepository.save(
@@ -341,20 +337,20 @@ class PersonalRecommendationIntegrationTest {
         assertThat(secondRequestId).isNotEqualTo(firstRequestId);
         assertThat(personalRecommendationRepository.count()).isEqualTo(2);
 
-        PersonalRecommendation expiredRecommendation = personalRecommendationRepository.findById(firstRequestId)
+        PersonalRecommendation oldRecommendation = personalRecommendationRepository.findById(firstRequestId)
                 .orElseThrow();
         PersonalRecommendation newRecommendation = personalRecommendationRepository.findById(secondRequestId)
                 .orElseThrow();
-        assertThat(expiredRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.EXPIRED);
-        assertThat(expiredRecommendation.getClosedAt()).isNotNull();
+        assertThat(oldRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.OPEN);
+        assertThat(oldRecommendation.getClosedAt()).isNull();
         assertThat(newRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.OPEN);
         assertThat(newRecommendation.getClosedAt()).isNull();
     }
 
     @Test
-    @DisplayName("미선택 개인 추천 만료 서비스는 24시간 지난 열린 추천을 종료한다")
-    void expirationServiceClosesOpenRecommendationAfter24Hours() throws Exception {
-        Member member = saveMember("expiration-service-user", "만료서비스");
+    @DisplayName("개인 추천 목록은 시간상 만료된 열린 추천을 제외한다")
+    void getMyPersonalRecommendationsExcludesExpiredOpenRecommendation() throws Exception {
+        Member member = saveMember("expiration-list-user", "만료목록");
         String accessToken = accessToken(member);
         AttributeCategory spicy = attributeCategoryRepository.save(
                 new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 10));
@@ -366,18 +362,20 @@ class PersonalRecommendationIntegrationTest {
         long requestId = recommendation.path("requestId").asLong();
         expireRequestedAt(requestId);
 
-        int expiredCount = personalRecommendationExpirationService.expireOpenPersonalRecommendations();
+        mockMvc.perform(get("/api/v1/personal/recommendations")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content.length()").value(0));
 
-        PersonalRecommendation expiredRecommendation = personalRecommendationRepository.findById(requestId)
+        PersonalRecommendation oldRecommendation = personalRecommendationRepository.findById(requestId)
                 .orElseThrow();
-        assertThat(expiredCount).isEqualTo(1);
-        assertThat(expiredRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.EXPIRED);
-        assertThat(expiredRecommendation.getClosedAt()).isNotNull();
+        assertThat(oldRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.OPEN);
+        assertThat(oldRecommendation.getClosedAt()).isNull();
     }
 
     @Test
-    @DisplayName("24시간이 지났어도 scheduler가 닫기 전이면 개인 추천을 선택할 수 있다")
-    void selectPersonalRecommendationAllowsExpiredByTimeUntilSchedulerClosesIt() throws Exception {
+    @DisplayName("24시간이 지난 개인 추천은 선택할 수 없다")
+    void selectPersonalRecommendationRejectsExpiredByTimeRecommendation() throws Exception {
         Member member = saveMember("select-expired-user", "선택만료");
         String accessToken = accessToken(member);
         AttributeCategory spicy = attributeCategoryRepository.save(
@@ -399,19 +397,19 @@ class PersonalRecommendationIntegrationTest {
                                   "selectedCandidateId": %d
                                 }
                 """.formatted(candidateId)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.status").value(PersonalRecommendationStatus.SELECTED.name()));
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("PERSONAL_RECOMMENDATION_EXPIRED"));
 
-        PersonalRecommendation selectedRecommendation = personalRecommendationRepository.findById(requestId)
+        PersonalRecommendation oldRecommendation = personalRecommendationRepository.findById(requestId)
                 .orElseThrow();
-        assertThat(selectedRecommendation.getSelectedCandidate()).isNotNull();
-        assertThat(selectedRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.SELECTED);
-        assertThat(selectedRecommendation.getClosedAt()).isNotNull();
+        assertThat(oldRecommendation.getSelectedCandidate()).isNull();
+        assertThat(oldRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.OPEN);
+        assertThat(oldRecommendation.getClosedAt()).isNull();
     }
 
     @Test
-    @DisplayName("24시간이 지났어도 scheduler가 닫기 전이면 개인 추천을 재요청할 수 있다")
-    void rerollPersonalRecommendationAllowsExpiredByTimeUntilSchedulerClosesIt() throws Exception {
+    @DisplayName("24시간이 지난 개인 추천은 재요청할 수 없다")
+    void rerollPersonalRecommendationRejectsExpiredByTimeRecommendation() throws Exception {
         Member member = saveMember("reroll-expired-user", "재요청만료");
         String accessToken = accessToken(member);
         AttributeCategory spicy = attributeCategoryRepository.save(
@@ -433,72 +431,14 @@ class PersonalRecommendationIntegrationTest {
                                   "contextJson": {}
                                 }
                                 """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.requestId").isNumber());
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("PERSONAL_RECOMMENDATION_EXPIRED"));
 
-        PersonalRecommendation rerolledRecommendation = personalRecommendationRepository.findById(requestId)
+        PersonalRecommendation oldRecommendation = personalRecommendationRepository.findById(requestId)
                 .orElseThrow();
-        assertThat(rerolledRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.REROLLED_WITHOUT_SKIP);
-        assertThat(rerolledRecommendation.getClosedAt()).isNotNull();
-        assertThat(personalRecommendationRepository.count()).isEqualTo(2);
-    }
-
-    @Test
-    @DisplayName("scheduler가 만료 종료한 개인 추천은 선택할 수 없다")
-    void selectPersonalRecommendationRejectsSchedulerExpiredRecommendation() throws Exception {
-        Member member = saveMember("select-scheduler-expired-user", "스케줄러선택만료");
-        String accessToken = accessToken(member);
-        AttributeCategory spicy = attributeCategoryRepository.save(
-                new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 10));
-        MenuItem bibimbap = menuItemRepository.save(new MenuItem("BIBIMBAP", "비빔밥", "채소와 밥"));
-        saveMenuAttribute(bibimbap, spicy);
-        saveTasteProfile(member, spicy, null);
-
-        JsonNode recommendation = createRecommendation(accessToken);
-        long requestId = recommendation.path("requestId").asLong();
-        long candidateId = recommendation.path("candidates").get(0).path("id").asLong();
-        expireRequestedAt(requestId);
-        personalRecommendationExpirationService.expireOpenPersonalRecommendations();
-
-        mockMvc.perform(patch("/api/v1/personal/recommendations/{requestId}", requestId)
-                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "selectedCandidateId": %d
-                                }
-                                """.formatted(candidateId)))
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.error.code").value("PERSONAL_RECOMMENDATION_EXPIRED"));
-    }
-
-    @Test
-    @DisplayName("scheduler가 만료 종료한 개인 추천은 재요청할 수 없다")
-    void rerollPersonalRecommendationRejectsSchedulerExpiredRecommendation() throws Exception {
-        Member member = saveMember("reroll-scheduler-expired-user", "스케줄러재요청만료");
-        String accessToken = accessToken(member);
-        AttributeCategory spicy = attributeCategoryRepository.save(
-                new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 10));
-        MenuItem bibimbap = menuItemRepository.save(new MenuItem("BIBIMBAP", "비빔밥", "채소와 밥"));
-        saveMenuAttribute(bibimbap, spicy);
-        saveTasteProfile(member, spicy, null);
-
-        JsonNode recommendation = createRecommendation(accessToken);
-        long requestId = recommendation.path("requestId").asLong();
-        expireRequestedAt(requestId);
-        personalRecommendationExpirationService.expireOpenPersonalRecommendations();
-
-        mockMvc.perform(post("/api/v1/personal/recommendations/{requestId}/reroll", requestId)
-                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "rerollType": "INPUT_CHANGED",
-                                  "contextJson": {}
-                                }
-                                """))
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.error.code").value("PERSONAL_RECOMMENDATION_EXPIRED"));
+        assertThat(oldRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.OPEN);
+        assertThat(oldRecommendation.getClosedAt()).isNull();
+        assertThat(personalRecommendationRepository.count()).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
Closes #307

## 📝 작업 내용
- 개인/그룹 추천 만료 처리를 주기 스케줄러 기반 상태 전이에서 요청 시점 lazy expiration 판정으로 변경했습니다.
- 만료된 `OPEN`/`PREPARING` 추천은 새 추천 생성 충돌 대상, 목록 조회, 그룹 상세의 `activeRecommendation`에서 제외되도록 했습니다.
- 만료된 추천에 대한 선택/재요청/ready/투표/최종 확정 같은 상태 변경 API는 즉시 만료 오류로 거절하도록 정리했습니다.
- 관련 통합 테스트와 API/데이터 문서를 새 만료 정책에 맞게 갱신했습니다.
- 불필요한 주기 작업을 줄이고, 만료를 “DB 상태 변경 이벤트”가 아니라 “현재 시각 기준 도메인 판정”으로 단순화하기 위한 변경입니다.

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분: 만료된 추천을 물리적으로 `EXPIRED`로 전이하지 않고 조회/생성/상태 변경 경로에서 일관되게 제외 또는 거절하는 정책이 API 기대와 맞는지 봐주세요.
- 알려진 제한 사항: 기존에 DB에 남아 있는 만료된 `OPEN`/`PREPARING` 레코드는 상태값 자체가 자동으로 `EXPIRED`로 바뀌지 않습니다.