### PR TITLE
[Fix] 중복되는 이메일이 있을 경우 예외 발생

### DIFF
--- a/src/main/java/matchuri/backend/api/auth/EmailApi.java
+++ b/src/main/java/matchuri/backend/api/auth/EmailApi.java
@@ -26,7 +26,8 @@ public interface EmailApi {
                     회원가입, 로그인 ID 찾기, 비밀번호 재설정을 위한 이메일 인증 코드를 발송합니다.
                     
                     - 인증 코드 원문은 응답에 포함하지 않습니다.
-                    - 계정 존재 여부와 무관하게 같은 성공 응답을 반환합니다.
+                    - `SIGNUP` 목적에서 이미 사용 중인 자체 로그인 이메일이면 중복 이메일 오류를 반환합니다.
+                    - `FIND_LOGIN_ID`, `RESET_PASSWORD` 목적에서는 계정 존재 여부와 무관하게 같은 성공 응답을 반환합니다.
                     - `RESET_PASSWORD` 목적에서는 `loginId`가 필요합니다.
                     - 같은 대상에 이미 발급된 미완료 인증 코드는 새 발송 시 만료 처리됩니다.
                     """
@@ -76,6 +77,28 @@ public interface EmailApi {
                                                     "reason": "RESET_PASSWORD 목적에서는 loginId가 필요합니다."
                                                   }
                                                 ]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "회원가입 목적에서 이미 사용 중인 자체 로그인 이메일",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "duplicateEmail",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "data": null,
+                                              "error": {
+                                                "status": 409,
+                                                "code": "MEMBER_DUPLICATE_EMAIL",
+                                                "message": "이미 사용 중인 이메일입니다. email : tester@example.com",
+                                                "details": []
                                               }
                                             }
                                             """

--- a/src/main/java/matchuri/backend/api/auth/dto/response/SendEmailResponse.java
+++ b/src/main/java/matchuri/backend/api/auth/dto/response/SendEmailResponse.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "이메일 인증 코드 발송 접수 응답입니다.")
 public record SendEmailResponse(
-        @Schema(description = "발송 요청이 접수되었는지 여부입니다. 계정 존재 여부와 무관하게 true를 반환합니다.", example = "true")
+        @Schema(description = "발송 요청이 접수되었는지 여부입니다.", example = "true")
         boolean accepted,
 
         @Schema(description = "다음 재발송 요청을 권장하는 대기 시간(초)입니다.", example = "60")

--- a/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/auth/service/EmailVerificationServiceImpl.java
@@ -20,6 +20,7 @@ import matchuri.backend.domain.auth.support.verification.EmailVerificationTokenG
 import matchuri.backend.domain.auth.support.verification.VerificationCodeGenerator;
 import matchuri.backend.domain.auth.support.verification.VerificationCodeHasher;
 import matchuri.backend.domain.member.entity.MemberStatus;
+import matchuri.backend.domain.member.exception.MemberErrorCode;
 import matchuri.backend.domain.member.repository.MemberRepository;
 import matchuri.backend.global.exception.AuthenticationException;
 import matchuri.backend.global.exception.BusinessException;
@@ -50,6 +51,12 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
                 command.loginId(),
                 EmailVerificationStatus.PENDING
         );
+
+        if (isDuplicateSignupEmail(command)) {
+            expirePrevious(pendingVerifications);
+            log.info("Signup email verification rejected by duplicate email: email={}", maskEmail(command.email()));
+            throw new BusinessException(MemberErrorCode.DUPLICATE_EMAIL, command.email());
+        }
 
         if (!shouldSend(command)) {
             expirePrevious(pendingVerifications);
@@ -126,7 +133,7 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
 
     private boolean shouldSend(SendEmailVerificationCommand command) {
         if (command.purpose() == EmailVerificationPurpose.SIGNUP) {
-            return !memberRepository.existsByEmailAndSocialFalseAndStatus(command.email(), MemberStatus.ACTIVE);
+            return true;
         }
         if (command.purpose() == EmailVerificationPurpose.FIND_LOGIN_ID) {
             return memberRepository.existsByEmailAndSocialFalseAndStatus(command.email(), MemberStatus.ACTIVE);
@@ -139,6 +146,11 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
             );
         }
         return false;
+    }
+
+    private boolean isDuplicateSignupEmail(SendEmailVerificationCommand command) {
+        return command.purpose() == EmailVerificationPurpose.SIGNUP
+                && memberRepository.existsByEmailAndSocialFalseAndStatus(command.email(), MemberStatus.ACTIVE);
     }
 
     private Optional<EmailVerification> findLatestPending(ConfirmEmailVerificationCommand command) {

--- a/src/test/java/matchuri/backend/domain/auth/service/EmailVerificationServiceImplTest.java
+++ b/src/test/java/matchuri/backend/domain/auth/service/EmailVerificationServiceImplTest.java
@@ -22,6 +22,7 @@ import matchuri.backend.domain.auth.support.verification.EmailVerificationTokenG
 import matchuri.backend.domain.auth.support.verification.VerificationCodeGenerator;
 import matchuri.backend.domain.auth.support.verification.VerificationCodeHasher;
 import matchuri.backend.domain.member.entity.MemberStatus;
+import matchuri.backend.domain.member.exception.MemberErrorCode;
 import matchuri.backend.domain.member.repository.MemberRepository;
 import matchuri.backend.global.exception.AuthenticationException;
 import matchuri.backend.global.exception.BusinessException;
@@ -99,6 +100,40 @@ class EmailVerificationServiceImplTest {
                 EmailVerificationPurpose.SIGNUP,
                 "123456"
         );
+    }
+
+    @Test
+    @DisplayName("회원가입 인증 발송에서 이미 가입된 자체 로그인 이메일이면 중복 이메일 예외를 반환하고 메일을 보내지 않는다")
+    void sendSignupVerificationEmailRejectsDuplicateEmail() {
+        EmailVerification pendingVerification = EmailVerification.issue(
+                "tester@example.com",
+                null,
+                EmailVerificationPurpose.SIGNUP,
+                "hashed-code",
+                LocalDateTime.now().plusMinutes(5),
+                LocalDateTime.now()
+        );
+        when(repository.findAllByTargetAndStatus(
+                "tester@example.com",
+                EmailVerificationPurpose.SIGNUP,
+                null,
+                EmailVerificationStatus.PENDING
+        )).thenReturn(List.of(pendingVerification));
+        when(memberRepository.existsByEmailAndSocialFalseAndStatus("tester@example.com", MemberStatus.ACTIVE))
+                .thenReturn(true);
+
+        assertThatThrownBy(() -> service.sendVerificationEmail(new SendEmailVerificationCommand(
+                "tester@example.com",
+                EmailVerificationPurpose.SIGNUP,
+                null
+        )))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(MemberErrorCode.DUPLICATE_EMAIL);
+
+        assertThat(pendingVerification.getStatus()).isEqualTo(EmailVerificationStatus.EXPIRED);
+        verify(repository, never()).save(any());
+        verify(authMailSender, never()).sendVerificationEmail(any(), any(), any());
     }
 
     @Test

--- a/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/global/docs/OpenApiDocumentationIntegrationTest.java
@@ -114,6 +114,9 @@ class OpenApiDocumentationIntegrationTest {
                         "$.paths['/api/v1/auth/email'].post.responses['200'].content['application/json'].schema.$ref")
                         .value("#/components/schemas/SendEmailVerificationApiResponse"))
                 .andExpect(jsonPath(
+                        "$.paths['/api/v1/auth/email'].post.responses['409'].content['application/json'].examples.duplicateEmail.value.error.code")
+                        .value("MEMBER_DUPLICATE_EMAIL"))
+                .andExpect(jsonPath(
                         "$.paths['/api/v1/auth/email'].post.responses['502'].content['application/json'].examples.sendFailed.value.error.code")
                         .value("AUTH_EMAIL_SEND_FAILED"))
                 .andExpect(jsonPath("$.paths['/api/v1/auth/email/confirm'].post.summary")


### PR DESCRIPTION
## 관련 이슈
Closes #310

## 📝 작업 내용
- `SIGNUP` 목적의 이메일 인증 코드 발송 요청에서 이미 활성 자체 로그인 계정에 사용 중인 이메일이면 `MEMBER_DUPLICATE_EMAIL` 예외를 반환하도록 변경했습니다.
- 중복 이메일 감지 시 기존 미완료 인증 레코드는 만료 처리하고, 인증 메일은 발송하지 않도록 했습니다.
- 이메일 인증 발송 API Swagger 문서에 `409 MEMBER_DUPLICATE_EMAIL` 응답 예시를 추가했습니다.
- MVP 프로토타입 정책에 맞춰 회원가입 이메일 중복은 명시적으로 노출하도록 `docs/api`, `docs/design-docs`, `docs/SECURITY.md` 문서를 갱신했습니다.
- 기존에는 이미 가입된 이메일로 회원가입 인증을 요청해도 `200 accepted=true`가 반환되어 사용자가 인증 메일을 기다리는 흐름에 갇힐 수 있어, 회원가입 UX를 명확히 하기 위해 변경했습니다.

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
  - `SIGNUP` 목적에서만 이메일 중복을 명시적으로 반환하고, `FIND_LOGIN_ID`/`RESET_PASSWORD`의 계정 존재 여부 비노출 정책은 유지되는지 확인 부탁드립니다.
  - 중복 이메일 발생 시 기존 `PENDING` 인증 레코드를 만료 처리하는 흐름이 적절한지 확인 부탁드립니다.
- 알려진 제한 사항:
  - MVP 프로토타입 UX를 우선해 회원가입 이메일 중복 여부를 API 응답으로 노출합니다.
  - 별도 DB 스키마 변경이나 rate limit 강화는 포함하지 않았습니다.

검증:
- `.\gradlew.bat --no-daemon test --rerun-tasks`