### PR TITLE
[Fix] SSE ASYNC redispatch 인가 예외 처리

### DIFF
--- a/src/main/java/matchuri/backend/global/config/SecurityConfig.java
+++ b/src/main/java/matchuri/backend/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package matchuri.backend.global.config;
 
+import jakarta.servlet.DispatcherType;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.global.config.MatchuriProperties.Auth;
 import matchuri.backend.global.security.JwtAuthenticationFilter;
@@ -21,6 +22,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -78,6 +80,7 @@ public class SecurityConfig {
                         .authenticationEntryPoint(authenticationEntryPoint)
                         .accessDeniedHandler(accessDeniedHandler))
                 .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(realtimeAsyncRequestMatcher()).permitAll()
                         .requestMatchers(authProps.getPublicApiPatterns().toArray(String[]::new)).permitAll()
                         .requestMatchers(HttpMethod.GET, authProps.getPublicGetApiPatterns().toArray(String[]::new))
                         .permitAll()
@@ -103,6 +106,13 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    private RequestMatcher realtimeAsyncRequestMatcher() {
+        return request -> DispatcherType.ASYNC.equals(request.getDispatcherType())
+                && HttpMethod.GET.matches(request.getMethod())
+                && ("/api/v1/realtime/events".equals(request.getRequestURI())
+                || request.getRequestURI().matches("^/api/v1/groups/[^/]+/realtime/events$"));
     }
 
     @Bean


### PR DESCRIPTION
## 관련 이슈
Closes #313

## 📝 작업 내용
- SSE 연결 유지 중 발생하는 Spring Security `AuthorizationDeniedException` 로그를 방지하기 위해 `SecurityConfig`에 SSE 전용 ASYNC dispatcher 허용 규칙을 추가했습니다.
- 허용 범위는 전체 비동기 요청이 아니라 아래 SSE 엔드포인트의 `GET` + `DispatcherType.ASYNC`로 한정했습니다.
  - `/api/v1/realtime/events`
  - `/api/v1/groups/{groupId}/realtime/events`
- 최초 SSE 연결 요청은 기존처럼 JWT 인증, 필수 약관/닉네임 온보딩 필터, 그룹 멤버십 검사를 그대로 거칩니다.
- 이 변경은 `SseEmitter`가 연결 이후 heartbeat/event 전송 과정에서 async dispatch를 만들 때, 이미 검증된 SSE 요청이 `anyRequest().authenticated()`에 다시 걸려 예외 로그를 발생시키는 문제를 줄이기 위해 필요합니다.

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
  - `realtimeAsyncRequestMatcher()`가 SSE 엔드포인트에만 충분히 좁게 적용되어 있는지
  - 최초 SSE 연결 인증/인가 정책이 우회되지 않는지
- 알려진 제한 사항:
  - 운영 환경에서 SSE가 정상 동작하려면 Nginx 등 reverse proxy에서 SSE buffering/timeout 설정이 별도로 필요합니다.