### PR TITLE
[Fix] active 추천건이 아닌 가장 최근 종료건을 반환하도록 수정

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -133,15 +133,15 @@ public interface GroupApi {
     @Operation(
             summary = "그룹 상세 조회",
             description = """
-                    그룹 방 상세와 현재 멤버, 진행 중인 그룹 추천 상태를 조회합니다.
+                    그룹 방 상세와 현재 멤버, 가장 최근 그룹 추천 상태를 조회합니다.
 
                     - 로그인한 활성 회원만 사용할 수 있습니다.
                     - 현재 회원이 해당 그룹의 `ACTIVE` 멤버일 때만 조회할 수 있습니다.
                     - 그룹의 모든 `ACTIVE` 멤버에게 고정 초대 코드를 함께 반환합니다.
                     - 멤버 목록의 각 항목은 현재 로그인한 회원이면 `isMe=true`, 아니면 `false`를 반환합니다.
                     - 삭제된 그룹은 조회할 수 없습니다.
-                    - `PREPARING` 또는 `OPEN` 추천 세션이 있으면 `activeRecommendation`을 함께 반환합니다.
-                    - `PREPARING`이면 readiness 진행률을, `OPEN`이면 후보와 투표 진행률을 포함합니다.
+                    - 가장 최근 추천 세션이 있으면 `recentlyRecommendation`을 함께 반환합니다.
+                    - `PREPARING`이면 readiness 진행률을, `OPEN` 또는 종료 상태이면 후보와 투표 진행률을 포함합니다.
                     """
     )
     @ApiResponses({

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -248,9 +248,9 @@ public class GroupMapper {
                 result.members().stream()
                         .map(this::toGroupMemberSummaryResponse)
                         .toList(),
-                result.activeRecommendation() == null
+                result.recentlyRecommendation() == null
                         ? null
-                        : toGroupRecommendationSessionResponse(result.activeRecommendation())
+                        : toGroupRecommendationSessionResponse(result.recentlyRecommendation())
         );
     }
 

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -92,7 +92,7 @@ public final class GroupApiExamples {
                     "isMe": false
                   }
                 ],
-                "activeRecommendation": {
+                "recentlyRecommendation": {
                   "sessionId": 5001,
                   "status": "PREPARING",
                   "readiness": {
@@ -140,7 +140,7 @@ public final class GroupApiExamples {
                     "isMe": false
                   }
                 ],
-                "activeRecommendation": {
+                "recentlyRecommendation": {
                   "sessionId": 5001,
                   "status": "OPEN",
                   "readiness": null,

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupDetailResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupDetailResponse.java
@@ -33,8 +33,8 @@ public record GroupDetailResponse(
         @Schema(description = "현재 그룹 멤버 목록입니다.")
         List<GroupMemberSummaryResponse> members,
 
-        @Schema(description = "진행 중인 그룹 추천입니다. 없으면 null입니다.")
-        GroupRecommendationSessionResponse activeRecommendation
+        @Schema(description = "가장 최근 그룹 추천입니다. 없으면 null입니다.")
+        GroupRecommendationSessionResponse recentlyRecommendation
 ) {
     public static GroupDetailResponse mockActive() {
         return new GroupDetailResponse(

--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationRepository.java
@@ -21,11 +21,7 @@ public interface GroupRecommendationRepository extends JpaRepository<GroupRecomm
 
     Optional<GroupRecommendation> findByIdAndRoomId(Long id, Long roomId);
 
-    Optional<GroupRecommendation> findFirstByRoomIdAndStatusInAndStartedAtAfterOrderByStartedAtDescIdDesc(
-            Long roomId,
-            Collection<GroupRecommendationStatus> statuses,
-            LocalDateTime startedAt
-    );
+    Optional<GroupRecommendation> findFirstByRoomIdOrderByStartedAtDescIdDesc(Long roomId);
 
     @Query("""
             select recommendation

--- a/src/main/java/matchuri/backend/domain/group/result/GroupDetailResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupDetailResult.java
@@ -14,6 +14,6 @@ public record GroupDetailResult(
         String address,
         GroupRoomStatus status,
         List<GroupMemberSummaryResult> members,
-        GroupRecommendationResult activeRecommendation
+        GroupRecommendationResult recentlyRecommendation
 ) {
 }

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -868,12 +868,8 @@ public class GroupServiceImpl implements GroupService {
                 .stream()
                 .map(membership -> toMemberSummaryResult(membership, member.getId()))
                 .toList();
-        GroupRecommendationResult activeRecommendation = groupRecommendationRepository
-                .findFirstByRoomIdAndStatusInAndStartedAtAfterOrderByStartedAtDescIdDesc(
-                        groupId,
-                        ACTIVE_RECOMMENDATION_STATUSES,
-                        groupRecommendationExpirationService.activeThreshold(LocalDateTime.now())
-                )
+        GroupRecommendationResult recentlyRecommendation = groupRecommendationRepository
+                .findFirstByRoomIdOrderByStartedAtDescIdDesc(groupId)
                 .map(this::toGroupRecommendationResult)
                 .orElse(null);
         GroupLocation location = latestGroupLocation(room.getId());
@@ -888,7 +884,7 @@ public class GroupServiceImpl implements GroupService {
                 location == null ? null : location.getAddress(),
                 room.getStatus(),
                 members,
-                activeRecommendation
+                recentlyRecommendation
         );
     }
 

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -1665,8 +1665,8 @@ class GroupIntegrationTest {
     }
 
     @Test
-    @DisplayName("그룹 상세 조회는 열린 그룹 추천이 있으면 activeRecommendation을 반환한다")
-    void getGroupReturnsActiveRecommendation() throws Exception {
+    @DisplayName("그룹 상세 조회는 열린 그룹 추천이 있으면 recentlyRecommendation을 반환한다")
+    void getGroupReturnsRecentlyOpenRecommendation() throws Exception {
         Member owner = saveMember("group-active-recommendation-owner", "활성추천방장");
         GroupRoom groupRoom = saveGroupOwnedBy(owner, "활성 추천 그룹");
         MenuItem menuItem = saveMenu("active-rec-menu", "활성추천메뉴");
@@ -1682,17 +1682,17 @@ class GroupIntegrationTest {
         mockMvc.perform(get("/api/v1/groups/{groupId}", groupRoom.getId())
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.activeRecommendation.sessionId").value(recommendation.getId()))
-                .andExpect(jsonPath("$.data.activeRecommendation.status").value(GroupRecommendationStatus.OPEN.name()))
-                .andExpect(jsonPath("$.data.activeRecommendation.readiness").value(nullValue()))
-                .andExpect(jsonPath("$.data.activeRecommendation.candidates[0].candidateId").value(candidate.getId()))
-                .andExpect(jsonPath("$.data.activeRecommendation.voteProgress.totalMemberCount").value(1))
-                .andExpect(jsonPath("$.data.activeRecommendation.voteProgress.votedMemberCount").value(0));
+                .andExpect(jsonPath("$.data.recentlyRecommendation.sessionId").value(recommendation.getId()))
+                .andExpect(jsonPath("$.data.recentlyRecommendation.status").value(GroupRecommendationStatus.OPEN.name()))
+                .andExpect(jsonPath("$.data.recentlyRecommendation.readiness").value(nullValue()))
+                .andExpect(jsonPath("$.data.recentlyRecommendation.candidates[0].candidateId").value(candidate.getId()))
+                .andExpect(jsonPath("$.data.recentlyRecommendation.voteProgress.totalMemberCount").value(1))
+                .andExpect(jsonPath("$.data.recentlyRecommendation.voteProgress.votedMemberCount").value(0));
     }
 
     @Test
-    @DisplayName("그룹 상세 조회는 준비 중인 그룹 추천도 activeRecommendation으로 반환한다")
-    void getGroupReturnsPreparingActiveRecommendation() throws Exception {
+    @DisplayName("그룹 상세 조회는 준비 중인 그룹 추천도 recentlyRecommendation으로 반환한다")
+    void getGroupReturnsPreparingRecentlyRecommendation() throws Exception {
         Member owner = saveMember("group-preparing-recommendation-owner", "준비추천방장");
         Member member = saveMember("group-preparing-recommendation-member", "준비추천멤버");
         GroupRoom groupRoom = saveGroupOwnedBy(owner, "준비 추천 그룹");
@@ -1712,13 +1712,63 @@ class GroupIntegrationTest {
         mockMvc.perform(get("/api/v1/groups/{groupId}", groupRoom.getId())
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.activeRecommendation.sessionId").value(recommendation.getId()))
-                .andExpect(jsonPath("$.data.activeRecommendation.status")
+                .andExpect(jsonPath("$.data.recentlyRecommendation.sessionId").value(recommendation.getId()))
+                .andExpect(jsonPath("$.data.recentlyRecommendation.status")
                         .value(GroupRecommendationStatus.PREPARING.name()))
-                .andExpect(jsonPath("$.data.activeRecommendation.readiness.totalMemberCount").value(2))
-                .andExpect(jsonPath("$.data.activeRecommendation.readiness.readyMemberCount").value(1))
-                .andExpect(jsonPath("$.data.activeRecommendation.candidates.length()").value(0))
-                .andExpect(jsonPath("$.data.activeRecommendation.voteProgress").value(nullValue()));
+                .andExpect(jsonPath("$.data.recentlyRecommendation.readiness.totalMemberCount").value(2))
+                .andExpect(jsonPath("$.data.recentlyRecommendation.readiness.readyMemberCount").value(1))
+                .andExpect(jsonPath("$.data.recentlyRecommendation.candidates.length()").value(0))
+                .andExpect(jsonPath("$.data.recentlyRecommendation.voteProgress").value(nullValue()));
+    }
+
+    @Test
+    @DisplayName("그룹 상세 조회는 종료된 최신 그룹 추천 결과도 recentlyRecommendation으로 반환한다")
+    void getGroupReturnsFinalizedRecentlyRecommendation() throws Exception {
+        Member owner = saveMember("group-finalized-recent-owner", "확정최근방장");
+        Member member = saveMember("group-finalized-recent-member", "확정최근멤버");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "확정 최근 그룹");
+        groupRoomMemberRepository.save(new GroupRoomMember(
+                groupRoom,
+                member,
+                GroupMemberRole.MEMBER,
+                LocalDateTime.now()
+        ));
+        MenuItem chicken = saveMenu("recent-final-chicken", "치킨");
+        MenuItem gimbap = saveMenu("recent-final-gimbap", "김밥");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now().minusMinutes(10)
+        ));
+        GroupRecommendationCandidate firstCandidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, chicken, 1, 80.0, "{}")
+        );
+        GroupRecommendationCandidate secondCandidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(recommendation, gimbap, 2, 70.0, "{}")
+        );
+        groupRecommendationVoteRepository.save(new GroupRecommendationVote(recommendation, firstCandidate, owner));
+        groupRecommendationVoteRepository.save(new GroupRecommendationVote(recommendation, firstCandidate, member));
+        recommendation.finalizeWith(firstCandidate, LocalDateTime.now().minusMinutes(5));
+        groupRecommendationRepository.save(recommendation);
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.recentlyRecommendation.sessionId").value(recommendation.getId()))
+                .andExpect(jsonPath("$.data.recentlyRecommendation.status")
+                        .value(GroupRecommendationStatus.FINALIZED.name()))
+                .andExpect(jsonPath("$.data.recentlyRecommendation.readiness").value(nullValue()))
+                .andExpect(jsonPath("$.data.recentlyRecommendation.candidates.length()").value(2))
+                .andExpect(jsonPath("$.data.recentlyRecommendation.candidates[0].candidateId")
+                        .value(firstCandidate.getId()))
+                .andExpect(jsonPath("$.data.recentlyRecommendation.candidates[0].voteCount").value(2))
+                .andExpect(jsonPath("$.data.recentlyRecommendation.candidates[1].candidateId")
+                        .value(secondCandidate.getId()))
+                .andExpect(jsonPath("$.data.recentlyRecommendation.voteProgress.totalMemberCount").value(2))
+                .andExpect(jsonPath("$.data.recentlyRecommendation.voteProgress.votedMemberCount").value(2))
+                .andExpect(jsonPath("$.data.recentlyRecommendation.finalCandidate.candidateId")
+                        .value(firstCandidate.getId()))
+                .andExpect(jsonPath("$.data.recentlyRecommendation.finalCandidate.menuName").value("치킨"));
     }
 
     @Test
@@ -1844,7 +1894,7 @@ class GroupIntegrationTest {
                 .andExpect(jsonPath("$.data.members[1].memberId").value(activeMember.getId()))
                 .andExpect(jsonPath("$.data.members[1].nickname").value("상세멤버"))
                 .andExpect(jsonPath("$.data.members[1].isMe").value(false))
-                .andExpect(jsonPath("$.data.activeRecommendation").value(nullValue()));
+                .andExpect(jsonPath("$.data.recentlyRecommendation").value(nullValue()));
 
         mockMvc.perform(get("/api/v1/groups/{groupId}", groupRoom.getId())
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(activeMember))))
@@ -1853,7 +1903,7 @@ class GroupIntegrationTest {
                 .andExpect(jsonPath("$.data.members[0].isMe").value(false))
                 .andExpect(jsonPath("$.data.members[1].memberId").value(activeMember.getId()))
                 .andExpect(jsonPath("$.data.members[1].isMe").value(true))
-                .andExpect(jsonPath("$.data.activeRecommendation").value(nullValue()));
+                .andExpect(jsonPath("$.data.recentlyRecommendation").value(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
Closes #315

## 📝 작업 내용
- 그룹 상세 조회 응답의 추천 필드를 `activeRecommendation`에서 `recentlyRecommendation`으로 변경했습니다.
- 기존에는 진행 중인 `PREPARING`/`OPEN` 추천만 그룹 상세에서 확인할 수 있었지만, 이제 상태와 무관하게 가장 최근 그룹 추천 1건을 반환합니다.
- 종료된 투표 결과(`FINALIZED`)도 후보, 투표 진행률, 최종 후보 정보를 그룹 상세에서 확인할 수 있도록 통합 테스트와 API 문서를 갱신했습니다.

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분: `recentlyRecommendation` 네이밍 및 그룹 상세에서 종료된 최신 추천까지 반환하는 API 계약이 프론트 연동 의도와 맞는지 확인 부탁드립니다.
- 알려진 제한 사항: 기존 `activeRecommendation` 필드는 제거되어 클라이언트에서 `recentlyRecommendation`으로 참조 변경이 필요합니다.


```json
{
    "success": true,
    "data": {
        "id": 4,
        "name": "테테테테스트트트",
        "inviteCode": "4RGWXBML",
        "latitude": 37.4960663,
        "longitude": 127.0315503,
        "radiusMeters": 1000,
        "address": "서울특별시 강남구 테헤란로6길 39",
        "status": "ACTIVE",
        "members": [
            {
                "memberId": 6,
                "nickname": "어진잉테스",
                "role": "OWNER",
                "status": "ACTIVE",
                "joinedAt": "2026-06-26T08:32:35.496552",
                "isMe": true
            }
        ],
        "recentlyRecommendation": {
            "sessionId": 1,
            "status": "FINALIZED",
            "readiness": null,
            "candidates": [
                {
                    "candidateId": 1,
                    "menuId": 33,
                    "menuName": "반미",
                    "thumbnailUrl": null,
                    "rankNo": 1,
                    "score": 60.0,
                    "voteCount": 1
                },
                {
                    "candidateId": 2,
                    "menuId": 40,
                    "menuName": "타코",
                    "thumbnailUrl": null,
                    "rankNo": 2,
                    "score": 60.0,
                    "voteCount": 0
                },
                {
                    "candidateId": 3,
                    "menuId": 14,
                    "menuName": "냉면",
                    "thumbnailUrl": null,
                    "rankNo": 3,
                    "score": 40.0,
                    "voteCount": 0
                }
            ],
            "voteProgress": {
                "totalMemberCount": 1,
                "votedMemberCount": 1
            },
            "finalCandidate": {
                "candidateId": 1,
                "menuId": 33,
                "menuName": "반미",
                "thumbnailUrl": null,
                "rankNo": 1,
                "score": 60.0,
                "voteCount": 1
            },
            "createdAt": "2026-06-26T08:32:39.113896"
        }
    },
    "error": null
}

```