### PR TITLE
[Fix] 추천 상세보기 응답에 contextJson 추가

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -468,12 +468,13 @@ public interface GroupApi {
     @Operation(
             summary = "그룹 추천 세션 상세 조회",
             description = """
-                    그룹 추천 상태, 준비 진행률, 후보, 투표 진행률, 최종 후보를 조회합니다.
+                    그룹 추천 상태, 추천 당시 컨텍스트 JSON, 준비 진행률, 후보, 투표 진행률, 최종 후보를 조회합니다.
 
                     구현 기준:
                     - 로그인한 활성 회원만 사용할 수 있습니다.
                     - 현재 회원이 해당 그룹의 `ACTIVE` 멤버일 때만 조회할 수 있습니다.
                     - `sessionId`는 API 표현 이름이며 저장 모델은 `group_recommendations.id`로 해석합니다.
+                    - `contextJson`은 추천 당시 위치 등 컨텍스트 스냅샷이며, 파싱하지 않은 JSON 문자열로 반환합니다.
                     - `PREPARING` 세션이면 후보는 빈 배열, 투표 진행률은 null, readiness 진행률은 값으로 반환합니다.
                     - `OPEN` 세션이면 후보별 현재 투표 수와 전체 투표 진행률을 함께 반환하고 readiness는 null입니다.
                     """

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -260,6 +260,7 @@ public class GroupMapper {
         return new GroupRecommendationSessionResponse(
                 result.sessionId(),
                 result.status(),
+                result.contextJson(),
                 result.readiness() == null
                         ? null
                         : toGroupRecommendationReadinessProgressResponse(result.readiness()),

--- a/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
+++ b/src/main/java/matchuri/backend/api/group/dto/docs/GroupApiExamples.java
@@ -95,6 +95,7 @@ public final class GroupApiExamples {
                 "recentlyRecommendation": {
                   "sessionId": 5001,
                   "status": "PREPARING",
+                  "contextJson": null,
                   "readiness": {
                     "totalMemberCount": 4,
                     "readyMemberCount": 2,
@@ -143,6 +144,7 @@ public final class GroupApiExamples {
                 "recentlyRecommendation": {
                   "sessionId": 5001,
                   "status": "OPEN",
+                  "contextJson": "{\\\"latitude\\\":37.498095,\\\"longitude\\\":127.027610,\\\"radiusMeters\\\":1000,\\\"address\\\":\\\"서울 강남구 테헤란로 123\\\"}",
                   "readiness": null,
                   "candidates": [
                     {
@@ -407,6 +409,7 @@ public final class GroupApiExamples {
               "data": {
                 "sessionId": 5001,
                 "status": "OPEN",
+                "contextJson": "{\\\"latitude\\\":37.498095,\\\"longitude\\\":127.027610,\\\"radiusMeters\\\":1000,\\\"address\\\":\\\"서울 강남구 테헤란로 123\\\"}",
                 "readiness": null,
                 "candidates": [
                   {

--- a/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationSessionResponse.java
+++ b/src/main/java/matchuri/backend/api/group/dto/response/GroupRecommendationSessionResponse.java
@@ -12,6 +12,13 @@ public record GroupRecommendationSessionResponse(
         @Schema(description = "그룹 추천 상태입니다.", example = "OPEN")
         GroupRecommendationStatus status,
 
+        @Schema(
+                description = "추천 당시 위치 등 컨텍스트 JSON 문자열입니다. 서버는 파싱하지 않고 저장된 스냅샷을 그대로 반환합니다.",
+                example = "{\"latitude\":37.498095,\"longitude\":127.027610,\"radiusMeters\":1000,\"address\":\"서울 강남구 테헤란로 123\"}",
+                nullable = true
+        )
+        String contextJson,
+
         @Schema(description = "준비 단계 진행률입니다. PREPARING 상태가 아니면 null입니다.", nullable = true)
         GroupRecommendationReadinessProgressResponse readiness,
 
@@ -31,6 +38,7 @@ public record GroupRecommendationSessionResponse(
         return new GroupRecommendationSessionResponse(
                 5001L,
                 GroupRecommendationStatus.OPEN,
+                "{\"latitude\":37.498095,\"longitude\":127.027610,\"radiusMeters\":1000,\"address\":\"서울 강남구 테헤란로 123\"}",
                 null,
                 GroupMocks.candidates(),
                 GroupVoteProgressResponse.mockInProgress(),

--- a/src/main/java/matchuri/backend/domain/group/result/GroupRecommendationResult.java
+++ b/src/main/java/matchuri/backend/domain/group/result/GroupRecommendationResult.java
@@ -7,6 +7,7 @@ import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
 public record GroupRecommendationResult(
         Long sessionId,
         GroupRecommendationStatus status,
+        String contextJson,
         GroupRecommendationReadinessProgressResult readiness,
         List<GroupRecommendationCandidateResult> candidates,
         GroupVoteProgressResult voteProgress,

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -935,6 +935,7 @@ public class GroupServiceImpl implements GroupService {
         return new GroupRecommendationResult(
                 recommendation.getId(),
                 recommendation.getStatus(),
+                responseContextJson(recommendation.getContextJson()),
                 preparing
                         ? readinessProgress(
                                 recommendation.getId(),
@@ -948,6 +949,27 @@ public class GroupServiceImpl implements GroupService {
                 finalCandidate,
                 recommendation.getCreatedAt()
         );
+    }
+
+    private String responseContextJson(String contextJson) {
+        if (contextJson == null || contextJson.isBlank()) {
+            return contextJson;
+        }
+
+        String normalized = contextJson;
+        while (normalized.startsWith("\"") && normalized.endsWith("\"")) {
+            try {
+                JsonNode contextNode = objectMapper.readTree(normalized);
+                if (!contextNode.isTextual()) {
+                    return normalized;
+                }
+                normalized = contextNode.asText();
+            } catch (JsonProcessingException exception) {
+                return contextJson;
+            }
+        }
+
+        return normalized;
     }
 
     private List<GroupRecommendationCandidateResult> toCandidateResults(GroupRecommendation recommendation) {

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -924,9 +924,11 @@ class GroupIntegrationTest {
         ));
         MenuItem bibimbap = saveMenu("view-bibimbap", "비빔밥");
         MenuItem gimbap = saveMenu("view-gimbap", "김밥");
+        String contextJson =
+                "{\"latitude\":37.498095,\"longitude\":127.027610,\"radiusMeters\":1000,\"address\":\"서울 강남구 테헤란로 123\"}";
         GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
                 groupRoom,
-                "{}",
+                contextJson,
                 LocalDateTime.now()
         ));
         GroupRecommendationCandidate firstCandidate = groupRecommendationCandidateRepository.save(
@@ -945,6 +947,7 @@ class GroupIntegrationTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.sessionId").value(recommendation.getId()))
                 .andExpect(jsonPath("$.data.status").value(GroupRecommendationStatus.OPEN.name()))
+                .andExpect(jsonPath("$.data.contextJson").value(contextJson))
                 .andExpect(jsonPath("$.data.readiness").value(nullValue()))
                 .andExpect(jsonPath("$.data.candidates.length()").value(2))
                 .andExpect(jsonPath("$.data.candidates[0].candidateId").value(firstCandidate.getId()))


### PR DESCRIPTION
## 관련 이슈
Closes #316

## 📝 작업 내용
- 그룹 추천 세션 상세 조회 응답에 `contextJson` 필드를 추가했습니다.
- `contextJson`은 추천 당시 위치 정보가 포함된 `GroupRecommendation.contextJson` 스냅샷을 문자열 그대로 반환합니다.
- 투표 결과 화면에서 추천 요청 당시의 위치 정보를 표시할 수 있도록 API 문서와 통합 테스트를 함께 갱신했습니다.
- `contextJson`은 반정형 데이터이기에 값 그대로 전달합니다, client에서 파싱이 필요합니다.

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분: `contextJson`을 객체가 아닌 문자열 그대로 반환하는 계약이 프론트의 위치 표시 처리 방식과 맞는지 확인 부탁드립니다.
- 알려진 제한 사항: `contextJson` 내부 구조는 서버에서 검증하거나 파싱하지 않으므로, 클라이언트가 필요한 위치 필드를 직접 파싱해서 사용해야 합니다.