### PR TITLE
[Fix] 만료된 추천에 대해 lazy-expire 수행

### DIFF
--- a/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationRepository.java
+++ b/src/main/java/matchuri/backend/domain/group/repository/GroupRecommendationRepository.java
@@ -2,14 +2,13 @@ package matchuri.backend.domain.group.repository;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import matchuri.backend.domain.group.entity.GroupRecommendation;
 import matchuri.backend.domain.group.entity.GroupRecommendationStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface GroupRecommendationRepository extends JpaRepository<GroupRecommendation, Long> {
 
@@ -23,20 +22,12 @@ public interface GroupRecommendationRepository extends JpaRepository<GroupRecomm
 
     Optional<GroupRecommendation> findFirstByRoomIdOrderByStartedAtDescIdDesc(Long roomId);
 
-    @Query("""
-            select recommendation
-            from GroupRecommendation recommendation
-            where recommendation.room.id = :roomId
-              and (
-                    recommendation.status not in :activeStatuses
-                    or recommendation.startedAt > :activeThreshold
-              )
-            order by recommendation.startedAt desc, recommendation.id desc
-            """)
-    Page<GroupRecommendation> findVisibleByRoomIdOrderByStartedAtDescIdDesc(
-            @Param("roomId") Long roomId,
-            @Param("activeStatuses") Collection<GroupRecommendationStatus> activeStatuses,
-            @Param("activeThreshold") LocalDateTime activeThreshold,
-            Pageable pageable
+    Page<GroupRecommendation> findByRoomIdOrderByStartedAtDescIdDesc(Long roomId, Pageable pageable);
+
+    List<GroupRecommendation> findByRoomIdInAndStatusInAndEndedAtIsNullAndStartedAtLessThanEqual(
+            Collection<Long> roomIds,
+            Collection<GroupRecommendationStatus> statuses,
+            LocalDateTime startedAt
     );
+
 }

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -126,6 +126,8 @@ public class GroupServiceImpl implements GroupService {
             throw new BusinessException(GroupErrorCode.RECOMMENDATION_CREATE_FORBIDDEN, room.getId());
         }
 
+        expireActiveGroupRecommendations(room.getId(), LocalDateTime.now());
+
         if (hasActiveRecommendation(room.getId())) {
             throw new BusinessException(GroupErrorCode.RECOMMENDATION_ACTIVE_EXISTS, room.getId());
         }
@@ -300,19 +302,19 @@ public class GroupServiceImpl implements GroupService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public GroupRecommendationResult getGroupRecommendation(Long groupId, Long sessionId) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
         validateActiveMembership(groupId, member.getId());
 
         GroupRecommendation recommendation = groupRecommendationRepository.findByIdAndRoomId(sessionId, groupId)
                 .orElseThrow(() -> new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_FOUND, sessionId));
+        expireGroupRecommendationIfNeeded(recommendation, LocalDateTime.now());
 
         return toGroupRecommendationResult(recommendation, member.getId());
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional(noRollbackFor = BusinessException.class)
     public GroupRecommendationCandidateListResult getGroupRecommendationCandidates(Long groupId, Long sessionId) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
         validateActiveMembership(groupId, member.getId());
@@ -329,24 +331,19 @@ public class GroupServiceImpl implements GroupService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public Page<@NonNull GroupRecommendationSummaryResult> getGroupRecommendations(Long groupId, int page, int size) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
         GroupRoom room = getActiveGroupRoom(groupId);
         validateActiveMembership(room.getId(), member.getId());
 
+        expireActiveGroupRecommendations(room.getId(), LocalDateTime.now());
+
         return groupRecommendationRepository
-                .findVisibleByRoomIdOrderByStartedAtDescIdDesc(
-                        room.getId(),
-                        ACTIVE_RECOMMENDATION_STATUSES,
-                        groupRecommendationExpirationService.activeThreshold(LocalDateTime.now()),
-                        PageRequest.of(page, size)
-                )
+                .findByRoomIdOrderByStartedAtDescIdDesc(room.getId(), PageRequest.of(page, size))
                 .map(GroupRecommendationSummaryResult::from);
     }
 
     @Override
-    @Transactional(readOnly = true)
     public GroupRecommendationReadinessResult getGroupRecommendationReadiness(Long groupId, Long sessionId) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
         GroupRoom room = getActiveGroupRoom(groupId);
@@ -354,6 +351,7 @@ public class GroupServiceImpl implements GroupService {
 
         GroupRecommendation recommendation = groupRecommendationRepository.findByIdAndRoomId(sessionId, room.getId())
                 .orElseThrow(() -> new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_FOUND, sessionId));
+        expireGroupRecommendationIfNeeded(recommendation, LocalDateTime.now());
 
         List<GroupRoomMember> activeMembers = groupRoomMemberRepository.findActiveMembersByRoomId(room.getId());
         Map<Long, GroupRecommendationReadiness> readinessByMemberId = groupRecommendationReadinessRepository
@@ -383,6 +381,7 @@ public class GroupServiceImpl implements GroupService {
     }
 
     @Override
+    @Transactional(noRollbackFor = BusinessException.class)
     public ReadyGroupRecommendationResult readyGroupRecommendation(Long groupId, Long sessionId) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
         GroupRoom room = getActiveGroupRoom(groupId);
@@ -480,7 +479,7 @@ public class GroupServiceImpl implements GroupService {
     }
 
     @Override
-    @Transactional
+    @Transactional(noRollbackFor = BusinessException.class)
     public GroupVoteResult voteGroupRecommendation(Long groupId, Long sessionId, Long candidateId) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
         validateActiveMembership(groupId, member.getId());
@@ -536,6 +535,7 @@ public class GroupServiceImpl implements GroupService {
     }
 
     @Override
+    @Transactional(noRollbackFor = BusinessException.class)
     public FinalizeGroupRecommendationResult finalizeGroupRecommendation(Long groupId, Long sessionId) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
         GroupRoomMember membership = validateActiveMembership(groupId, member.getId());
@@ -783,7 +783,6 @@ public class GroupServiceImpl implements GroupService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public Page<@NonNull GroupSummaryResult> getMyGroups(GetMyGroupsCommand command) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
         Page<@NonNull GroupRoomMember> memberships = groupRoomMemberRepository.findMyActiveMemberships(
@@ -792,6 +791,12 @@ public class GroupServiceImpl implements GroupService {
                 PageRequest.of(command.page(), command.size())
         );
         Map<Long, Long> activeMemberCounts = countActiveMembers(memberships);
+        expireActiveGroupRecommendations(
+                memberships.getContent().stream()
+                        .map(membership -> membership.getRoom().getId())
+                        .toList(),
+                LocalDateTime.now()
+        );
 
         return memberships.map(membership -> toSummaryResult(membership, activeMemberCounts));
     }
@@ -854,7 +859,6 @@ public class GroupServiceImpl implements GroupService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public GroupDetailResult getGroup(Long groupId) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
         GroupRoom room = groupRoomRepository.findByIdAndStatusNot(groupId, GroupRoomStatus.DELETED)
@@ -868,6 +872,7 @@ public class GroupServiceImpl implements GroupService {
                 .stream()
                 .map(membership -> toMemberSummaryResult(membership, member.getId()))
                 .toList();
+        expireActiveGroupRecommendations(groupId, LocalDateTime.now());
         GroupRecommendationResult recentlyRecommendation = groupRecommendationRepository
                 .findFirstByRoomIdOrderByStartedAtDescIdDesc(groupId)
                 .map(recommendation -> toGroupRecommendationResult(recommendation, member.getId()))
@@ -910,10 +915,40 @@ public class GroupServiceImpl implements GroupService {
     }
 
     private void validateGroupRecommendationNotExpired(GroupRecommendation recommendation, Long sessionId) {
-        if (recommendation.getStatus() == GroupRecommendationStatus.EXPIRED
-                || groupRecommendationExpirationService.isExpired(recommendation, LocalDateTime.now())) {
+        if (expireGroupRecommendationIfNeeded(recommendation, LocalDateTime.now())) {
             throw new BusinessException(GroupErrorCode.RECOMMENDATION_EXPIRED, sessionId);
         }
+    }
+
+    private void expireActiveGroupRecommendations(Long roomId, LocalDateTime now) {
+        expireActiveGroupRecommendations(List.of(roomId), now);
+    }
+
+    private void expireActiveGroupRecommendations(List<Long> roomIds, LocalDateTime now) {
+        if (roomIds.isEmpty()) {
+            return;
+        }
+
+        groupRecommendationRepository
+                .findByRoomIdInAndStatusInAndEndedAtIsNullAndStartedAtLessThanEqual(
+                        roomIds,
+                        ACTIVE_RECOMMENDATION_STATUSES,
+                        groupRecommendationExpirationService.activeThreshold(now)
+                )
+                .forEach(recommendation -> recommendation.expire(now));
+    }
+
+    private boolean expireGroupRecommendationIfNeeded(GroupRecommendation recommendation, LocalDateTime now) {
+        if (recommendation.getStatus() == GroupRecommendationStatus.EXPIRED) {
+            return true;
+        }
+
+        if (!groupRecommendationExpirationService.isExpired(recommendation, now)) {
+            return false;
+        }
+
+        recommendation.expire(now);
+        return true;
     }
 
     private GroupRecommendationResult toGroupRecommendationResult(
@@ -1200,20 +1235,13 @@ public class GroupServiceImpl implements GroupService {
                 room.getName(),
                 room.getStatus(),
                 activeMemberCounts.getOrDefault(room.getId(), 0L).intValue(),
-                latestVisibleRecommendationStatus(room.getId()),
+                latestRecommendationStatus(room.getId()),
                 room.getCreatedAt()
         );
     }
 
-    private GroupRecommendationStatus latestVisibleRecommendationStatus(Long roomId) {
-        return groupRecommendationRepository.findVisibleByRoomIdOrderByStartedAtDescIdDesc(
-                        roomId,
-                        ACTIVE_RECOMMENDATION_STATUSES,
-                        groupRecommendationExpirationService.activeThreshold(LocalDateTime.now()),
-                        PageRequest.of(0, 1)
-                )
-                .stream()
-                .findFirst()
+    private GroupRecommendationStatus latestRecommendationStatus(Long roomId) {
+        return groupRecommendationRepository.findFirstByRoomIdOrderByStartedAtDescIdDesc(roomId)
                 .map(GroupRecommendation::getStatus)
                 .orElse(null);
     }

--- a/src/main/java/matchuri/backend/domain/recommendation/repository/PersonalRecommendationRepository.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/repository/PersonalRecommendationRepository.java
@@ -9,14 +9,14 @@ import org.jspecify.annotations.NullMarked;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 @NullMarked
 public interface PersonalRecommendationRepository extends JpaRepository<PersonalRecommendation, Long> {
     List<PersonalRecommendation> findByMemberId(Long memberId);
 
     List<PersonalRecommendation> findByMemberIdOrderByRequestedAtDescIdDesc(Long memberId);
+
+    Page<PersonalRecommendation> findByMemberIdOrderByRequestedAtDescIdDesc(Long memberId, Pageable pageable);
 
     Optional<PersonalRecommendation> findByIdAndMemberId(Long id, Long memberId);
 
@@ -25,20 +25,9 @@ public interface PersonalRecommendationRepository extends JpaRepository<Personal
             PersonalRecommendationStatus status
     );
 
-    @Query("""
-            select recommendation
-            from PersonalRecommendation recommendation
-            where recommendation.member.id = :memberId
-              and (
-                    recommendation.status <> :openStatus
-                    or recommendation.requestedAt > :activeThreshold
-              )
-            order by recommendation.requestedAt desc, recommendation.id desc
-            """)
-    Page<PersonalRecommendation> findVisibleByMemberIdOrderByRequestedAtDescIdDesc(
-            @Param("memberId") long memberId,
-            @Param("openStatus") PersonalRecommendationStatus openStatus,
-            @Param("activeThreshold") LocalDateTime activeThreshold,
-            Pageable pageable
+    List<PersonalRecommendation> findByMemberIdAndStatusAndSelectedCandidateIsNullAndClosedAtIsNullAndRequestedAtLessThanEqual(
+            long memberId,
+            PersonalRecommendationStatus status,
+            LocalDateTime requestedAt
     );
 }

--- a/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
@@ -94,13 +94,13 @@ public class RecommendationServiceImpl implements RecommendationService {
 
         List<PersonalRecommendation> recommendations =
                 personalRecommendationRepository.findByMemberIdOrderByRequestedAtDescIdDesc(member.getId());
-        closeExpiredOrRejectOpenRecommendation(recommendations);
+        expireOrRejectOpenRecommendation(recommendations);
 
         return createPersonalRecommendation(member, contextJson, recommendations);
     }
 
     @Override
-    @Transactional
+    @Transactional(noRollbackFor = BusinessException.class)
     public PersonalRecommendationResult rerollPersonalRecommendation(
             Long sourcePersonalRecommendationId,
             PersonalRecommendationRerollType rerollType,
@@ -237,11 +237,11 @@ public class RecommendationServiceImpl implements RecommendationService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public PersonalRecommendationResult getPersonalRecommendation(Long personalRecommendationId) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
         PersonalRecommendation personalRecommendation = getOwnedPersonalRecommendation(personalRecommendationId,
                 member.getId());
+        expirePersonalRecommendationIfNeeded(personalRecommendation, LocalDateTime.now());
         List<PersonalRecommendationCandidate> candidates =
                 personalRecommendationCandidateRepository.findByPersonalRecommendationIdOrderByRankNoAsc(
                         personalRecommendationId);
@@ -250,12 +250,13 @@ public class RecommendationServiceImpl implements RecommendationService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public List<PersonalRecommendationCandidateResult> getPersonalRecommendationCandidates(
             Long personalRecommendationId
     ) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
-        getOwnedPersonalRecommendation(personalRecommendationId, member.getId());
+        PersonalRecommendation personalRecommendation = getOwnedPersonalRecommendation(personalRecommendationId,
+                member.getId());
+        expirePersonalRecommendationIfNeeded(personalRecommendation, LocalDateTime.now());
 
         return personalRecommendationCandidateRepository
                 .findByPersonalRecommendationIdOrderByRankNoAsc(personalRecommendationId)
@@ -268,23 +269,17 @@ public class RecommendationServiceImpl implements RecommendationService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public Page<@NonNull PersonalRecommendationSummaryResult> getMyPersonalRecommendations(int page, int size) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
-        LocalDateTime activeThreshold = personalRecommendationExpirationService.activeThreshold(LocalDateTime.now());
+        expireOpenPersonalRecommendations(member.getId(), LocalDateTime.now());
 
         return personalRecommendationRepository
-                .findVisibleByMemberIdOrderByRequestedAtDescIdDesc(
-                        member.getId(),
-                        PersonalRecommendationStatus.OPEN,
-                        activeThreshold,
-                        PageRequest.of(page, size)
-                )
+                .findByMemberIdOrderByRequestedAtDescIdDesc(member.getId(), PageRequest.of(page, size))
                 .map(PersonalRecommendationSummaryResult::from);
     }
 
     @Override
-    @Transactional
+    @Transactional(noRollbackFor = BusinessException.class)
     public SelectPersonalRecommendationResult selectPersonalRecommendationCandidate(
             Long personalRecommendationId,
             Long selectedCandidateId
@@ -319,7 +314,7 @@ public class RecommendationServiceImpl implements RecommendationService {
                 .orElseThrow(() -> new BusinessException(RecommendationErrorCode.NOT_FOUND, personalRecommendationId));
     }
 
-    private void closeExpiredOrRejectOpenRecommendation(List<PersonalRecommendation> recommendations) {
+    private void expireOrRejectOpenRecommendation(List<PersonalRecommendation> recommendations) {
         LocalDateTime now = LocalDateTime.now();
 
         for (PersonalRecommendation recommendation : recommendations) {
@@ -327,7 +322,7 @@ public class RecommendationServiceImpl implements RecommendationService {
                 continue;
             }
 
-            if (personalRecommendationExpirationService.isExpired(recommendation, now)) {
+            if (expirePersonalRecommendationIfNeeded(recommendation, now)) {
                 continue;
             }
 
@@ -338,14 +333,36 @@ public class RecommendationServiceImpl implements RecommendationService {
     }
 
     private void validatePersonalRecommendationOpen(PersonalRecommendation recommendation, LocalDateTime now) {
-        if (recommendation.getStatus() == PersonalRecommendationStatus.EXPIRED
-                || personalRecommendationExpirationService.isExpired(recommendation, now)) {
+        if (expirePersonalRecommendationIfNeeded(recommendation, now)) {
             throw new BusinessException(RecommendationErrorCode.EXPIRED, recommendation.getId());
         }
 
         if (!recommendation.isOpen()) {
             throw new BusinessException(RecommendationErrorCode.ALREADY_CLOSED, recommendation.getId());
         }
+    }
+
+    private void expireOpenPersonalRecommendations(Long memberId, LocalDateTime now) {
+        personalRecommendationRepository
+                .findByMemberIdAndStatusAndSelectedCandidateIsNullAndClosedAtIsNullAndRequestedAtLessThanEqual(
+                        memberId,
+                        PersonalRecommendationStatus.OPEN,
+                        personalRecommendationExpirationService.activeThreshold(now)
+                )
+                .forEach(recommendation -> recommendation.expire(now));
+    }
+
+    private boolean expirePersonalRecommendationIfNeeded(PersonalRecommendation recommendation, LocalDateTime now) {
+        if (recommendation.getStatus() == PersonalRecommendationStatus.EXPIRED) {
+            return true;
+        }
+
+        if (!personalRecommendationExpirationService.isExpired(recommendation, now)) {
+            return false;
+        }
+
+        recommendation.expire(now);
+        return true;
     }
 
     private TasteProfileSnapshot toTasteProfileSnapshot(Member member, MemberTasteProfile tasteProfile) {

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -65,6 +65,8 @@ import matchuri.backend.domain.menu.repository.IngredientRepository;
 import matchuri.backend.domain.menu.repository.MenuAttributeCategoryRepository;
 import matchuri.backend.domain.menu.repository.MenuIngredientRepository;
 import matchuri.backend.domain.menu.repository.MenuItemRepository;
+import matchuri.backend.domain.recommendation.repository.PersonalRecommendationCandidateRepository;
+import matchuri.backend.domain.recommendation.repository.PersonalRecommendationRepository;
 import matchuri.backend.global.config.MatchuriProperties;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -124,6 +126,12 @@ class GroupIntegrationTest {
     private GroupRecommendationVoteRepository groupRecommendationVoteRepository;
 
     @Autowired
+    private PersonalRecommendationCandidateRepository personalRecommendationCandidateRepository;
+
+    @Autowired
+    private PersonalRecommendationRepository personalRecommendationRepository;
+
+    @Autowired
     private MenuItemRepository menuItemRepository;
 
     @Autowired
@@ -171,6 +179,8 @@ class GroupIntegrationTest {
         groupLocationRepository.deleteAll();
         groupRoomMemberRepository.deleteAll();
         groupRoomRepository.deleteAll();
+        personalRecommendationCandidateRepository.deleteAll();
+        personalRecommendationRepository.deleteAll();
         memberTasteProfileDislikedMenuItemRepository.deleteAll();
         memberTasteProfileRestrictionIngredientRepository.deleteAll();
         memberTasteProfileCategoryRepository.deleteAll();
@@ -382,8 +392,8 @@ class GroupIntegrationTest {
     }
 
     @Test
-    @DisplayName("그룹 추천 시작은 시간상 만료된 진행 중 추천을 무시하고 새 준비 세션을 생성한다")
-    void createGroupRecommendationIgnoresExpiredActiveRecommendationAndCreatesPreparingSession() throws Exception {
+    @DisplayName("그룹 추천 시작은 시간상 만료된 진행 중 추천을 EXPIRED로 전환하고 새 준비 세션을 생성한다")
+    void createGroupRecommendationExpiresOldActiveRecommendationAndCreatesPreparingSession() throws Exception {
         Member owner = saveMember("expired-active-group-owner", "만료추천방장");
         GroupRoom groupRoom = saveGroupOwnedBy(owner, "만료 추천 그룹");
         GroupRecommendation oldRecommendation = groupRecommendationRepository.save(GroupRecommendation.preparing(
@@ -405,14 +415,14 @@ class GroupIntegrationTest {
 
         GroupRecommendation existingRecommendation = groupRecommendationRepository.findById(oldRecommendation.getId())
                 .orElseThrow();
-        assertThat(existingRecommendation.getStatus()).isEqualTo(GroupRecommendationStatus.PREPARING);
-        assertThat(existingRecommendation.getEndedAt()).isNull();
+        assertThat(existingRecommendation.getStatus()).isEqualTo(GroupRecommendationStatus.EXPIRED);
+        assertThat(existingRecommendation.getEndedAt()).isNotNull();
         assertThat(groupRecommendationRepository.count()).isEqualTo(2);
     }
 
     @Test
-    @DisplayName("그룹 추천 목록은 시간상 만료된 PREPARING/OPEN 추천을 제외한다")
-    void getGroupRecommendationsExcludesExpiredActiveRecommendations() throws Exception {
+    @DisplayName("그룹 추천 목록은 시간상 만료된 PREPARING/OPEN 추천을 EXPIRED로 전환해 반환한다")
+    void getGroupRecommendationsExpiresActiveRecommendations() throws Exception {
         Member owner = saveMember("group-expiration-service-owner", "그룹만료방장");
         GroupRoom groupRoom = saveGroupOwnedBy(owner, "그룹 만료 서비스");
         GroupRecommendation oldPreparing = groupRecommendationRepository.save(GroupRecommendation.preparing(
@@ -441,14 +451,16 @@ class GroupIntegrationTest {
         mockMvc.perform(get("/api/v1/groups/{groupId}/recommendations", groupRoom.getId())
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.content.length()").value(2))
+                .andExpect(jsonPath("$.data.content.length()").value(4))
                 .andExpect(jsonPath("$.data.content[0].sessionId").value(recentPreparing.getId()))
-                .andExpect(jsonPath("$.data.content[1].sessionId").value(alreadyClosed.getId()));
+                .andExpect(jsonPath("$.data.content[1].sessionId").value(alreadyClosed.getId()))
+                .andExpect(jsonPath("$.data.content[2].status").value(GroupRecommendationStatus.EXPIRED.name()))
+                .andExpect(jsonPath("$.data.content[3].status").value(GroupRecommendationStatus.EXPIRED.name()));
 
         assertThat(groupRecommendationRepository.findById(oldPreparing.getId()).orElseThrow().getStatus())
-                .isEqualTo(GroupRecommendationStatus.PREPARING);
+                .isEqualTo(GroupRecommendationStatus.EXPIRED);
         assertThat(groupRecommendationRepository.findById(oldOpen.getId()).orElseThrow().getStatus())
-                .isEqualTo(GroupRecommendationStatus.OPEN);
+                .isEqualTo(GroupRecommendationStatus.EXPIRED);
     }
 
     @Test
@@ -1750,6 +1762,30 @@ class GroupIntegrationTest {
     }
 
     @Test
+    @DisplayName("그룹 상세 조회는 시간상 만료된 최신 추천을 EXPIRED로 전환해 recentlyRecommendation으로 반환한다")
+    void getGroupExpiresLatestRecommendationAndReturnsRecentlyRecommendation() throws Exception {
+        Member owner = saveMember("group-expired-recent-owner", "만료최근방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "만료 최근 추천 그룹");
+        GroupRecommendation recommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now().minusHours(25)
+        ));
+
+        mockMvc.perform(get("/api/v1/groups/{groupId}", groupRoom.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.recentlyRecommendation.sessionId").value(recommendation.getId()))
+                .andExpect(jsonPath("$.data.recentlyRecommendation.status")
+                        .value(GroupRecommendationStatus.EXPIRED.name()));
+
+        GroupRecommendation expiredRecommendation = groupRecommendationRepository.findById(recommendation.getId())
+                .orElseThrow();
+        assertThat(expiredRecommendation.getStatus()).isEqualTo(GroupRecommendationStatus.EXPIRED);
+        assertThat(expiredRecommendation.getEndedAt()).isNotNull();
+    }
+
+    @Test
     @DisplayName("그룹 상세 조회는 종료된 최신 그룹 추천 결과도 recentlyRecommendation으로 반환한다")
     void getGroupReturnsFinalizedRecentlyRecommendation() throws Exception {
         Member owner = saveMember("group-finalized-recent-owner", "확정최근방장");
@@ -1825,6 +1861,44 @@ class GroupIntegrationTest {
                 .andExpect(jsonPath("$.data.content[0].id").value(groupRoom.getId()))
                 .andExpect(jsonPath("$.data.content[0].latestRecommendationStatus")
                         .value(GroupRecommendationStatus.PREPARING.name()));
+    }
+
+    @Test
+    @DisplayName("내 그룹 목록은 시간상 만료된 최신 추천을 EXPIRED로 전환해 최신 상태로 반환한다")
+    void getMyGroupsExpiresLatestRecommendationAndReturnsExpiredStatus() throws Exception {
+        Member owner = saveMember("group-list-expired-owner", "목록만료방장");
+        GroupRoom groupRoom = saveGroupOwnedBy(owner, "목록 만료 추천 그룹");
+        MenuItem menuItem = saveMenu("list-expired-menu", "목록만료메뉴");
+        GroupRecommendation finalizedRecommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now().minusHours(26)
+        ));
+        GroupRecommendationCandidate candidate = groupRecommendationCandidateRepository.save(
+                new GroupRecommendationCandidate(finalizedRecommendation, menuItem, 1, 90.0, "{}")
+        );
+        finalizedRecommendation.finalizeWith(candidate, LocalDateTime.now().minusHours(25));
+        GroupRecommendation expiredOpenRecommendation = groupRecommendationRepository.save(new GroupRecommendation(
+                groupRoom,
+                "{}",
+                LocalDateTime.now().minusHours(25)
+        ));
+
+        mockMvc.perform(get("/api/v1/groups")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content.length()").value(1))
+                .andExpect(jsonPath("$.data.content[0].id").value(groupRoom.getId()))
+                .andExpect(jsonPath("$.data.content[0].latestRecommendationStatus")
+                        .value(GroupRecommendationStatus.EXPIRED.name()));
+
+        GroupRecommendation reloadedRecommendation = groupRecommendationRepository
+                .findById(expiredOpenRecommendation.getId())
+                .orElseThrow();
+        assertThat(reloadedRecommendation.getStatus()).isEqualTo(GroupRecommendationStatus.EXPIRED);
+        assertThat(reloadedRecommendation.getEndedAt()).isNotNull();
     }
 
     @Test

--- a/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
@@ -341,15 +341,15 @@ class PersonalRecommendationIntegrationTest {
                 .orElseThrow();
         PersonalRecommendation newRecommendation = personalRecommendationRepository.findById(secondRequestId)
                 .orElseThrow();
-        assertThat(oldRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.OPEN);
-        assertThat(oldRecommendation.getClosedAt()).isNull();
+        assertThat(oldRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.EXPIRED);
+        assertThat(oldRecommendation.getClosedAt()).isNotNull();
         assertThat(newRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.OPEN);
         assertThat(newRecommendation.getClosedAt()).isNull();
     }
 
     @Test
-    @DisplayName("개인 추천 목록은 시간상 만료된 열린 추천을 제외한다")
-    void getMyPersonalRecommendationsExcludesExpiredOpenRecommendation() throws Exception {
+    @DisplayName("개인 추천 목록은 시간상 만료된 열린 추천을 EXPIRED로 전환해 반환한다")
+    void getMyPersonalRecommendationsExpiresOpenRecommendation() throws Exception {
         Member member = saveMember("expiration-list-user", "만료목록");
         String accessToken = accessToken(member);
         AttributeCategory spicy = attributeCategoryRepository.save(
@@ -365,12 +365,43 @@ class PersonalRecommendationIntegrationTest {
         mockMvc.perform(get("/api/v1/personal/recommendations")
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.content.length()").value(0));
+                .andExpect(jsonPath("$.data.content.length()").value(1))
+                .andExpect(jsonPath("$.data.content[0].id").value(requestId))
+                .andExpect(jsonPath("$.data.content[0].status").value(PersonalRecommendationStatus.EXPIRED.name()))
+                .andExpect(jsonPath("$.data.content[0].closedAt").isNotEmpty());
 
         PersonalRecommendation oldRecommendation = personalRecommendationRepository.findById(requestId)
                 .orElseThrow();
-        assertThat(oldRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.OPEN);
-        assertThat(oldRecommendation.getClosedAt()).isNull();
+        assertThat(oldRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.EXPIRED);
+        assertThat(oldRecommendation.getClosedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("개인 추천 상세 조회는 시간상 만료된 열린 추천을 EXPIRED로 전환해 반환한다")
+    void getPersonalRecommendationExpiresOpenRecommendation() throws Exception {
+        Member member = saveMember("expiration-detail-user", "만료상세");
+        String accessToken = accessToken(member);
+        AttributeCategory spicy = attributeCategoryRepository.save(
+                new AttributeCategory(CategoryType.FLAVOR, "SPICY", "매운맛", 10));
+        MenuItem bibimbap = menuItemRepository.save(new MenuItem("BIBIMBAP", "비빔밥", "채소와 밥"));
+        saveMenuAttribute(bibimbap, spicy);
+        saveTasteProfile(member, spicy, null);
+
+        JsonNode recommendation = createRecommendation(accessToken);
+        long requestId = recommendation.path("requestId").asLong();
+        expireRequestedAt(requestId);
+
+        mockMvc.perform(get("/api/v1/personal/recommendations/{requestId}", requestId)
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(requestId))
+                .andExpect(jsonPath("$.data.status").value(PersonalRecommendationStatus.EXPIRED.name()))
+                .andExpect(jsonPath("$.data.closedAt").isNotEmpty());
+
+        PersonalRecommendation oldRecommendation = personalRecommendationRepository.findById(requestId)
+                .orElseThrow();
+        assertThat(oldRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.EXPIRED);
+        assertThat(oldRecommendation.getClosedAt()).isNotNull();
     }
 
     @Test
@@ -403,8 +434,8 @@ class PersonalRecommendationIntegrationTest {
         PersonalRecommendation oldRecommendation = personalRecommendationRepository.findById(requestId)
                 .orElseThrow();
         assertThat(oldRecommendation.getSelectedCandidate()).isNull();
-        assertThat(oldRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.OPEN);
-        assertThat(oldRecommendation.getClosedAt()).isNull();
+        assertThat(oldRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.EXPIRED);
+        assertThat(oldRecommendation.getClosedAt()).isNotNull();
     }
 
     @Test
@@ -436,8 +467,8 @@ class PersonalRecommendationIntegrationTest {
 
         PersonalRecommendation oldRecommendation = personalRecommendationRepository.findById(requestId)
                 .orElseThrow();
-        assertThat(oldRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.OPEN);
-        assertThat(oldRecommendation.getClosedAt()).isNull();
+        assertThat(oldRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.EXPIRED);
+        assertThat(oldRecommendation.getClosedAt()).isNotNull();
         assertThat(personalRecommendationRepository.count()).isEqualTo(1);
     }
 


### PR DESCRIPTION
## 관련 이슈
Closes #321 

## 📝 작업 내용
- 그룹/개인 추천 만료 처리를 lazy expire-on-touch 방식으로 변경했습니다.
- 만료된 `OPEN`/`PREPARING` 추천을 조회, 생성, 상태 변경 API 접근 시점에 `EXPIRED`로 전환하도록 했습니다.
- `GET /api/v1/groups`의 `latestRecommendationStatus`, `GET /api/v1/groups/{groupId}`의 `recentlyRecommendation`, 추천 목록/상세 응답이 만료 상태를 일관되게 반환하도록 정리했습니다.
- 개인 추천도 목록/상세/선택/재요청에서 만료된 `OPEN` 추천을 `EXPIRED`로 확정하도록 반영했습니다.
- 상태 변경 API에서 만료 전환 후 409 응답을 반환해도 DB 상태 변경이 롤백되지 않도록 처리했습니다.
- 관련 API/데이터 문서와 통합 테스트를 갱신했습니다.
- 스케줄러 제거 이후 `OPEN`으로 보이지만 실제 행동은 만료로 막히는 응답 불일치를 해소하기 위한 변경입니다.

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분: `GET` 계열 조회에서도 만료된 추천을 `EXPIRED`로 전환하는 정책과, 클라이언트가 `recentlyRecommendation` 존재 여부가 아니라 `status` 기준으로 액션 가능 여부를 판단하는 계약을 확인해주세요.
- 알려진 제한 사항: 별도 주기 스케줄러는 없으므로, 오랫동안 접근되지 않은 만료 추천은 다음 조회/생성/상태 변경 요청 시점에 `EXPIRED`로 전환됩니다.