### PR TITLE
[Refactor] 사용하지 않는 로그인 정보를 받지 않도로 수정 (MC-28)

### DIFF
--- a/src/main/java/matchuri/backend/domain/auth/support/oauth2/GoogleOAuth2UserInfoResolver.java
+++ b/src/main/java/matchuri/backend/domain/auth/support/oauth2/GoogleOAuth2UserInfoResolver.java
@@ -17,8 +17,7 @@ public class GoogleOAuth2UserInfoResolver implements OAuth2UserInfoResolver {
         return new OAuth2ProviderUserInfo(
                 SocialProviderType.GOOGLE,
                 oauth2User.getAttribute("sub"),
-                oauth2User.getAttribute("email"),
-                oauth2User.getAttribute("name")
+                oauth2User.getAttribute("email")
         );
     }
 }

--- a/src/main/java/matchuri/backend/domain/auth/support/oauth2/KakaoOAuth2UserInfoResolver.java
+++ b/src/main/java/matchuri/backend/domain/auth/support/oauth2/KakaoOAuth2UserInfoResolver.java
@@ -17,18 +17,11 @@ public class KakaoOAuth2UserInfoResolver implements OAuth2UserInfoResolver {
     @Override
     public OAuth2ProviderUserInfo resolve(OAuth2User oauth2User) {
         Map<?, ?> kakaoAccount = TypeUtils.asMap(oauth2User.getAttribute("kakao_account"));
-        Map<?, ?> properties = TypeUtils.asMap(oauth2User.getAttribute("properties"));
-        Map<?, ?> profile = TypeUtils.asMap(kakaoAccount.get("profile"));
 
         return new OAuth2ProviderUserInfo(
                 SocialProviderType.KAKAO,
                 TypeUtils.stringValue(oauth2User.getAttribute("id")),
-                TypeUtils.stringValue(kakaoAccount.get("email")),
-                TypeUtils.firstPresent(
-                        TypeUtils.stringValue(properties.get("nickname")),
-                        TypeUtils.stringValue(profile.get("nickname")),
-                        TypeUtils.stringValue(kakaoAccount.get("name"))
-                )
+                TypeUtils.stringValue(kakaoAccount.get("email"))
         );
     }
 }

--- a/src/main/java/matchuri/backend/domain/auth/support/oauth2/NaverOAuth2UserInfoResolver.java
+++ b/src/main/java/matchuri/backend/domain/auth/support/oauth2/NaverOAuth2UserInfoResolver.java
@@ -21,8 +21,7 @@ public class NaverOAuth2UserInfoResolver implements OAuth2UserInfoResolver {
         return new OAuth2ProviderUserInfo(
                 SocialProviderType.NAVER,
                 TypeUtils.stringValue(response.get("id")),
-                TypeUtils.stringValue(response.get("email")),
-                TypeUtils.stringValue(response.get("nickname"))
+                TypeUtils.stringValue(response.get("email"))
         );
     }
 }

--- a/src/main/java/matchuri/backend/domain/auth/support/oauth2/OAuth2ProviderUserInfo.java
+++ b/src/main/java/matchuri/backend/domain/auth/support/oauth2/OAuth2ProviderUserInfo.java
@@ -5,7 +5,6 @@ import matchuri.backend.domain.member.entity.SocialProviderType;
 public record OAuth2ProviderUserInfo(
         SocialProviderType provider,
         String providerUserId,
-        String email,
-        String nickname
+        String email
 ) {
 }

--- a/src/main/java/matchuri/backend/global/util/TypeUtils.java
+++ b/src/main/java/matchuri/backend/global/util/TypeUtils.java
@@ -24,13 +24,4 @@ public class TypeUtils {
         return stringValue;
     }
 
-    public static String firstPresent(String... values) {
-        for (String value : values) {
-            if (value != null && !value.isBlank()) {
-                return value;
-            }
-        }
-
-        return null;
-    }
 }

--- a/src/test/java/matchuri/backend/domain/auth/service/OAuth2LoginServiceTest.java
+++ b/src/test/java/matchuri/backend/domain/auth/service/OAuth2LoginServiceTest.java
@@ -38,8 +38,7 @@ class OAuth2LoginServiceTest {
                 List.of(),
                 java.util.Map.of(
                         "sub", "google-user-1",
-                        "email", "google@example.com",
-                        "name", "구글사용자"
+                        "email", "google@example.com"
                 ),
                 "sub"
         );

--- a/src/test/java/matchuri/backend/domain/auth/support/oauth2/GoogleOAuth2UserInfoResolverTest.java
+++ b/src/test/java/matchuri/backend/domain/auth/support/oauth2/GoogleOAuth2UserInfoResolverTest.java
@@ -20,8 +20,7 @@ class GoogleOAuth2UserInfoResolverTest {
                 java.util.List.of(),
                 Map.of(
                         "sub", "google-user-1",
-                        "email", "google@example.com",
-                        "name", "구글사용자"
+                        "email", "google@example.com"
                 ),
                 "sub"
         );
@@ -32,6 +31,5 @@ class GoogleOAuth2UserInfoResolverTest {
         assertThat(userInfo.provider()).isEqualTo(SocialProviderType.GOOGLE);
         assertThat(userInfo.providerUserId()).isEqualTo("google-user-1");
         assertThat(userInfo.email()).isEqualTo("google@example.com");
-        assertThat(userInfo.nickname()).isEqualTo("구글사용자");
     }
 }

--- a/src/test/java/matchuri/backend/domain/auth/support/oauth2/KakaoOAuth2UserInfoResolverTest.java
+++ b/src/test/java/matchuri/backend/domain/auth/support/oauth2/KakaoOAuth2UserInfoResolverTest.java
@@ -21,11 +21,7 @@ class KakaoOAuth2UserInfoResolverTest {
                 List.of(),
                 Map.of(
                         "id", 123456789L,
-                        "properties", Map.of("nickname", "카카오사용자"),
-                        "kakao_account", Map.of(
-                                "email", "kakao@example.com",
-                                "profile", Map.of("nickname", "프로필닉네임")
-                        )
+                        "kakao_account", Map.of("email", "kakao@example.com")
                 ),
                 "id"
         );
@@ -36,19 +32,16 @@ class KakaoOAuth2UserInfoResolverTest {
         assertThat(userInfo.provider()).isEqualTo(SocialProviderType.KAKAO);
         assertThat(userInfo.providerUserId()).isEqualTo("123456789");
         assertThat(userInfo.email()).isEqualTo("kakao@example.com");
-        assertThat(userInfo.nickname()).isEqualTo("카카오사용자");
     }
 
     @Test
-    @DisplayName("Kakao 계정 이메일과 properties 닉네임이 없어도 고유 식별자를 정규화한다")
+    @DisplayName("Kakao 계정 이메일이 없어도 고유 식별자를 정규화한다")
     void resolvesKakaoUserInfoWithoutOptionalFields() {
         OAuth2User oauth2User = new DefaultOAuth2User(
                 List.of(),
                 Map.of(
                         "id", 987654321L,
-                        "kakao_account", Map.of(
-                                "profile", Map.of("nickname", "프로필닉네임")
-                        )
+                        "kakao_account", Map.of()
                 ),
                 "id"
         );
@@ -57,6 +50,5 @@ class KakaoOAuth2UserInfoResolverTest {
 
         assertThat(userInfo.providerUserId()).isEqualTo("987654321");
         assertThat(userInfo.email()).isNull();
-        assertThat(userInfo.nickname()).isEqualTo("프로필닉네임");
     }
 }

--- a/src/test/java/matchuri/backend/domain/auth/support/oauth2/NaverOAuth2UserInfoResolverTest.java
+++ b/src/test/java/matchuri/backend/domain/auth/support/oauth2/NaverOAuth2UserInfoResolverTest.java
@@ -22,8 +22,7 @@ class NaverOAuth2UserInfoResolverTest {
                 Map.of(
                         "response", Map.of(
                                 "id", "naver-user-1",
-                                "email", "naver@example.com",
-                                "nickname", "네이버사용자"
+                                "email", "naver@example.com"
                         )
                 ),
                 "response"
@@ -35,11 +34,10 @@ class NaverOAuth2UserInfoResolverTest {
         assertThat(userInfo.provider()).isEqualTo(SocialProviderType.NAVER);
         assertThat(userInfo.providerUserId()).isEqualTo("naver-user-1");
         assertThat(userInfo.email()).isEqualTo("naver@example.com");
-        assertThat(userInfo.nickname()).isEqualTo("네이버사용자");
     }
 
     @Test
-    @DisplayName("Naver 계정 이메일과 닉네임이 없어도 고유 식별자를 정규화한다")
+    @DisplayName("Naver 계정 이메일이 없어도 고유 식별자를 정규화한다")
     void resolvesNaverUserInfoWithoutOptionalFields() {
         OAuth2User oauth2User = new DefaultOAuth2User(
                 List.of(),
@@ -51,6 +49,5 @@ class NaverOAuth2UserInfoResolverTest {
 
         assertThat(userInfo.providerUserId()).isEqualTo("naver-user-2");
         assertThat(userInfo.email()).isNull();
-        assertThat(userInfo.nickname()).isNull();
     }
 }


### PR DESCRIPTION
## 관련 이슈
노션 MC-28 백로그

## 📝 작업 내용
- OAuth2 provider 사용자 정보 공통 record에서 사용되지 않는 `nickname` 필드를 제거했습니다.
- Google/Kakao/Naver OAuth2 resolver에서 provider 원본 nickname/name 추출 로직을 제거했습니다.
- 관련 resolver 테스트에서 `nickname` 검증을 제거하고, 현재 실제 사용 필드인 `provider`, `providerUserId`, `email` 중심으로 정리했습니다.
- `nickname` 추출에만 쓰이던 `TypeUtils.firstPresent` 유틸 메서드를 제거했습니다.
- provider에서 받은 nickname은 회원 생성/로그인 흐름에서 사용되지 않고, 신규 소셜 회원 닉네임은 기존처럼 email 기반 임시 닉네임으로 생성되므로 불필요한 데이터 수집/전달을 줄이기 위해 변경했습니다.

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분: OAuth2 로그인 이후 회원 닉네임은 provider 원본 nickname이 아니라 기존 임시 닉네임 생성 정책을 계속 따르는 점을 확인 부탁드립니다.
- 알려진 제한 사항: 없음. `.\gradlew.bat test` 통과했습니다.