### PR TITLE
[Feat] 개인 위치 저장 및 조회 API 구현 (MC-41)

### DIFF
--- a/init/sql/01-schema.sql
+++ b/init/sql/01-schema.sql
@@ -142,6 +142,19 @@ CREATE TABLE member_taste_profiles (
     CONSTRAINT uk_member_taste_profiles_member UNIQUE (member_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+CREATE TABLE member_locations (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    member_id BIGINT NOT NULL,
+    latitude DECIMAL(10,7) NOT NULL,
+    longitude DECIMAL(10,7) NOT NULL,
+    radius_meters INT NOT NULL,
+    address VARCHAR(255) NOT NULL,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    CONSTRAINT uk_member_locations_member UNIQUE (member_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 CREATE TABLE member_taste_profile_categories (
     id BIGINT NOT NULL AUTO_INCREMENT,
     profile_id BIGINT NOT NULL,
@@ -406,6 +419,9 @@ ALTER TABLE member_agreements
 
 ALTER TABLE member_taste_profiles
     ADD CONSTRAINT fk_member_taste_profiles_member FOREIGN KEY (member_id) REFERENCES members (id);
+
+ALTER TABLE member_locations
+    ADD CONSTRAINT fk_member_locations_member FOREIGN KEY (member_id) REFERENCES members (id);
 
 ALTER TABLE member_taste_profile_categories
     ADD CONSTRAINT fk_member_taste_profile_categories_profile FOREIGN KEY (profile_id) REFERENCES member_taste_profiles (id),

--- a/src/main/java/matchuri/backend/api/member/MemberApi.java
+++ b/src/main/java/matchuri/backend/api/member/MemberApi.java
@@ -12,6 +12,7 @@ import matchuri.backend.api.common.docs.ErrorExamples;
 import matchuri.backend.api.member.dto.docs.CreateMemberApiResponse;
 import matchuri.backend.api.member.dto.docs.LoginIdExistsApiResponse;
 import matchuri.backend.api.member.dto.docs.MemberProfileApiResponse;
+import matchuri.backend.api.member.dto.docs.MemberLocationApiResponse;
 import matchuri.backend.api.member.dto.docs.MemberTasteProfileSummaryApiResponse;
 import matchuri.backend.api.member.dto.docs.MemberTasteProfileUpdateApiResponse;
 import matchuri.backend.api.member.dto.docs.NicknameExistsApiResponse;
@@ -19,12 +20,14 @@ import matchuri.backend.api.member.dto.docs.RegisterLocalMemberApiResponse;
 import matchuri.backend.api.member.dto.docs.UpdateMemberPasswordApiResponse;
 import matchuri.backend.api.member.dto.request.CreateMemberRequest;
 import matchuri.backend.api.member.dto.request.RegisterLocalMemberRequest;
+import matchuri.backend.api.member.dto.request.PutMemberLocationRequest;
 import matchuri.backend.api.member.dto.request.UpdateMemberBasicInfoRequest;
 import matchuri.backend.api.member.dto.request.UpdateMemberPasswordRequest;
 import matchuri.backend.api.member.dto.request.UpdateMemberTasteProfileRequest;
 import matchuri.backend.api.member.dto.response.CreateMemberResponse;
 import matchuri.backend.api.member.dto.response.LoginIdExistsResponse;
 import matchuri.backend.api.member.dto.response.MemberProfileResponse;
+import matchuri.backend.api.member.dto.response.MemberLocationResponse;
 import matchuri.backend.api.member.dto.response.MemberTasteProfileSummaryResponse;
 import matchuri.backend.api.member.dto.response.MemberTasteProfileUpdateResponse;
 import matchuri.backend.api.member.dto.response.NicknameExistsResponse;
@@ -452,6 +455,153 @@ public interface MemberApi {
             )
     })
     ApiResponse<MemberProfileResponse> getMyProfile();
+
+    @Operation(
+            summary = "내 개인 위치 조회",
+            description = """
+                    현재 로그인한 회원이 저장한 개인 위치를 조회합니다.
+
+                    - `Authorization: Bearer <accessToken>` 헤더가 필요합니다.
+                    - 저장된 위치가 없으면 `MEMBER_LOCATION_NOT_FOUND`를 반환합니다.
+                    - 이 위치를 개인 추천에 자동 적용하는 동작은 현재 범위에 포함되지 않습니다.
+                    """)
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = MemberLocationApiResponse.class),
+                            examples = @ExampleObject(name = "success", value = """
+                                    {
+                                      "success": true,
+                                      "data": {
+                                        "latitude": 37.498095,
+                                        "longitude": 127.027610,
+                                        "radiusMeters": 1000,
+                                        "address": "서울 강남구 테헤란로 123"
+                                      },
+                                      "error": null
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken이 없거나 유효하지 않거나 만료됨",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "tokenMissing", value = ErrorExamples.AUTH_TOKEN_MISSING),
+                            @ExampleObject(name = "tokenInvalid", value = ErrorExamples.AUTH_TOKEN_INVALID),
+                            @ExampleObject(name = "tokenExpired", value = ErrorExamples.AUTH_TOKEN_EXPIRED)
+                    })
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "필수 온보딩 미완료 또는 비활성 회원",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "requiredAgreement", value = ErrorExamples.MEMBER_AGREEMENT_REQUIRED),
+                            @ExampleObject(name = "nicknameRequired", value = ErrorExamples.MEMBER_NICKNAME_REQUIRED),
+                            @ExampleObject(name = "inactiveMember", value = ErrorExamples.MEMBER_INACTIVE)
+                    })
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "저장된 개인 위치가 없음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(
+                            name = "locationNotFound",
+                            value = """
+                                    {
+                                      "success": false,
+                                      "data": null,
+                                      "error": {
+                                        "status": 404,
+                                        "code": "MEMBER_LOCATION_NOT_FOUND",
+                                        "message": "저장된 개인 위치를 찾을 수 없습니다.",
+                                        "details": []
+                                      }
+                                    }
+                                    """
+                    ))
+            )
+    })
+    ApiResponse<MemberLocationResponse> getMyLocation();
+
+    @Operation(
+            summary = "내 개인 위치 전체 교체 저장",
+            description = """
+                    현재 로그인한 회원의 개인 위치를 전체 교체 방식으로 저장합니다.
+
+                    - 최초 요청은 위치를 생성하고 이후 요청은 같은 회원의 위치를 교체합니다.
+                    - `latitude`, `longitude`, `radiusMeters`, `address`는 모두 필수입니다.
+                    - `address`의 앞뒤 공백은 제거해 저장합니다.
+                    - 저장과 수정 모두 `200 OK`와 최신 위치를 반환합니다.
+                    """)
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "저장 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = MemberLocationApiResponse.class),
+                            examples = @ExampleObject(name = "success", value = """
+                                    {
+                                      "success": true,
+                                      "data": {
+                                        "latitude": 37.498095,
+                                        "longitude": 127.027610,
+                                        "radiusMeters": 1000,
+                                        "address": "서울 강남구 테헤란로 123"
+                                      },
+                                      "error": null
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "필수값 누락 또는 위치 값 제약 위반",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(
+                            name = "invalidBody",
+                            value = """
+                                    {
+                                      "success": false,
+                                      "data": null,
+                                      "error": {
+                                        "status": 400,
+                                        "code": "COMMON_INVALID_BODY_FIELD",
+                                        "message": "요청 본문 필드가 올바르지 않습니다",
+                                        "details": [
+                                          {
+                                            "source": "BODY",
+                                            "field": "latitude",
+                                            "reason": "latitude는 필수입니다."
+                                          }
+                                        ]
+                                      }
+                                    }
+                                    """
+                    ))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken이 없거나 유효하지 않거나 만료됨",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "tokenMissing", value = ErrorExamples.AUTH_TOKEN_MISSING),
+                            @ExampleObject(name = "tokenInvalid", value = ErrorExamples.AUTH_TOKEN_INVALID),
+                            @ExampleObject(name = "tokenExpired", value = ErrorExamples.AUTH_TOKEN_EXPIRED)
+                    })
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "필수 온보딩 미완료 또는 비활성 회원",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "requiredAgreement", value = ErrorExamples.MEMBER_AGREEMENT_REQUIRED),
+                            @ExampleObject(name = "nicknameRequired", value = ErrorExamples.MEMBER_NICKNAME_REQUIRED),
+                            @ExampleObject(name = "inactiveMember", value = ErrorExamples.MEMBER_INACTIVE)
+                    })
+            )
+    })
+    ApiResponse<MemberLocationResponse> putMyLocation(PutMemberLocationRequest request);
 
     @Operation(
             summary = "내 취향 프로필 조회",

--- a/src/main/java/matchuri/backend/api/member/MemberController.java
+++ b/src/main/java/matchuri/backend/api/member/MemberController.java
@@ -4,11 +4,13 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.api.member.dto.request.CreateMemberRequest;
 import matchuri.backend.api.member.dto.request.RegisterLocalMemberRequest;
+import matchuri.backend.api.member.dto.request.PutMemberLocationRequest;
 import matchuri.backend.api.member.dto.request.UpdateMemberBasicInfoRequest;
 import matchuri.backend.api.member.dto.request.UpdateMemberPasswordRequest;
 import matchuri.backend.api.member.dto.request.UpdateMemberTasteProfileRequest;
 import matchuri.backend.api.member.dto.response.CreateMemberResponse;
 import matchuri.backend.api.member.dto.response.LoginIdExistsResponse;
+import matchuri.backend.api.member.dto.response.MemberLocationResponse;
 import matchuri.backend.api.member.dto.response.MemberProfileResponse;
 import matchuri.backend.api.member.dto.response.MemberTasteProfileSummaryResponse;
 import matchuri.backend.api.member.dto.response.MemberTasteProfileUpdateResponse;
@@ -27,6 +29,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -90,6 +93,23 @@ public class MemberController implements MemberApi {
         MemberProfileResponse response = memberMapper.toMemberProfileResponse(myProfile);
 
         return ApiResponse.success(response);
+    }
+
+    @Override
+    @GetMapping("/me/location")
+    public ApiResponse<MemberLocationResponse> getMyLocation() {
+        var result = memberService.getMyLocation();
+        return ApiResponse.success(memberMapper.toMemberLocationResponse(result));
+    }
+
+    @Override
+    @PutMapping("/me/location")
+    public ApiResponse<MemberLocationResponse> putMyLocation(
+            @Valid @RequestBody PutMemberLocationRequest request
+    ) {
+        var command = memberMapper.toPutMemberLocationCommand(request);
+        var result = memberService.putMyLocation(command);
+        return ApiResponse.success(memberMapper.toMemberLocationResponse(result));
     }
 
     @Override

--- a/src/main/java/matchuri/backend/api/member/dto/docs/MemberLocationApiResponse.java
+++ b/src/main/java/matchuri/backend/api/member/dto/docs/MemberLocationApiResponse.java
@@ -1,0 +1,16 @@
+package matchuri.backend.api.member.dto.docs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import matchuri.backend.api.member.dto.response.MemberLocationResponse;
+import matchuri.backend.global.api.ErrorResponse;
+
+@Schema(description = "내 개인 위치 API의 공통 응답 envelope입니다.")
+public record MemberLocationApiResponse(
+        @Schema(description = "요청 성공 여부입니다.", example = "true")
+        boolean success,
+        @Schema(description = "성공 시 반환되는 개인 위치 payload입니다.")
+        MemberLocationResponse data,
+        @Schema(description = "실패 시 반환되는 에러 정보입니다.")
+        ErrorResponse error
+) {
+}

--- a/src/main/java/matchuri/backend/api/member/dto/request/PutMemberLocationRequest.java
+++ b/src/main/java/matchuri/backend/api/member/dto/request/PutMemberLocationRequest.java
@@ -1,0 +1,36 @@
+package matchuri.backend.api.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+import matchuri.backend.domain.member.entity.MemberLocation;
+
+public record PutMemberLocationRequest(
+        @Schema(description = "개인 추천 기준 위치의 위도입니다.", example = "37.498095", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "latitude는 필수입니다.")
+        @DecimalMin(value = "-90.0", message = "latitude는 -90 이상이어야 합니다.")
+        @DecimalMax(value = "90.0", message = "latitude는 90 이하여야 합니다.")
+        BigDecimal latitude,
+
+        @Schema(description = "개인 추천 기준 위치의 경도입니다.", example = "127.027610", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "longitude는 필수입니다.")
+        @DecimalMin(value = "-180.0", message = "longitude는 -180 이상이어야 합니다.")
+        @DecimalMax(value = "180.0", message = "longitude는 180 이하여야 합니다.")
+        BigDecimal longitude,
+
+        @Schema(description = "개인 추천 기준 위치의 반경 거리(미터)입니다.", example = "1000", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "radiusMeters는 필수입니다.")
+        @Min(value = 0, message = "radiusMeters는 0 이상이어야 합니다.")
+        Integer radiusMeters,
+
+        @Schema(description = "개인 추천 기준 위치의 주소 문자열입니다.", example = "서울 강남구 테헤란로 123", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "address는 비어 있을 수 없습니다.")
+        @Size(max = MemberLocation.ADDRESS_MAX_LENGTH, message = "address는 255자를 초과할 수 없습니다.")
+        String address
+) {
+}

--- a/src/main/java/matchuri/backend/api/member/dto/response/MemberLocationResponse.java
+++ b/src/main/java/matchuri/backend/api/member/dto/response/MemberLocationResponse.java
@@ -1,0 +1,16 @@
+package matchuri.backend.api.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+
+public record MemberLocationResponse(
+        @Schema(description = "개인 추천 기준 위치의 위도입니다.", example = "37.498095")
+        BigDecimal latitude,
+        @Schema(description = "개인 추천 기준 위치의 경도입니다.", example = "127.027610")
+        BigDecimal longitude,
+        @Schema(description = "개인 추천 기준 위치의 반경 거리(미터)입니다.", example = "1000")
+        Integer radiusMeters,
+        @Schema(description = "개인 추천 기준 위치의 주소 문자열입니다.", example = "서울 강남구 테헤란로 123")
+        String address
+) {
+}

--- a/src/main/java/matchuri/backend/api/member/mapper/MemberMapper.java
+++ b/src/main/java/matchuri/backend/api/member/mapper/MemberMapper.java
@@ -4,10 +4,12 @@ import matchuri.backend.api.auth.dto.response.LoginResponse;
 import matchuri.backend.api.auth.dto.response.LogoutResponse;
 import matchuri.backend.api.common.dto.OnboardingStatusResponse;
 import matchuri.backend.api.member.dto.request.RegisterLocalMemberRequest;
+import matchuri.backend.api.member.dto.request.PutMemberLocationRequest;
 import matchuri.backend.api.member.dto.request.UpdateMemberPasswordRequest;
 import matchuri.backend.api.member.dto.request.UpdateMemberTasteProfileRequest;
 import matchuri.backend.api.member.dto.response.CreateMemberResponse;
 import matchuri.backend.api.member.dto.response.LoginIdExistsResponse;
+import matchuri.backend.api.member.dto.response.MemberLocationResponse;
 import matchuri.backend.api.member.dto.response.MemberProfileResponse;
 import matchuri.backend.api.member.dto.response.MemberTasteAttributeCategoryResponse;
 import matchuri.backend.api.member.dto.response.MemberTasteDislikedMenuItemResponse;
@@ -24,6 +26,7 @@ import matchuri.backend.domain.auth.command.OAuth2ExchangeCommand;
 import matchuri.backend.domain.auth.result.LoginPayload;
 import matchuri.backend.domain.auth.result.LogoutResult;
 import matchuri.backend.domain.member.command.CreateMemberCommand;
+import matchuri.backend.domain.member.command.PutMemberLocationCommand;
 import matchuri.backend.domain.member.command.RegisterLocalMemberCommand;
 import matchuri.backend.domain.member.command.SubmitRequiredAgreementsCommand;
 import matchuri.backend.domain.member.command.UpdateMemberBasicInfoCommand;
@@ -31,6 +34,7 @@ import matchuri.backend.domain.member.command.UpdateMemberPasswordCommand;
 import matchuri.backend.domain.member.command.UpdateMemberTasteProfileCommand;
 import matchuri.backend.domain.member.entity.SocialProviderType;
 import matchuri.backend.domain.member.result.CreateMemberResult;
+import matchuri.backend.domain.member.result.MemberLocationResult;
 import matchuri.backend.domain.member.result.MemberProfileResult;
 import matchuri.backend.domain.member.result.MemberTasteProfileSummaryResult;
 import matchuri.backend.domain.member.result.MemberTasteUpdateResult;
@@ -43,6 +47,24 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class MemberMapper {
+
+    public PutMemberLocationCommand toPutMemberLocationCommand(PutMemberLocationRequest request) {
+        return new PutMemberLocationCommand(
+                request.latitude(),
+                request.longitude(),
+                request.radiusMeters(),
+                request.address().trim()
+        );
+    }
+
+    public MemberLocationResponse toMemberLocationResponse(MemberLocationResult result) {
+        return new MemberLocationResponse(
+                result.latitude(),
+                result.longitude(),
+                result.radiusMeters(),
+                result.address()
+        );
+    }
 
     public LoginIdExistsResponse toLoginIdExistsResponse(String loginId, boolean exists) {
         return new LoginIdExistsResponse(loginId, exists);

--- a/src/main/java/matchuri/backend/domain/member/command/PutMemberLocationCommand.java
+++ b/src/main/java/matchuri/backend/domain/member/command/PutMemberLocationCommand.java
@@ -1,0 +1,11 @@
+package matchuri.backend.domain.member.command;
+
+import java.math.BigDecimal;
+
+public record PutMemberLocationCommand(
+        BigDecimal latitude,
+        BigDecimal longitude,
+        Integer radiusMeters,
+        String address
+) {
+}

--- a/src/main/java/matchuri/backend/domain/member/entity/MemberLocation.java
+++ b/src/main/java/matchuri/backend/domain/member/entity/MemberLocation.java
@@ -1,0 +1,70 @@
+package matchuri.backend.domain.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import matchuri.backend.domain.common.BaseEntity;
+
+@Getter
+@Entity
+@Table(
+        name = "member_locations",
+        comment = "회원 개인 위치",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_member_locations_member", columnNames = "member_id")
+        }
+)
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberLocation extends BaseEntity {
+
+    public static final int ADDRESS_MAX_LENGTH = 255;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(comment = "회원 개인 위치 ID")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false, unique = true, comment = "회원 ID")
+    private Member member;
+
+    @Column(nullable = false, precision = 10, scale = 7, comment = "위도")
+    private BigDecimal latitude;
+
+    @Column(nullable = false, precision = 10, scale = 7, comment = "경도")
+    private BigDecimal longitude;
+
+    @Column(name = "radius_meters", nullable = false, comment = "반경 거리(미터)")
+    private Integer radiusMeters;
+
+    @Column(nullable = false, length = ADDRESS_MAX_LENGTH, comment = "주소 문자열")
+    private String address;
+
+    public MemberLocation(Member member, BigDecimal latitude, BigDecimal longitude, Integer radiusMeters,
+                          String address) {
+        this.member = member;
+        update(latitude, longitude, radiusMeters, address);
+    }
+
+    public void update(BigDecimal latitude, BigDecimal longitude, Integer radiusMeters, String address) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.radiusMeters = radiusMeters;
+        this.address = address.trim();
+    }
+}

--- a/src/main/java/matchuri/backend/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/member/exception/MemberErrorCode.java
@@ -27,6 +27,7 @@ public enum MemberErrorCode implements ErrorCode {
             "유효하지 않거나 비활성화된 restriction ingredient ID가 포함되어 있습니다. restrictionIngredientIds : {0}"),
     INVALID_TASTE_DISLIKED_MENU_ITEM(HttpStatus.BAD_REQUEST,
             "유효하지 않거나 비활성화된 disliked menu item ID가 포함되어 있습니다. dislikedMenuItemIds : {0}"),
+    LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, "저장된 개인 위치를 찾을 수 없습니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
     NICKNAME_REQUIRED(HttpStatus.FORBIDDEN, "닉네임 설정이 필요합니다."),
     INACTIVE_MEMBER(HttpStatus.FORBIDDEN, "비활성화된 회원입니다. memberId : {0}");

--- a/src/main/java/matchuri/backend/domain/member/repository/MemberLocationRepository.java
+++ b/src/main/java/matchuri/backend/domain/member/repository/MemberLocationRepository.java
@@ -1,0 +1,10 @@
+package matchuri.backend.domain.member.repository;
+
+import java.util.Optional;
+import matchuri.backend.domain.member.entity.MemberLocation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberLocationRepository extends JpaRepository<MemberLocation, Long> {
+
+    Optional<MemberLocation> findByMemberId(Long memberId);
+}

--- a/src/main/java/matchuri/backend/domain/member/result/MemberLocationResult.java
+++ b/src/main/java/matchuri/backend/domain/member/result/MemberLocationResult.java
@@ -1,0 +1,20 @@
+package matchuri.backend.domain.member.result;
+
+import java.math.BigDecimal;
+import matchuri.backend.domain.member.entity.MemberLocation;
+
+public record MemberLocationResult(
+        BigDecimal latitude,
+        BigDecimal longitude,
+        Integer radiusMeters,
+        String address
+) {
+    public static MemberLocationResult from(MemberLocation location) {
+        return new MemberLocationResult(
+                location.getLatitude(),
+                location.getLongitude(),
+                location.getRadiusMeters(),
+                location.getAddress()
+        );
+    }
+}

--- a/src/main/java/matchuri/backend/domain/member/service/MemberService.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberService.java
@@ -1,12 +1,14 @@
 package matchuri.backend.domain.member.service;
 
 import matchuri.backend.domain.member.command.CreateMemberCommand;
+import matchuri.backend.domain.member.command.PutMemberLocationCommand;
 import matchuri.backend.domain.member.command.RegisterLocalMemberCommand;
 import matchuri.backend.domain.member.command.UpdateMemberBasicInfoCommand;
 import matchuri.backend.domain.member.command.UpdateMemberPasswordCommand;
 import matchuri.backend.domain.member.command.UpdateMemberTasteProfileCommand;
 import matchuri.backend.domain.member.result.CreateMemberResult;
 import matchuri.backend.domain.member.result.MemberProfileResult;
+import matchuri.backend.domain.member.result.MemberLocationResult;
 import matchuri.backend.domain.member.result.MemberTasteProfileSummaryResult;
 import matchuri.backend.domain.member.result.MemberTasteUpdateResult;
 import matchuri.backend.domain.member.result.RegisterLocalMemberResult;
@@ -25,6 +27,10 @@ public interface MemberService {
     CreateMemberResult createMember(CreateMemberCommand command);
 
     MemberProfileResult getMyProfile();
+
+    MemberLocationResult getMyLocation();
+
+    MemberLocationResult putMyLocation(PutMemberLocationCommand command);
 
     MemberTasteProfileSummaryResult getMyTasteProfile();
 

--- a/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
@@ -8,12 +8,14 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.domain.auth.support.verification.EmailVerificationTokenVerifier;
 import matchuri.backend.domain.member.command.CreateMemberCommand;
+import matchuri.backend.domain.member.command.PutMemberLocationCommand;
 import matchuri.backend.domain.member.command.RegisterLocalMemberCommand;
 import matchuri.backend.domain.member.command.UpdateMemberBasicInfoCommand;
 import matchuri.backend.domain.member.command.UpdateMemberPasswordCommand;
 import matchuri.backend.domain.member.command.UpdateMemberTasteProfileCommand;
 import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.entity.MemberAgreement;
+import matchuri.backend.domain.member.entity.MemberLocation;
 import matchuri.backend.domain.member.entity.MemberStatus;
 import matchuri.backend.domain.member.entity.MemberTasteProfile;
 import matchuri.backend.domain.member.entity.MemberTasteProfileCategory;
@@ -21,6 +23,7 @@ import matchuri.backend.domain.member.entity.MemberTasteProfileDislikedMenuItem;
 import matchuri.backend.domain.member.entity.MemberTasteProfileRestrictionIngredient;
 import matchuri.backend.domain.member.exception.MemberErrorCode;
 import matchuri.backend.domain.member.repository.MemberAgreementRepository;
+import matchuri.backend.domain.member.repository.MemberLocationRepository;
 import matchuri.backend.domain.member.repository.MemberRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileCategoryRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileDislikedMenuItemRepository;
@@ -28,6 +31,7 @@ import matchuri.backend.domain.member.repository.MemberTasteProfileRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileRestrictionIngredientRepository;
 import matchuri.backend.domain.member.result.CreateMemberResult;
 import matchuri.backend.domain.member.result.MemberProfileResult;
+import matchuri.backend.domain.member.result.MemberLocationResult;
 import matchuri.backend.domain.member.result.MemberTasteProfileSummaryResult;
 import matchuri.backend.domain.member.result.MemberTasteUpdateResult;
 import matchuri.backend.domain.member.result.RegisterLocalMemberResult;
@@ -58,6 +62,7 @@ public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
     private final MemberAgreementRepository memberAgreementRepository;
+    private final MemberLocationRepository memberLocationRepository;
     private final MemberTasteProfileRepository memberTasteProfileRepository;
     private final MemberTasteProfileCategoryRepository memberTasteProfileCategoryRepository;
     private final MemberTasteProfileRestrictionIngredientRepository memberTasteProfileRestrictionIngredientRepository;
@@ -120,6 +125,36 @@ public class MemberServiceImpl implements MemberService {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
 
         return MemberProfileResult.from(member);
+    }
+
+    @Override
+    public MemberLocationResult getMyLocation() {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        MemberLocation location = memberLocationRepository.findByMemberId(member.getId())
+                .orElseThrow(() -> new BusinessException(MemberErrorCode.LOCATION_NOT_FOUND));
+
+        return MemberLocationResult.from(location);
+    }
+
+    @Override
+    @Transactional
+    public MemberLocationResult putMyLocation(PutMemberLocationCommand command) {
+        Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
+        MemberLocation location = memberLocationRepository.findByMemberId(member.getId()).orElse(null);
+
+        if (location == null) {
+            location = memberLocationRepository.save(new MemberLocation(
+                    member,
+                    command.latitude(),
+                    command.longitude(),
+                    command.radiusMeters(),
+                    command.address()
+            ));
+        } else {
+            location.update(command.latitude(), command.longitude(), command.radiusMeters(), command.address());
+        }
+
+        return MemberLocationResult.from(location);
     }
 
     @Override

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -116,6 +116,7 @@ matchuri:
       allowed-methods:
         - GET
         - POST
+        - PUT
         - PATCH
         - DELETE
         - OPTIONS

--- a/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -40,6 +41,7 @@ import matchuri.backend.domain.member.entity.MemberTasteProfileDislikedMenuItem;
 import matchuri.backend.domain.member.entity.MemberTasteProfileRestrictionIngredient;
 import matchuri.backend.domain.member.entity.SocialProviderType;
 import matchuri.backend.domain.member.repository.MemberAgreementRepository;
+import matchuri.backend.domain.member.repository.MemberLocationRepository;
 import matchuri.backend.domain.member.repository.MemberRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileCategoryRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileDislikedMenuItemRepository;
@@ -54,6 +56,7 @@ import matchuri.backend.domain.menu.repository.IngredientRepository;
 import matchuri.backend.domain.menu.repository.MenuItemRepository;
 import matchuri.backend.global.config.MatchuriProperties;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -107,6 +110,9 @@ class MemberAuthIntegrationTest {
     private MemberAgreementRepository memberAgreementRepository;
 
     @Autowired
+    private MemberLocationRepository memberLocationRepository;
+
+    @Autowired
     private AttributeCategoryRepository attributeCategoryRepository;
 
     @Autowired
@@ -123,6 +129,7 @@ class MemberAuthIntegrationTest {
         emailVerificationRepository.deleteAll();
         authExchangeCodeRepository.deleteAll();
         authRefreshTokenRepository.deleteAll();
+        memberLocationRepository.deleteAll();
         memberAgreementRepository.deleteAll();
         memberTasteProfileCategoryRepository.deleteAll();
         memberTasteProfileRestrictionIngredientRepository.deleteAll();
@@ -132,6 +139,11 @@ class MemberAuthIntegrationTest {
         ingredientRepository.deleteAll();
         menuItemRepository.deleteAll();
         memberRepository.deleteAll();
+    }
+
+    @AfterEach
+    void cleanUpMemberLocations() {
+        memberLocationRepository.deleteAll();
     }
 
     @Test
@@ -193,6 +205,82 @@ class MemberAuthIntegrationTest {
                 .andExpect(jsonPath("$.data.nickname").value("점심탐험가"))
                 .andExpect(jsonPath("$.data.isSocial").value(false))
                 .andExpect(jsonPath("$.data.email").value("signup@example.com"));
+    }
+
+    @Test
+    @DisplayName("내 개인 위치 PUT은 생성과 전체 교체를 처리하고 GET은 최신 위치를 반환한다")
+    void putAndGetMyLocation() throws Exception {
+        String accessToken = createFullyOnboardedMember("location-user");
+
+        mockMvc.perform(put("/api/v1/members/me/location")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "latitude": 37.498095,
+                                  "longitude": 127.027610,
+                                  "radiusMeters": 1000,
+                                  "address": " 서울 강남구 테헤란로 123 "
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.latitude").value(37.498095))
+                .andExpect(jsonPath("$.data.address").value("서울 강남구 테헤란로 123"));
+
+        mockMvc.perform(put("/api/v1/members/me/location")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "latitude": 35.1795543,
+                                  "longitude": 129.0756416,
+                                  "radiusMeters": 2000,
+                                  "address": "부산광역시 중구"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.radiusMeters").value(2000));
+
+        mockMvc.perform(get("/api/v1/members/me/location")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.latitude").value(35.1795543))
+                .andExpect(jsonPath("$.data.longitude").value(129.0756416))
+                .andExpect(jsonPath("$.data.radiusMeters").value(2000))
+                .andExpect(jsonPath("$.data.address").value("부산광역시 중구"));
+
+        assertThat(memberLocationRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("저장된 개인 위치가 없으면 GET은 MEMBER_LOCATION_NOT_FOUND를 반환한다")
+    void getMyLocationReturnsNotFoundWhenMissing() throws Exception {
+        String accessToken = createFullyOnboardedMember("missing-location-user");
+
+        mockMvc.perform(get("/api/v1/members/me/location")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("MEMBER_LOCATION_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("개인 위치 PUT은 필수값과 값 범위를 검증한다")
+    void putMyLocationValidatesRequest() throws Exception {
+        String accessToken = createFullyOnboardedMember("invalid-location-user");
+
+        mockMvc.perform(put("/api/v1/members/me/location")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "latitude": 91,
+                                  "longitude": 127.027610,
+                                  "radiusMeters": -1,
+                                  "address": " "
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("COMMON_INVALID_BODY_FIELD"));
     }
 
     @Test
@@ -1228,6 +1316,24 @@ class MemberAuthIntegrationTest {
                                 }
                                 """.formatted(loginId, password)))
                 .andExpect(status().isOk());
+    }
+
+    private String createFullyOnboardedMember(String loginId) throws Exception {
+        createMemberThroughApi(loginId, "P@ssw0rd!");
+        AuthSession authSession = login(loginId, "P@ssw0rd!");
+        String accessToken = submitRequiredAgreements(authSession.accessToken());
+
+        mockMvc.perform(patch("/api/v1/members/me")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "nickname": "%s"
+                                }
+                                """.formatted(loginId)))
+                .andExpect(status().isOk());
+
+        return accessToken;
     }
 
     private String issueSignupEmailVerificationToken(String email) {

--- a/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
+++ b/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
@@ -9,11 +9,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import matchuri.backend.domain.auth.support.verification.EmailVerificationTokenVerifier;
 import matchuri.backend.domain.member.command.CreateMemberCommand;
+import matchuri.backend.domain.member.command.PutMemberLocationCommand;
 import matchuri.backend.domain.member.command.RegisterLocalMemberCommand;
 import matchuri.backend.domain.member.command.SubmitRequiredAgreementsCommand;
 import matchuri.backend.domain.member.command.UpdateMemberBasicInfoCommand;
@@ -21,6 +23,7 @@ import matchuri.backend.domain.member.command.UpdateMemberTasteProfileCommand;
 import matchuri.backend.domain.member.entity.AgreementType;
 import matchuri.backend.domain.member.entity.Member;
 import matchuri.backend.domain.member.entity.MemberAgreement;
+import matchuri.backend.domain.member.entity.MemberLocation;
 import matchuri.backend.domain.member.entity.MemberRole;
 import matchuri.backend.domain.member.entity.MemberStatus;
 import matchuri.backend.domain.member.entity.MemberTasteProfile;
@@ -29,12 +32,14 @@ import matchuri.backend.domain.member.entity.MemberTasteProfileDislikedMenuItem;
 import matchuri.backend.domain.member.entity.MemberTasteProfileRestrictionIngredient;
 import matchuri.backend.domain.member.exception.MemberErrorCode;
 import matchuri.backend.domain.member.repository.MemberAgreementRepository;
+import matchuri.backend.domain.member.repository.MemberLocationRepository;
 import matchuri.backend.domain.member.repository.MemberRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileCategoryRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileDislikedMenuItemRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileRestrictionIngredientRepository;
 import matchuri.backend.domain.member.result.MemberProfileResult;
+import matchuri.backend.domain.member.result.MemberLocationResult;
 import matchuri.backend.domain.member.result.MemberTasteProfileSummaryResult;
 import matchuri.backend.domain.member.result.MemberTasteUpdateResult;
 import matchuri.backend.domain.member.result.OnboardingNextStep;
@@ -72,6 +77,9 @@ class MemberServiceImplTest {
 
     @Mock
     private MemberAgreementRepository memberAgreementRepository;
+
+    @Mock
+    private MemberLocationRepository memberLocationRepository;
 
     @Mock
     private MemberTasteProfileRepository memberTasteProfileRepository;
@@ -114,6 +122,66 @@ class MemberServiceImplTest {
 
     @InjectMocks
     private MemberServiceImpl memberService;
+
+    @Test
+    @DisplayName("내 개인 위치 최초 PUT은 회원당 위치를 생성한다")
+    void putMyLocationCreatesLocation() {
+        Member member = Member.builder().id(1L).memberRole(MemberRole.MEMBER).status(MemberStatus.ACTIVE).build();
+        PutMemberLocationCommand command = new PutMemberLocationCommand(
+                new BigDecimal("37.4980950"),
+                new BigDecimal("127.0276100"),
+                1000,
+                " 서울 강남구 테헤란로 123 "
+        );
+
+        when(activeMemberReader.getCurrentAuthenticatedActiveMember()).thenReturn(member);
+        when(memberLocationRepository.findByMemberId(1L)).thenReturn(Optional.empty());
+        when(memberLocationRepository.save(any(MemberLocation.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        MemberLocationResult result = memberService.putMyLocation(command);
+
+        assertThat(result.latitude()).isEqualByComparingTo("37.4980950");
+        assertThat(result.longitude()).isEqualByComparingTo("127.0276100");
+        assertThat(result.radiusMeters()).isEqualTo(1000);
+        assertThat(result.address()).isEqualTo("서울 강남구 테헤란로 123");
+        verify(memberLocationRepository).save(any(MemberLocation.class));
+    }
+
+    @Test
+    @DisplayName("내 개인 위치 재 PUT은 기존 위치를 전체 교체한다")
+    void putMyLocationReplacesExistingLocation() {
+        Member member = Member.builder().id(1L).memberRole(MemberRole.MEMBER).status(MemberStatus.ACTIVE).build();
+        MemberLocation location = new MemberLocation(
+                member, new BigDecimal("37.0"), new BigDecimal("127.0"), 500, "기존 주소"
+        );
+        PutMemberLocationCommand command = new PutMemberLocationCommand(
+                new BigDecimal("35.1795543"), new BigDecimal("129.0756416"), 2000, "부산광역시 중구"
+        );
+
+        when(activeMemberReader.getCurrentAuthenticatedActiveMember()).thenReturn(member);
+        when(memberLocationRepository.findByMemberId(1L)).thenReturn(Optional.of(location));
+
+        MemberLocationResult result = memberService.putMyLocation(command);
+
+        assertThat(result.latitude()).isEqualByComparingTo("35.1795543");
+        assertThat(result.longitude()).isEqualByComparingTo("129.0756416");
+        assertThat(result.radiusMeters()).isEqualTo(2000);
+        assertThat(result.address()).isEqualTo("부산광역시 중구");
+    }
+
+    @Test
+    @DisplayName("저장된 개인 위치가 없으면 MEMBER_LOCATION_NOT_FOUND를 반환한다")
+    void getMyLocationRejectsMissingLocation() {
+        Member member = Member.builder().id(1L).memberRole(MemberRole.MEMBER).status(MemberStatus.ACTIVE).build();
+        when(activeMemberReader.getCurrentAuthenticatedActiveMember()).thenReturn(member);
+        when(memberLocationRepository.findByMemberId(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(memberService::getMyLocation)
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(MemberErrorCode.LOCATION_NOT_FOUND);
+    }
 
     @Test
     @DisplayName("자체 회원가입 통합은 회원과 필수 약관을 함께 저장한다")

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -94,6 +94,7 @@ matchuri:
       allowed-methods:
         - GET
         - POST
+        - PUT
         - PATCH
         - DELETE
         - OPTIONS


### PR DESCRIPTION
## 관련 노션 백로그 ID
MC-41

## 📝 작업 내용
- 무엇을 변경했나요?
  - 인증 회원 본인의 개인 위치를 조회하는 `GET /api/v1/members/me/location`을 추가했습니다.
  - 개인 위치를 최초 생성하거나 전체 교체하는 `PUT /api/v1/members/me/location` upsert API를 추가했습니다.
  - `member_locations` 엔티티와 테이블을 추가하고 `member_id` FK+unique로 회원당 최대 1개 위치를 보장했습니다.
  - 위도, 경도, 반경, 주소의 필수값과 범위를 검증하고 주소 앞뒤 공백을 제거해 저장하도록 했습니다.
  - 미등록 조회 시 `MEMBER_LOCATION_NOT_FOUND`를 반환하고 Swagger, CORS PUT 설정, 서비스/통합 테스트를 함께 반영했습니다.
- 왜 이 변경이 필요한가요?
  - 개인 추천 기준으로 사용할 수 있는 회원별 위치를 서버에 지속적으로 저장하고 다시 조회할 수 있어야 하기 때문입니다.
  - 동일 회원의 위치가 중복 생성되지 않고 PUT 재호출 시 예측 가능하게 전체 교체되도록 API와 DB 무결성을 함께 보장하기 위해 필요합니다.

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [x] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분: PUT 최초 생성/재호출의 전체 교체 동작, `member_id` unique 기반 1:0..1 무결성, 미등록 GET 404 및 입력 검증 계약
- 알려진 제한 사항: 위치 삭제 API와 저장 위치의 개인 추천 자동 적용은 이번 범위에서 제외했습니다. API/데이터 문서 변경은 https://github.com/matchuri/matchuri/pull/4 에 분리했습니다.
