### PR TITLE
[Refactor] 위치 정보가 없을 경우 200 + null로 응답 (MC-61)

### DIFF
--- a/src/main/java/matchuri/backend/api/member/MemberApi.java
+++ b/src/main/java/matchuri/backend/api/member/MemberApi.java
@@ -462,7 +462,7 @@ public interface MemberApi {
                     현재 로그인한 회원이 저장한 개인 위치를 조회합니다.
 
                     - `Authorization: Bearer <accessToken>` 헤더가 필요합니다.
-                    - 저장된 위치가 없으면 `MEMBER_LOCATION_NOT_FOUND`를 반환합니다.
+                    - 저장된 위치가 없으면 `200 OK`와 `data: null`을 반환합니다.
                     - 이 위치를 개인 추천에 자동 적용하는 동작은 현재 범위에 포함되지 않습니다.
                     """)
     @ApiResponses({
@@ -472,18 +472,27 @@ public interface MemberApi {
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = MemberLocationApiResponse.class),
-                            examples = @ExampleObject(name = "success", value = """
-                                    {
-                                      "success": true,
-                                      "data": {
-                                        "latitude": 37.498095,
-                                        "longitude": 127.027610,
-                                        "radiusMeters": 1000,
-                                        "address": "서울 강남구 테헤란로 123"
-                                      },
-                                      "error": null
-                                    }
-                                    """)
+                            examples = {
+                                    @ExampleObject(name = "locationExists", value = """
+                                            {
+                                              "success": true,
+                                              "data": {
+                                                "latitude": 37.498095,
+                                                "longitude": 127.027610,
+                                                "radiusMeters": 1000,
+                                                "address": "서울 강남구 테헤란로 123"
+                                              },
+                                              "error": null
+                                            }
+                                            """),
+                                    @ExampleObject(name = "locationNotRegistered", value = """
+                                            {
+                                              "success": true,
+                                              "data": null,
+                                              "error": null
+                                            }
+                                            """)
+                            }
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -503,25 +512,6 @@ public interface MemberApi {
                             @ExampleObject(name = "nicknameRequired", value = ErrorExamples.MEMBER_NICKNAME_REQUIRED),
                             @ExampleObject(name = "inactiveMember", value = ErrorExamples.MEMBER_INACTIVE)
                     })
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "404",
-                    description = "저장된 개인 위치가 없음",
-                    content = @Content(mediaType = "application/json", examples = @ExampleObject(
-                            name = "locationNotFound",
-                            value = """
-                                    {
-                                      "success": false,
-                                      "data": null,
-                                      "error": {
-                                        "status": 404,
-                                        "code": "MEMBER_LOCATION_NOT_FOUND",
-                                        "message": "저장된 개인 위치를 찾을 수 없습니다.",
-                                        "details": []
-                                      }
-                                    }
-                                    """
-                    ))
             )
     })
     ApiResponse<MemberLocationResponse> getMyLocation();

--- a/src/main/java/matchuri/backend/api/member/MemberController.java
+++ b/src/main/java/matchuri/backend/api/member/MemberController.java
@@ -99,7 +99,7 @@ public class MemberController implements MemberApi {
     @GetMapping("/me/location")
     public ApiResponse<MemberLocationResponse> getMyLocation() {
         var result = memberService.getMyLocation();
-        return ApiResponse.success(memberMapper.toMemberLocationResponse(result));
+        return ApiResponse.success(result == null ? null : memberMapper.toMemberLocationResponse(result));
     }
 
     @Override

--- a/src/main/java/matchuri/backend/api/member/dto/docs/MemberLocationApiResponse.java
+++ b/src/main/java/matchuri/backend/api/member/dto/docs/MemberLocationApiResponse.java
@@ -8,7 +8,7 @@ import matchuri.backend.global.api.ErrorResponse;
 public record MemberLocationApiResponse(
         @Schema(description = "요청 성공 여부입니다.", example = "true")
         boolean success,
-        @Schema(description = "성공 시 반환되는 개인 위치 payload입니다.")
+        @Schema(description = "저장된 개인 위치입니다. 위치가 등록되지 않았으면 null입니다.", nullable = true)
         MemberLocationResponse data,
         @Schema(description = "실패 시 반환되는 에러 정보입니다.")
         ErrorResponse error

--- a/src/main/java/matchuri/backend/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/matchuri/backend/domain/member/exception/MemberErrorCode.java
@@ -27,7 +27,6 @@ public enum MemberErrorCode implements ErrorCode {
             "유효하지 않거나 비활성화된 restriction ingredient ID가 포함되어 있습니다. restrictionIngredientIds : {0}"),
     INVALID_TASTE_DISLIKED_MENU_ITEM(HttpStatus.BAD_REQUEST,
             "유효하지 않거나 비활성화된 disliked menu item ID가 포함되어 있습니다. dislikedMenuItemIds : {0}"),
-    LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, "저장된 개인 위치를 찾을 수 없습니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
     NICKNAME_REQUIRED(HttpStatus.FORBIDDEN, "닉네임 설정이 필요합니다."),
     INACTIVE_MEMBER(HttpStatus.FORBIDDEN, "비활성화된 회원입니다. memberId : {0}");

--- a/src/main/java/matchuri/backend/domain/member/service/MemberService.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberService.java
@@ -15,6 +15,7 @@ import matchuri.backend.domain.member.result.RegisterLocalMemberResult;
 import matchuri.backend.domain.member.result.UpdateMemberPasswordResult;
 import matchuri.backend.domain.member.result.UpdateMemberResult;
 import matchuri.backend.domain.member.result.WithdrawMemberResult;
+import org.jspecify.annotations.Nullable;
 
 public interface MemberService {
 
@@ -28,7 +29,7 @@ public interface MemberService {
 
     MemberProfileResult getMyProfile();
 
-    MemberLocationResult getMyLocation();
+    @Nullable MemberLocationResult getMyLocation();
 
     MemberLocationResult putMyLocation(PutMemberLocationCommand command);
 

--- a/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/member/service/MemberServiceImpl.java
@@ -50,6 +50,7 @@ import matchuri.backend.domain.menu.repository.MenuItemRepository;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 import matchuri.backend.domain.recommendation.repository.PersonalRecommendationRepository;
 import matchuri.backend.global.exception.BusinessException;
+import org.jspecify.annotations.Nullable;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -128,12 +129,11 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public MemberLocationResult getMyLocation() {
+    public @Nullable MemberLocationResult getMyLocation() {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
-        MemberLocation location = memberLocationRepository.findByMemberId(member.getId())
-                .orElseThrow(() -> new BusinessException(MemberErrorCode.LOCATION_NOT_FOUND));
+        MemberLocation location = memberLocationRepository.findByMemberId(member.getId()).orElse(null);
 
-        return MemberLocationResult.from(location);
+        return location == null ? null : MemberLocationResult.from(location);
     }
 
     @Override

--- a/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/member/MemberAuthIntegrationTest.java
@@ -253,14 +253,16 @@ class MemberAuthIntegrationTest {
     }
 
     @Test
-    @DisplayName("저장된 개인 위치가 없으면 GET은 MEMBER_LOCATION_NOT_FOUND를 반환한다")
-    void getMyLocationReturnsNotFoundWhenMissing() throws Exception {
+    @DisplayName("저장된 개인 위치가 없으면 GET은 200과 data null을 반환한다")
+    void getMyLocationReturnsNullDataWhenMissing() throws Exception {
         String accessToken = createFullyOnboardedMember("missing-location-user");
 
         mockMvc.perform(get("/api/v1/members/me/location")
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken)))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.error.code").value("MEMBER_LOCATION_NOT_FOUND"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value(nullValue()))
+                .andExpect(jsonPath("$.error").value(nullValue()));
     }
 
     @Test

--- a/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
+++ b/src/test/java/matchuri/backend/domain/member/service/MemberServiceImplTest.java
@@ -171,16 +171,13 @@ class MemberServiceImplTest {
     }
 
     @Test
-    @DisplayName("저장된 개인 위치가 없으면 MEMBER_LOCATION_NOT_FOUND를 반환한다")
-    void getMyLocationRejectsMissingLocation() {
+    @DisplayName("저장된 개인 위치가 없으면 null을 반환한다")
+    void getMyLocationReturnsNullWhenMissing() {
         Member member = Member.builder().id(1L).memberRole(MemberRole.MEMBER).status(MemberStatus.ACTIVE).build();
         when(activeMemberReader.getCurrentAuthenticatedActiveMember()).thenReturn(member);
         when(memberLocationRepository.findByMemberId(1L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(memberService::getMyLocation)
-                .isInstanceOf(BusinessException.class)
-                .extracting("errorCode")
-                .isEqualTo(MemberErrorCode.LOCATION_NOT_FOUND);
+        assertThat(memberService.getMyLocation()).isNull();
     }
 
     @Test


### PR DESCRIPTION
## 관련 노션 백로그 ID
MC-61

## 📝 작업 내용
- 무엇을 변경했나요?
  - 개인 위치 조회 API에서 저장된 위치가 없는 경우 기존 `404 MEMBER_LOCATION_NOT_FOUND` 대신 `200 OK`를 반환하도록 변경했습니다.
  - 미등록 위치 응답을 `success=true`, `data=null`, `error=null` 형태로 통일했습니다.
  - Swagger UI에 위치 등록/미등록 응답 예시를 추가하고 `data`를 nullable로 명시했습니다.
  - 더 이상 사용하지 않는 `MEMBER_LOCATION_NOT_FOUND` 오류 코드를 제거했습니다.
  - 서비스 테스트와 API 통합 테스트를 새로운 응답 계약에 맞게 수정했습니다.
- 왜 이 변경이 필요한가요?
  - 개인 위치 미등록 상태는 잘못된 요청이나 클라이언트 오류가 아니라 정상적인 초기 상태이기 때문입니다.
  - 클라이언트가 예외 처리 없이 `data` 존재 여부로 위치 등록 상태를 판단할 수 있도록 응답 계약을 단순화하기 위해 변경했습니다.

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분: 개인 위치 미등록 시 `200 OK`, `success=true`, `data=null`, `error=null` 응답 계약과 Swagger UI의 nullable 스키마 및 예시가 일치하는지 확인 부탁드립니다.
- 알려진 제한 사항: 개인 위치 PUT API와 DB 구조는 변경하지 않았으며, 프론트엔드 대응 변경은 이번 백엔드 PR 범위에 포함하지 않았습니다.