### PR TITLE
[Refactor] 위치 정보 저장 시점 변경 및 책임 분리 (MC-65)

### DIFF
--- a/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendation.java
+++ b/src/main/java/matchuri/backend/domain/group/entity/GroupRecommendation.java
@@ -92,6 +92,10 @@ public class GroupRecommendation extends BaseEntity {
         this.endedAt = endedAt;
     }
 
+    public void saveContextJson(String contextJson) {
+        this.contextJson = contextJson;
+    }
+
     public void rerollWithSkip(LocalDateTime endedAt) {
         this.status = GroupRecommendationStatus.REROLLED_WITH_SKIP;
         this.endedAt = endedAt;

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -39,6 +39,7 @@ import matchuri.backend.domain.recommendation.algorithm.input.RecommendationCont
 import matchuri.backend.domain.recommendation.algorithm.input.TasteProfileSnapshot;
 import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendationCandidateResult;
 import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendationResult;
+import matchuri.backend.domain.recommendation.context.RecommendationLocationContextJsonFactory;
 import matchuri.backend.domain.realtime.event.GroupDeletedRealtimeEvent;
 import matchuri.backend.domain.realtime.event.GroupInviteCreatedRealtimeEvent;
 import matchuri.backend.domain.realtime.event.GroupMemberJoinedRealtimeEvent;
@@ -88,6 +89,7 @@ public class GroupServiceImpl implements GroupService {
     private final MenuRecommendationAlgorithmResolver menuRecommendationAlgorithmResolver;
     private final GroupInviteCodeGenerator groupInviteCodeGenerator;
     private final GroupRecommendationExpirationService groupRecommendationExpirationService;
+    private final RecommendationLocationContextJsonFactory recommendationLocationContextJsonFactory;
     private final ObjectMapper objectMapper;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -196,7 +198,6 @@ public class GroupServiceImpl implements GroupService {
 
         GroupRecommendation newRecommendation = groupRecommendationRepository.save(new GroupRecommendation(
                 room,
-                contextJson,
                 LocalDateTime.now()
         ));
         updateRoomLocationFromContextJson(room, contextJson);
@@ -255,7 +256,7 @@ public class GroupServiceImpl implements GroupService {
                 recommendationResult,
                 menuItemById
         );
-        recommendation.openWithContextJson(recommendationContextJson);
+        recommendation.open();
 
         return candidates;
     }
@@ -560,6 +561,8 @@ public class GroupServiceImpl implements GroupService {
         GroupRecommendationCandidate selectedCandidate = selectFinalCandidate(candidates, voteCountsByCandidateId);
         LocalDateTime finalizedAt = LocalDateTime.now();
         recommendation.finalizeWith(selectedCandidate, finalizedAt);
+        GroupLocation location = latestGroupLocation(groupId);
+        recommendation.saveContextJson(location == null ? null : toRecommendationContextJson(location));
         GroupRecommendationCandidateResult finalCandidate = GroupRecommendationCandidateResult.from(
                 selectedCandidate,
                 voteCountsByCandidateId.getOrDefault(selectedCandidate.getId(), 0)
@@ -1296,6 +1299,15 @@ public class GroupServiceImpl implements GroupService {
         } catch (JsonProcessingException exception) {
             throw new IllegalStateException("그룹 추천 컨텍스트 정보를 JSON으로 변환할 수 없습니다.", exception);
         }
+    }
+
+    private String toRecommendationContextJson(GroupLocation location) {
+        return recommendationLocationContextJsonFactory.create(
+                location.getLatitude(),
+                location.getLongitude(),
+                location.getRadiusMeters(),
+                location.getAddress()
+        );
     }
 
     private void updateRoomLocationFromContextJson(GroupRoom room, String contextJson) {

--- a/src/main/java/matchuri/backend/domain/recommendation/context/RecommendationLocationContextJsonFactory.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/context/RecommendationLocationContextJsonFactory.java
@@ -1,0 +1,35 @@
+package matchuri.backend.domain.recommendation.context;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RecommendationLocationContextJsonFactory {
+
+    private final ObjectMapper objectMapper;
+
+    public String create(
+            BigDecimal latitude,
+            BigDecimal longitude,
+            Integer radiusMeters,
+            String address
+    ) {
+        Map<String, Object> context = new LinkedHashMap<>();
+        context.put("latitude", latitude);
+        context.put("longitude", longitude);
+        context.put("radiusMeters", radiusMeters);
+        context.put("address", address);
+
+        try {
+            return objectMapper.writeValueAsString(context);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("추천 위치 컨텍스트를 JSON으로 변환할 수 없습니다.", exception);
+        }
+    }
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendation.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/entity/PersonalRecommendation.java
@@ -65,10 +65,10 @@ public class PersonalRecommendation extends BaseEntity {
         this.status = status;
     }
 
-    public static PersonalRecommendation of(Member member, String contextJson) {
+    public static PersonalRecommendation of(Member member) {
         return new PersonalRecommendation(
                 member,
-                contextJson,
+                null,
                 LocalDateTime.now(),
                 PersonalRecommendationStatus.OPEN
         );
@@ -81,6 +81,10 @@ public class PersonalRecommendation extends BaseEntity {
     public void select(PersonalRecommendationCandidate selectedCandidate, LocalDateTime closedAt) {
         this.selectedCandidate = selectedCandidate;
         close(PersonalRecommendationStatus.SELECTED, closedAt);
+    }
+
+    public void saveContextJson(String contextJson) {
+        this.contextJson = contextJson;
     }
 
     public void closeAsRerolledWithSkip(LocalDateTime closedAt) {

--- a/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
@@ -16,7 +16,9 @@ import matchuri.backend.domain.behavior.entity.ActionType;
 import matchuri.backend.domain.behavior.entity.MemberMenuAction;
 import matchuri.backend.domain.behavior.repository.MemberMenuActionRepository;
 import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.entity.MemberLocation;
 import matchuri.backend.domain.member.entity.MemberTasteProfile;
+import matchuri.backend.domain.member.repository.MemberLocationRepository;
 import matchuri.backend.domain.member.support.member.ActiveMemberReader;
 import matchuri.backend.domain.menu.entity.AttributeCategory;
 import matchuri.backend.domain.menu.entity.Ingredient;
@@ -38,6 +40,7 @@ import matchuri.backend.domain.recommendation.algorithm.input.TasteProfileSnapsh
 import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendationCandidateResult;
 import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendationResult;
 import matchuri.backend.domain.recommendation.command.GuestPersonalRecommendationCommand;
+import matchuri.backend.domain.recommendation.context.RecommendationLocationContextJsonFactory;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCandidate;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationRerollType;
@@ -70,6 +73,7 @@ public class RecommendationServiceImpl implements RecommendationService {
 
     private final ActiveMemberReader activeMemberReader;
     private final PersonalRecommendationRepository personalRecommendationRepository;
+    private final MemberLocationRepository memberLocationRepository;
     private final AttributeCategoryRepository attributeCategoryRepository;
     private final IngredientRepository ingredientRepository;
     private final MenuItemRepository menuItemRepository;
@@ -79,6 +83,7 @@ public class RecommendationServiceImpl implements RecommendationService {
     private final MenuRecommendationAlgorithmResolver menuRecommendationAlgorithmResolver;
     private final PersonalRecommendationExpirationService personalRecommendationExpirationService;
     private final MenuThumbnailUrlResolver menuThumbnailUrlResolver;
+    private final RecommendationLocationContextJsonFactory recommendationLocationContextJsonFactory;
     private final ObjectMapper objectMapper;
 
     /**
@@ -168,7 +173,7 @@ public class RecommendationServiceImpl implements RecommendationService {
         );
         MenuRecommendationResult recommendationResult = algorithm.recommend(input);
 
-        PersonalRecommendation personalRecommendation = PersonalRecommendation.of(member, contextJson);
+        PersonalRecommendation personalRecommendation = PersonalRecommendation.of(member);
         PersonalRecommendation savedPersonalRecommendation =
                 personalRecommendationRepository.save(personalRecommendation);
 
@@ -295,9 +300,11 @@ public class RecommendationServiceImpl implements RecommendationService {
                 .orElseThrow(() -> new BusinessException(
                         RecommendationErrorCode.CANDIDATE_NOT_FOUND,
                         selectedCandidateId
-                ));
+        ));
 
         personalRecommendation.select(selectedCandidate, LocalDateTime.now());
+        MemberLocation location = memberLocationRepository.findByMemberId(member.getId()).orElse(null);
+        personalRecommendation.saveContextJson(location == null ? null : toRecommendationContextJson(location));
         memberMenuActionRepository.save(new MemberMenuAction(
                 member,
                 selectedCandidate.getMenuItem(),
@@ -307,6 +314,15 @@ public class RecommendationServiceImpl implements RecommendationService {
         personalRecommendationRepository.flush();
 
         return SelectPersonalRecommendationResult.of(personalRecommendation, selectedCandidate);
+    }
+
+    private String toRecommendationContextJson(MemberLocation location) {
+        return recommendationLocationContextJsonFactory.create(
+                location.getLatitude(),
+                location.getLongitude(),
+                location.getRadiusMeters(),
+                location.getAddress()
+        );
     }
 
     private PersonalRecommendation getOwnedPersonalRecommendation(Long personalRecommendationId, Long memberId) {

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -716,10 +716,7 @@ class GroupIntegrationTest {
         GroupRecommendation openedRecommendation =
                 groupRecommendationRepository.findById(recommendation.getId()).orElseThrow();
         assertThat(openedRecommendation.getStatus()).isEqualTo(GroupRecommendationStatus.OPEN);
-        assertThat(openedRecommendation.getContextJson()).contains("37.498095");
-        assertThat(openedRecommendation.getContextJson()).contains("127.027610");
-        assertThat(openedRecommendation.getContextJson()).contains("1000");
-        assertThat(openedRecommendation.getContextJson()).contains("서울 강남구 테헤란로 123");
+        assertThat(openedRecommendation.getContextJson()).isNull();
         assertThat(groupRecommendationCandidateRepository
                 .findAllByGroupRecommendationIdOrderByRankNoAsc(recommendation.getId()))
                 .hasSize(2);
@@ -1476,6 +1473,7 @@ class GroupIntegrationTest {
         assertThat(finalizedRecommendation.getStatus()).isEqualTo(GroupRecommendationStatus.FINALIZED);
         assertThat(finalizedRecommendation.getSelectedCandidate().getId()).isEqualTo(secondCandidate.getId());
         assertThat(finalizedRecommendation.getEndedAt()).isNotNull();
+        assertThat(finalizedRecommendation.getContextJson()).isNull();
     }
 
     @Test

--- a/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -22,12 +23,14 @@ import javax.crypto.SecretKey;
 import matchuri.backend.domain.behavior.entity.ActionType;
 import matchuri.backend.domain.behavior.repository.MemberMenuActionRepository;
 import matchuri.backend.domain.member.entity.Member;
+import matchuri.backend.domain.member.entity.MemberLocation;
 import matchuri.backend.domain.member.entity.MemberRole;
 import matchuri.backend.domain.member.entity.MemberStatus;
 import matchuri.backend.domain.member.entity.MemberTasteProfile;
 import matchuri.backend.domain.member.entity.MemberTasteProfileCategory;
 import matchuri.backend.domain.member.entity.MemberTasteProfileRestrictionIngredient;
 import matchuri.backend.domain.member.repository.MemberRepository;
+import matchuri.backend.domain.member.repository.MemberLocationRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileCategoryRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileDislikedMenuItemRepository;
 import matchuri.backend.domain.member.repository.MemberTasteProfileRepository;
@@ -83,6 +86,9 @@ class PersonalRecommendationIntegrationTest {
     private MemberRepository memberRepository;
 
     @Autowired
+    private MemberLocationRepository memberLocationRepository;
+
+    @Autowired
     private AttributeCategoryRepository attributeCategoryRepository;
 
     @Autowired
@@ -133,6 +139,7 @@ class PersonalRecommendationIntegrationTest {
         menuItemRepository.deleteAll();
         attributeCategoryRepository.deleteAll();
         ingredientRepository.deleteAll();
+        memberLocationRepository.deleteAll();
         memberRepository.deleteAll();
     }
 
@@ -151,6 +158,13 @@ class PersonalRecommendationIntegrationTest {
         saveMenuAttribute(peanutNoodle, spicy);
         menuIngredientRepository.save(new MenuIngredient(peanutNoodle, peanut));
         saveTasteProfile(member, spicy, peanut);
+        memberLocationRepository.save(new MemberLocation(
+                member,
+                new BigDecimal("37.498095"),
+                new BigDecimal("127.027610"),
+                1000,
+                "서울 강남구 테헤란로 123"
+        ));
 
         MvcResult createResult = mockMvc.perform(post("/api/v1/personal/recommendations")
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
@@ -185,7 +199,7 @@ class PersonalRecommendationIntegrationTest {
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.id").value(requestId))
-                .andExpect(jsonPath("$.data.contextJson.mealTime").value("LUNCH"))
+                .andExpect(jsonPath("$.data.contextJson").isMap())
                 .andExpect(jsonPath("$.data.closedAt").value(nullValue()))
                 .andExpect(jsonPath("$.data.candidates.length()").value(2))
                 .andExpect(jsonPath("$.data.selectedCandidateId").value(nullValue()));
@@ -226,6 +240,10 @@ class PersonalRecommendationIntegrationTest {
                 .orElseThrow();
         assertThat(selectedRecommendation.getStatus()).isEqualTo(PersonalRecommendationStatus.SELECTED);
         assertThat(selectedRecommendation.getClosedAt()).isNotNull();
+        assertThat(selectedRecommendation.getContextJson()).contains("37.498095");
+        assertThat(selectedRecommendation.getContextJson()).contains("127.027610");
+        assertThat(selectedRecommendation.getContextJson()).contains("1000");
+        assertThat(selectedRecommendation.getContextJson()).contains("서울 강남구 테헤란로 123");
 
         mockMvc.perform(get("/api/v1/personal/recommendations/{requestId}", requestId)
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken)))


### PR DESCRIPTION
## 관련 노션 백로그 ID
MC-65

## 📝 작업 내용
- 개인 추천 생성 시에는 `context_json`을 저장하지 않고, 후보 선택 시점의 `MemberLocation`을 스냅샷으로 저장하도록 변경했습니다.
- 그룹 추천은 모든 멤버의 준비 완료로 후보를 생성하고 `OPEN` 전환될 때 `context_json`을 저장하지 않으며, 최종 메뉴 확정 시점의 최신 `GroupLocation`을 저장하도록 변경했습니다.
- 개인·그룹 컨텍스트 JSON 구조를 `latitude`, `longitude`, `radiusMeters`, `address`로 통일했습니다.
- 그룹 위치가 없으면 그룹 추천 최종 확정 후에도 `context_json`은 `null`로 유지합니다.
- 관련 API/데이터 모델 문서와 개인·그룹 추천 통합 테스트를 갱신했습니다.

변경 시점의 위치 정보를 남겨 추천 결과의 최종 선택 맥락을 정확히 추적하기 위해 필요합니다.

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
  - 개인 후보 선택 및 그룹 최종 확정 시점에만 `context_json`이 저장되는 lifecycle
  - 위치가 없는 그룹/기존 컨텍스트 값이 있는 레거시 행도 최종 확정 시 `null`로 정리되는지
- 알려진 제한 사항:
  - 프론트엔드 코드는 변경하지 않았습니다.
  - API 스키마는 변경하지 않았지만, `contextJson`의 저장·노출 시점 의미가 변경되었습니다.