### PR TITLE
[Refactor] 후보 확정시 변경된 반경을 포함하여 위치 정보를 설정 (MC-65)

### DIFF
--- a/src/main/java/matchuri/backend/api/group/GroupApi.java
+++ b/src/main/java/matchuri/backend/api/group/GroupApi.java
@@ -32,6 +32,7 @@ import matchuri.backend.api.group.dto.docs.UpdateGroupApiResponse;
 import matchuri.backend.api.group.dto.request.CreateGroupRecommendationRequest;
 import matchuri.backend.api.group.dto.request.CreateGroupRequest;
 import matchuri.backend.api.group.dto.request.CreateNicknameGroupInviteRequest;
+import matchuri.backend.api.group.dto.request.FinalizeGroupRecommendationRequest;
 import matchuri.backend.api.group.dto.request.JoinGroupRequest;
 import matchuri.backend.api.group.dto.request.RespondGroupInviteRequest;
 import matchuri.backend.api.group.dto.request.RerollGroupRecommendationRequest;
@@ -695,6 +696,7 @@ public interface GroupApi {
                     - 최다 득표 후보를 최종 후보로 저장합니다.
                     - 동률이면 추천 순위 `rankNo`가 가장 낮은 후보를 선택합니다.
                     - 투표가 0건이면 `rankNo=1` 후보를 선택합니다.
+                    - 클라이언트가 전달한 최종 확정 시점 위치를 추천 컨텍스트 스냅샷으로 저장합니다.
                     - 확정 후 그룹 추천 상태는 `FINALIZED`가 됩니다.
                     """
     )
@@ -712,5 +714,9 @@ public interface GroupApi {
                     )
             )
     })
-    ApiResponse<FinalizeGroupRecommendationResponse> finalizeRecommendation(Long groupId, Long sessionId);
+    ApiResponse<FinalizeGroupRecommendationResponse> finalizeRecommendation(
+            Long groupId,
+            Long sessionId,
+            @Valid FinalizeGroupRecommendationRequest request
+    );
 }

--- a/src/main/java/matchuri/backend/api/group/GroupController.java
+++ b/src/main/java/matchuri/backend/api/group/GroupController.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Min;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import matchuri.backend.api.group.dto.request.CreateGroupRecommendationRequest;
+import matchuri.backend.api.group.dto.request.FinalizeGroupRecommendationRequest;
 import matchuri.backend.api.group.dto.request.CreateGroupRequest;
 import matchuri.backend.api.group.dto.request.CreateNicknameGroupInviteRequest;
 import matchuri.backend.api.group.dto.request.JoinGroupRequest;
@@ -35,6 +36,7 @@ import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.CreateGroupRecommendationCommand;
 import matchuri.backend.domain.group.command.CreateNicknameGroupInviteCommand;
 import matchuri.backend.domain.group.command.DeleteGroupCommand;
+import matchuri.backend.domain.group.command.FinalizeGroupRecommendationCommand;
 import matchuri.backend.domain.group.command.GetMyGroupInvitesCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.command.JoinGroupCommand;
@@ -304,10 +306,11 @@ public class GroupController implements GroupApi {
     @PatchMapping("/{groupId}/recommendations/{sessionId}/finalize")
     public ApiResponse<FinalizeGroupRecommendationResponse> finalizeRecommendation(
             @PathVariable Long groupId,
-            @PathVariable Long sessionId
+            @PathVariable Long sessionId,
+            @Valid @RequestBody FinalizeGroupRecommendationRequest request
     ) {
-        FinalizeGroupRecommendationResult result = groupService.finalizeGroupRecommendation(groupId, sessionId);
-
+        FinalizeGroupRecommendationCommand command = groupMapper.toFinalizeGroupRecommendationCommand(groupId, sessionId, request);
+        FinalizeGroupRecommendationResult result = groupService.finalizeGroupRecommendation(command);
         return ApiResponse.success(groupMapper.toFinalizeGroupRecommendationResponse(result));
     }
 }

--- a/src/main/java/matchuri/backend/api/group/GroupMapper.java
+++ b/src/main/java/matchuri/backend/api/group/GroupMapper.java
@@ -3,6 +3,7 @@ package matchuri.backend.api.group;
 import matchuri.backend.api.group.dto.request.CreateGroupRecommendationRequest;
 import matchuri.backend.api.group.dto.request.CreateGroupRequest;
 import matchuri.backend.api.group.dto.request.CreateNicknameGroupInviteRequest;
+import matchuri.backend.api.group.dto.request.FinalizeGroupRecommendationRequest;
 import matchuri.backend.api.group.dto.request.JoinGroupRequest;
 import matchuri.backend.api.group.dto.request.RespondGroupInviteRequest;
 import matchuri.backend.api.group.dto.request.RerollGroupRecommendationRequest;
@@ -35,6 +36,7 @@ import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.CreateGroupRecommendationCommand;
 import matchuri.backend.domain.group.command.CreateNicknameGroupInviteCommand;
 import matchuri.backend.domain.group.command.DeleteGroupCommand;
+import matchuri.backend.domain.group.command.FinalizeGroupRecommendationCommand;
 import matchuri.backend.domain.group.command.GetMyGroupInvitesCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.command.JoinGroupCommand;
@@ -96,6 +98,21 @@ public class GroupMapper {
     ) {
         return new CreateGroupRecommendationCommand(
                 groupId,
+                request.latitude(),
+                request.longitude(),
+                request.radiusMeters(),
+                request.address()
+        );
+    }
+
+    public FinalizeGroupRecommendationCommand toFinalizeGroupRecommendationCommand(
+            Long groupId,
+            Long sessionId,
+            FinalizeGroupRecommendationRequest request
+    ) {
+        return new FinalizeGroupRecommendationCommand(
+                groupId,
+                sessionId,
                 request.latitude(),
                 request.longitude(),
                 request.radiusMeters(),

--- a/src/main/java/matchuri/backend/api/group/dto/request/FinalizeGroupRecommendationRequest.java
+++ b/src/main/java/matchuri/backend/api/group/dto/request/FinalizeGroupRecommendationRequest.java
@@ -1,0 +1,36 @@
+package matchuri.backend.api.group.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+import matchuri.backend.domain.group.entity.GroupLocation;
+
+public record FinalizeGroupRecommendationRequest(
+        @Schema(description = "최종 메뉴 확정 시점 위치의 위도입니다.", example = "37.498095", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "latitude는 필수입니다.")
+        @DecimalMin(value = "-90.0", message = "latitude는 -90 이상이어야 합니다.")
+        @DecimalMax(value = "90.0", message = "latitude는 90 이하여야 합니다.")
+        BigDecimal latitude,
+
+        @Schema(description = "최종 메뉴 확정 시점 위치의 경도입니다.", example = "127.027610", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "longitude는 필수입니다.")
+        @DecimalMin(value = "-180.0", message = "longitude는 -180 이상이어야 합니다.")
+        @DecimalMax(value = "180.0", message = "longitude는 180 이하여야 합니다.")
+        BigDecimal longitude,
+
+        @Schema(description = "최종 메뉴 확정 시점의 검색 반경(미터)입니다.", example = "1000", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "radiusMeters는 필수입니다.")
+        @Min(value = 0, message = "radiusMeters는 0 이상이어야 합니다.")
+        Integer radiusMeters,
+
+        @Schema(description = "최종 메뉴 확정 시점 위치의 주소입니다.", example = "서울 강남구 테헤란로 123", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "address는 비어 있을 수 없습니다.")
+        @Size(max = GroupLocation.ADDRESS_MAX_LENGTH, message = "address는 255자를 초과할 수 없습니다.")
+        String address
+) {
+}

--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationApi.java
@@ -318,6 +318,7 @@ public interface RecommendationApi {
                     개인 추천 후보 중 하나를 최종 선택으로 반영합니다.
 
                     선택된 후보는 개인 추천에 저장되며 `member_menu_actions`에 `CHOOSE` 로그가 함께 기록됩니다.
+                    클라이언트가 전달한 후보 확정 시점 위치를 추천 컨텍스트 스냅샷으로 저장합니다.
                     선택 성공 시 개인 추천은 `status=SELECTED`, `closedAt=선택 시각`으로 종료됩니다.
                     """
     )

--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationController.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationController.java
@@ -16,6 +16,7 @@ import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationRe
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationResponse;
 import matchuri.backend.api.recommendation.dto.response.SelectPersonalRecommendationResponse;
 import matchuri.backend.domain.recommendation.command.GuestPersonalRecommendationCommand;
+import matchuri.backend.domain.recommendation.command.SelectPersonalRecommendationCommand;
 import matchuri.backend.domain.recommendation.result.GuestPersonalRecommendationResult;
 import matchuri.backend.domain.recommendation.result.PersonalRecommendationCandidateResult;
 import matchuri.backend.domain.recommendation.result.PersonalRecommendationResult;
@@ -122,10 +123,8 @@ public class RecommendationController implements RecommendationApi {
             @PathVariable Long requestId,
             @Valid @RequestBody SelectPersonalRecommendationRequest request
     ) {
-        SelectPersonalRecommendationResult result = recommendationService.selectPersonalRecommendationCandidate(
-                requestId,
-                request.selectedCandidateId()
-        );
+        SelectPersonalRecommendationCommand command = recommendationMapper.toSelectCommand(requestId, request);
+        SelectPersonalRecommendationResult result = recommendationService.selectPersonalRecommendationCandidate(command);
 
         return ApiResponse.success(recommendationMapper.toSelectResponse(result));
     }

--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationMapper.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationMapper.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import matchuri.backend.api.recommendation.dto.request.CreateGuestPersonalRecommendationRequest;
 import matchuri.backend.api.recommendation.dto.request.CreatePersonalRecommendationRequest;
 import matchuri.backend.api.recommendation.dto.request.RerollPersonalRecommendationRequest;
+import matchuri.backend.api.recommendation.dto.request.SelectPersonalRecommendationRequest;
 import matchuri.backend.api.recommendation.dto.response.GuestPersonalRecommendationCandidateResponse;
 import matchuri.backend.api.recommendation.dto.response.GuestPersonalRecommendationResponse;
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationCandidateListResponse;
@@ -19,6 +20,7 @@ import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationRe
 import matchuri.backend.api.recommendation.dto.response.PersonalRecommendationResponse;
 import matchuri.backend.api.recommendation.dto.response.SelectPersonalRecommendationResponse;
 import matchuri.backend.domain.recommendation.command.GuestPersonalRecommendationCommand;
+import matchuri.backend.domain.recommendation.command.SelectPersonalRecommendationCommand;
 import matchuri.backend.domain.recommendation.result.GuestPersonalRecommendationCandidateResult;
 import matchuri.backend.domain.recommendation.result.GuestPersonalRecommendationResult;
 import matchuri.backend.domain.recommendation.result.PersonalRecommendationCandidateResult;
@@ -47,6 +49,20 @@ public class RecommendationMapper {
                 request.restrictionIngredientIds(),
                 request.dislikedMenuItemIds(),
                 toContextJson(request.contextJson())
+        );
+    }
+
+    public SelectPersonalRecommendationCommand toSelectCommand(
+            Long personalRecommendationId,
+            SelectPersonalRecommendationRequest request
+    ) {
+        return new SelectPersonalRecommendationCommand(
+                personalRecommendationId,
+                request.selectedCandidateId(),
+                request.latitude(),
+                request.longitude(),
+                request.radiusMeters(),
+                request.address()
         );
     }
 

--- a/src/main/java/matchuri/backend/api/recommendation/dto/request/SelectPersonalRecommendationRequest.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/request/SelectPersonalRecommendationRequest.java
@@ -1,13 +1,42 @@
 package matchuri.backend.api.recommendation.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+import matchuri.backend.domain.member.entity.MemberLocation;
 
 public record SelectPersonalRecommendationRequest(
         @Schema(description = "최종 선택할 개인 추천 후보 ID입니다.", example = "10001")
         @NotNull(message = "selectedCandidateId는 null일 수 없습니다.")
         @Positive(message = "selectedCandidateId는 양수여야 합니다.")
-        Long selectedCandidateId
+        Long selectedCandidateId,
+
+        @Schema(description = "후보 확정 시점 위치의 위도입니다.", example = "37.498095", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "latitude는 필수입니다.")
+        @DecimalMin(value = "-90.0", message = "latitude는 -90 이상이어야 합니다.")
+        @DecimalMax(value = "90.0", message = "latitude는 90 이하여야 합니다.")
+        BigDecimal latitude,
+
+        @Schema(description = "후보 확정 시점 위치의 경도입니다.", example = "127.027610", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "longitude는 필수입니다.")
+        @DecimalMin(value = "-180.0", message = "longitude는 -180 이상이어야 합니다.")
+        @DecimalMax(value = "180.0", message = "longitude는 180 이하여야 합니다.")
+        BigDecimal longitude,
+
+        @Schema(description = "후보 확정 시점의 검색 반경(미터)입니다.", example = "1000", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "radiusMeters는 필수입니다.")
+        @Min(value = 0, message = "radiusMeters는 0 이상이어야 합니다.")
+        Integer radiusMeters,
+
+        @Schema(description = "후보 확정 시점 위치의 주소입니다.", example = "서울 강남구 테헤란로 123", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "address는 비어 있을 수 없습니다.")
+        @Size(max = MemberLocation.ADDRESS_MAX_LENGTH, message = "address는 255자를 초과할 수 없습니다.")
+        String address
 ) {
 }

--- a/src/main/java/matchuri/backend/domain/group/command/FinalizeGroupRecommendationCommand.java
+++ b/src/main/java/matchuri/backend/domain/group/command/FinalizeGroupRecommendationCommand.java
@@ -1,0 +1,13 @@
+package matchuri.backend.domain.group.command;
+
+import java.math.BigDecimal;
+
+public record FinalizeGroupRecommendationCommand(
+        Long groupId,
+        Long sessionId,
+        BigDecimal latitude,
+        BigDecimal longitude,
+        Integer radiusMeters,
+        String address
+) {
+}

--- a/src/main/java/matchuri/backend/domain/group/service/GroupService.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupService.java
@@ -5,6 +5,7 @@ import matchuri.backend.domain.group.command.CreateGroupCommand;
 import matchuri.backend.domain.group.command.CreateGroupRecommendationCommand;
 import matchuri.backend.domain.group.command.CreateNicknameGroupInviteCommand;
 import matchuri.backend.domain.group.command.DeleteGroupCommand;
+import matchuri.backend.domain.group.command.FinalizeGroupRecommendationCommand;
 import matchuri.backend.domain.group.command.GetMyGroupInvitesCommand;
 import matchuri.backend.domain.group.command.GetMyGroupsCommand;
 import matchuri.backend.domain.group.command.JoinGroupCommand;
@@ -38,12 +39,7 @@ public interface GroupService {
 
     CreateGroupRecommendationResult createGroupRecommendation(CreateGroupRecommendationCommand command);
 
-    CreateGroupRecommendationResult rerollGroupRecommendation(
-            Long groupId,
-            Long sessionId,
-            GroupRecommendationRerollType rerollType,
-            String contextJson
-    );
+    CreateGroupRecommendationResult rerollGroupRecommendation(Long groupId, Long sessionId, GroupRecommendationRerollType rerollType, String contextJson);
 
     GroupRecommendationResult getGroupRecommendation(Long groupId, Long sessionId);
 
@@ -57,7 +53,7 @@ public interface GroupService {
 
     GroupVoteResult voteGroupRecommendation(Long groupId, Long sessionId, Long candidateId);
 
-    FinalizeGroupRecommendationResult finalizeGroupRecommendation(Long groupId, Long sessionId);
+    FinalizeGroupRecommendationResult finalizeGroupRecommendation(FinalizeGroupRecommendationCommand command);
 
     CreateNicknameGroupInviteResult createNicknameInvite(CreateNicknameGroupInviteCommand command);
 

--- a/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/group/service/GroupServiceImpl.java
@@ -537,39 +537,44 @@ public class GroupServiceImpl implements GroupService {
 
     @Override
     @Transactional(noRollbackFor = BusinessException.class)
-    public FinalizeGroupRecommendationResult finalizeGroupRecommendation(Long groupId, Long sessionId) {
+    public FinalizeGroupRecommendationResult finalizeGroupRecommendation(FinalizeGroupRecommendationCommand command) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
-        GroupRoomMember membership = validateActiveMembership(groupId, member.getId());
+        GroupRoomMember membership = validateActiveMembership(command.groupId(), member.getId());
 
         if (!membership.isOwner()) {
-            throw new BusinessException(GroupErrorCode.RECOMMENDATION_FINALIZE_FORBIDDEN, groupId);
+            throw new BusinessException(GroupErrorCode.RECOMMENDATION_FINALIZE_FORBIDDEN, command.groupId());
         }
 
-        GroupRecommendation recommendation = groupRecommendationRepository.findByIdAndRoomId(sessionId, groupId)
-                .orElseThrow(() -> new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_FOUND, sessionId));
+        GroupRecommendation recommendation = groupRecommendationRepository
+                .findByIdAndRoomId(command.sessionId(), command.groupId())
+                .orElseThrow(() -> new BusinessException(GroupErrorCode.RECOMMENDATION_NOT_FOUND, command.sessionId()));
 
-        validateGroupRecommendationOpen(recommendation, sessionId);
+        validateGroupRecommendationOpen(recommendation, command.sessionId());
 
         List<GroupRecommendationCandidate> candidates = groupRecommendationCandidateRepository
                 .findAllByGroupRecommendationIdOrderByRankNoAsc(recommendation.getId());
 
         if (candidates.isEmpty()) {
-            throw new BusinessException(GroupErrorCode.RECOMMENDATION_NO_CANDIDATES, sessionId);
+            throw new BusinessException(GroupErrorCode.RECOMMENDATION_NO_CANDIDATES, command.sessionId());
         }
 
         Map<Long, Integer> voteCountsByCandidateId = countVotesByCandidateId(recommendation.getId());
         GroupRecommendationCandidate selectedCandidate = selectFinalCandidate(candidates, voteCountsByCandidateId);
         LocalDateTime finalizedAt = LocalDateTime.now();
         recommendation.finalizeWith(selectedCandidate, finalizedAt);
-        GroupLocation location = latestGroupLocation(groupId);
-        recommendation.saveContextJson(location == null ? null : toRecommendationContextJson(location));
+        recommendation.saveContextJson(recommendationLocationContextJsonFactory.create(
+                command.latitude(),
+                command.longitude(),
+                command.radiusMeters(),
+                command.address()
+        ));
         GroupRecommendationCandidateResult finalCandidate = GroupRecommendationCandidateResult.from(
                 selectedCandidate,
                 voteCountsByCandidateId.getOrDefault(selectedCandidate.getId(), 0)
         );
 
         eventPublisher.publishEvent(new GroupRecommendationFinalizedRealtimeEvent(
-                groupId,
+                command.groupId(),
                 recommendation.getId(),
                 member.getId(),
                 recommendation.getStatus(),
@@ -1299,15 +1304,6 @@ public class GroupServiceImpl implements GroupService {
         } catch (JsonProcessingException exception) {
             throw new IllegalStateException("그룹 추천 컨텍스트 정보를 JSON으로 변환할 수 없습니다.", exception);
         }
-    }
-
-    private String toRecommendationContextJson(GroupLocation location) {
-        return recommendationLocationContextJsonFactory.create(
-                location.getLatitude(),
-                location.getLongitude(),
-                location.getRadiusMeters(),
-                location.getAddress()
-        );
     }
 
     private void updateRoomLocationFromContextJson(GroupRoom room, String contextJson) {

--- a/src/main/java/matchuri/backend/domain/recommendation/command/SelectPersonalRecommendationCommand.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/command/SelectPersonalRecommendationCommand.java
@@ -1,0 +1,13 @@
+package matchuri.backend.domain.recommendation.command;
+
+import java.math.BigDecimal;
+
+public record SelectPersonalRecommendationCommand(
+        Long personalRecommendationId,
+        Long selectedCandidateId,
+        BigDecimal latitude,
+        BigDecimal longitude,
+        Integer radiusMeters,
+        String address
+) {
+}

--- a/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationService.java
@@ -2,6 +2,7 @@ package matchuri.backend.domain.recommendation.service;
 
 import java.util.List;
 import matchuri.backend.domain.recommendation.command.GuestPersonalRecommendationCommand;
+import matchuri.backend.domain.recommendation.command.SelectPersonalRecommendationCommand;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationRerollType;
 import matchuri.backend.domain.recommendation.result.GuestPersonalRecommendationResult;
 import matchuri.backend.domain.recommendation.result.PersonalRecommendationCandidateResult;
@@ -28,8 +29,5 @@ public interface RecommendationService {
 
     Page<@NonNull PersonalRecommendationSummaryResult> getMyPersonalRecommendations(int page, int size);
 
-    SelectPersonalRecommendationResult selectPersonalRecommendationCandidate(
-            Long personalRecommendationId,
-            Long selectedCandidateId
-    );
+    SelectPersonalRecommendationResult selectPersonalRecommendationCandidate(SelectPersonalRecommendationCommand command);
 }

--- a/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
+++ b/src/main/java/matchuri/backend/domain/recommendation/service/RecommendationServiceImpl.java
@@ -2,6 +2,7 @@ package matchuri.backend.domain.recommendation.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -16,9 +17,7 @@ import matchuri.backend.domain.behavior.entity.ActionType;
 import matchuri.backend.domain.behavior.entity.MemberMenuAction;
 import matchuri.backend.domain.behavior.repository.MemberMenuActionRepository;
 import matchuri.backend.domain.member.entity.Member;
-import matchuri.backend.domain.member.entity.MemberLocation;
 import matchuri.backend.domain.member.entity.MemberTasteProfile;
-import matchuri.backend.domain.member.repository.MemberLocationRepository;
 import matchuri.backend.domain.member.support.member.ActiveMemberReader;
 import matchuri.backend.domain.menu.entity.AttributeCategory;
 import matchuri.backend.domain.menu.entity.Ingredient;
@@ -40,6 +39,7 @@ import matchuri.backend.domain.recommendation.algorithm.input.TasteProfileSnapsh
 import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendationCandidateResult;
 import matchuri.backend.domain.recommendation.algorithm.output.MenuRecommendationResult;
 import matchuri.backend.domain.recommendation.command.GuestPersonalRecommendationCommand;
+import matchuri.backend.domain.recommendation.command.SelectPersonalRecommendationCommand;
 import matchuri.backend.domain.recommendation.context.RecommendationLocationContextJsonFactory;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendation;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationCandidate;
@@ -73,7 +73,6 @@ public class RecommendationServiceImpl implements RecommendationService {
 
     private final ActiveMemberReader activeMemberReader;
     private final PersonalRecommendationRepository personalRecommendationRepository;
-    private final MemberLocationRepository memberLocationRepository;
     private final AttributeCategoryRepository attributeCategoryRepository;
     private final IngredientRepository ingredientRepository;
     private final MenuItemRepository menuItemRepository;
@@ -285,26 +284,27 @@ public class RecommendationServiceImpl implements RecommendationService {
 
     @Override
     @Transactional(noRollbackFor = BusinessException.class)
-    public SelectPersonalRecommendationResult selectPersonalRecommendationCandidate(
-            Long personalRecommendationId,
-            Long selectedCandidateId
-    ) {
+    public SelectPersonalRecommendationResult selectPersonalRecommendationCandidate(SelectPersonalRecommendationCommand command) {
         Member member = activeMemberReader.getCurrentAuthenticatedActiveMember();
-        PersonalRecommendation personalRecommendation = getOwnedPersonalRecommendation(personalRecommendationId,
+        PersonalRecommendation personalRecommendation = getOwnedPersonalRecommendation(command.personalRecommendationId(),
                 member.getId());
 
         validatePersonalRecommendationOpen(personalRecommendation, LocalDateTime.now());
 
         PersonalRecommendationCandidate selectedCandidate = personalRecommendationCandidateRepository
-                .findByIdAndPersonalRecommendationId(selectedCandidateId, personalRecommendationId)
+                .findByIdAndPersonalRecommendationId(command.selectedCandidateId(), command.personalRecommendationId())
                 .orElseThrow(() -> new BusinessException(
                         RecommendationErrorCode.CANDIDATE_NOT_FOUND,
-                        selectedCandidateId
-        ));
+                        command.selectedCandidateId()
+                ));
 
         personalRecommendation.select(selectedCandidate, LocalDateTime.now());
-        MemberLocation location = memberLocationRepository.findByMemberId(member.getId()).orElse(null);
-        personalRecommendation.saveContextJson(location == null ? null : toRecommendationContextJson(location));
+        personalRecommendation.saveContextJson(recommendationLocationContextJsonFactory.create(
+                command.latitude(),
+                command.longitude(),
+                command.radiusMeters(),
+                command.address()
+        ));
         memberMenuActionRepository.save(new MemberMenuAction(
                 member,
                 selectedCandidate.getMenuItem(),
@@ -314,15 +314,6 @@ public class RecommendationServiceImpl implements RecommendationService {
         personalRecommendationRepository.flush();
 
         return SelectPersonalRecommendationResult.of(personalRecommendation, selectedCandidate);
-    }
-
-    private String toRecommendationContextJson(MemberLocation location) {
-        return recommendationLocationContextJsonFactory.create(
-                location.getLatitude(),
-                location.getLongitude(),
-                location.getRadiusMeters(),
-                location.getAddress()
-        );
     }
 
     private PersonalRecommendation getOwnedPersonalRecommendation(Long personalRecommendationId, Long memberId) {

--- a/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/group/GroupIntegrationTest.java
@@ -588,7 +588,9 @@ class GroupIntegrationTest {
         mockMvc.perform(get("/api/v1/groups/{groupId}/recommendations/{sessionId}/readiness",
                         groupRoom.getId(),
                         recommendation.getId())
-                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(finalizeLocationRequest()))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_NOT_FOUND"));
     }
@@ -1457,7 +1459,9 @@ class GroupIntegrationTest {
         mockMvc.perform(patch("/api/v1/groups/{groupId}/recommendations/{sessionId}/finalize",
                         groupRoom.getId(),
                         recommendation.getId())
-                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(finalizeLocationRequest()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.sessionId").value(recommendation.getId()))
@@ -1473,7 +1477,10 @@ class GroupIntegrationTest {
         assertThat(finalizedRecommendation.getStatus()).isEqualTo(GroupRecommendationStatus.FINALIZED);
         assertThat(finalizedRecommendation.getSelectedCandidate().getId()).isEqualTo(secondCandidate.getId());
         assertThat(finalizedRecommendation.getEndedAt()).isNotNull();
-        assertThat(finalizedRecommendation.getContextJson()).isNull();
+        assertThat(finalizedRecommendation.getContextJson()).contains("37.498095");
+        assertThat(finalizedRecommendation.getContextJson()).contains("127.027610");
+        assertThat(finalizedRecommendation.getContextJson()).contains("1000");
+        assertThat(finalizedRecommendation.getContextJson()).contains("서울 강남구 테헤란로 123");
     }
 
     @Test
@@ -1507,7 +1514,9 @@ class GroupIntegrationTest {
         mockMvc.perform(patch("/api/v1/groups/{groupId}/recommendations/{sessionId}/finalize",
                         groupRoom.getId(),
                         recommendation.getId())
-                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(finalizeLocationRequest()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.finalCandidate.candidateId").value(firstCandidate.getId()))
                 .andExpect(jsonPath("$.data.finalCandidate.rankNo").value(1))
@@ -1536,7 +1545,9 @@ class GroupIntegrationTest {
         mockMvc.perform(patch("/api/v1/groups/{groupId}/recommendations/{sessionId}/finalize",
                         groupRoom.getId(),
                         recommendation.getId())
-                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(finalizeLocationRequest()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.finalCandidate.candidateId").value(firstCandidate.getId()))
                 .andExpect(jsonPath("$.data.finalCandidate.voteCount").value(0));
@@ -1567,7 +1578,9 @@ class GroupIntegrationTest {
         mockMvc.perform(patch("/api/v1/groups/{groupId}/recommendations/{sessionId}/finalize",
                         groupRoom.getId(),
                         recommendation.getId())
-                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member))))
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(member)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(finalizeLocationRequest()))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_FINALIZE_FORBIDDEN"));
 
@@ -1595,7 +1608,9 @@ class GroupIntegrationTest {
         mockMvc.perform(patch("/api/v1/groups/{groupId}/recommendations/{sessionId}/finalize",
                         groupRoom.getId(),
                         recommendation.getId())
-                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(finalizeLocationRequest()))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_NOT_OPEN"));
     }
@@ -1614,7 +1629,9 @@ class GroupIntegrationTest {
         mockMvc.perform(patch("/api/v1/groups/{groupId}/recommendations/{sessionId}/finalize",
                         groupRoom.getId(),
                         recommendation.getId())
-                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner))))
+                        .header(HttpHeaders.AUTHORIZATION, bearer(accessToken(owner)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(finalizeLocationRequest()))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error.code").value("GROUP_RECOMMENDATION_NO_CANDIDATES"));
 
@@ -3065,6 +3082,17 @@ class GroupIntegrationTest {
 
     private String bearer(String accessToken) {
         return "Bearer " + accessToken;
+    }
+
+    private String finalizeLocationRequest() {
+        return """
+                {
+                  "latitude": 37.498095,
+                  "longitude": 127.027610,
+                  "radiusMeters": 1000,
+                  "address": "서울 강남구 테헤란로 123"
+                }
+                """;
     }
 
     private String accessToken(Member member) {

--- a/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
@@ -222,11 +222,7 @@ class PersonalRecommendationIntegrationTest {
         mockMvc.perform(patch("/api/v1/personal/recommendations/{requestId}", requestId)
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "selectedCandidateId": %d
-                                }
-                                """.formatted(firstCandidateId)))
+                        .content(selectRequest(firstCandidateId)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.id").value(requestId))
                 .andExpect(jsonPath("$.data.status").value(PersonalRecommendationStatus.SELECTED.name()))
@@ -441,11 +437,7 @@ class PersonalRecommendationIntegrationTest {
         mockMvc.perform(patch("/api/v1/personal/recommendations/{requestId}", requestId)
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "selectedCandidateId": %d
-                                }
-                """.formatted(candidateId)))
+                        .content(selectRequest(candidateId)))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error.code").value("PERSONAL_RECOMMENDATION_EXPIRED"));
 
@@ -713,32 +705,20 @@ class PersonalRecommendationIntegrationTest {
         mockMvc.perform(patch("/api/v1/personal/recommendations/{requestId}", requestId)
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "selectedCandidateId": %d
-                                }
-                                """.formatted(candidateId + 10_000)))
+                        .content(selectRequest(candidateId + 10_000)))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.error.code").value("PERSONAL_RECOMMENDATION_CANDIDATE_NOT_FOUND"));
 
         mockMvc.perform(patch("/api/v1/personal/recommendations/{requestId}", requestId)
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "selectedCandidateId": %d
-                                }
-                                """.formatted(candidateId)))
+                        .content(selectRequest(candidateId)))
                 .andExpect(status().isOk());
 
         mockMvc.perform(patch("/api/v1/personal/recommendations/{requestId}", requestId)
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken))
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "selectedCandidateId": %d
-                                }
-                                """.formatted(candidateId)))
+                        .content(selectRequest(candidateId)))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error.code").value("PERSONAL_RECOMMENDATION_ALREADY_CLOSED"));
     }
@@ -800,6 +780,18 @@ class PersonalRecommendationIntegrationTest {
 
     private void saveMenuAttribute(MenuItem menuItem, AttributeCategory attributeCategory) {
         menuAttributeCategoryRepository.save(new MenuAttributeCategory(menuItem, attributeCategory));
+    }
+
+    private String selectRequest(long selectedCandidateId) {
+        return """
+                {
+                  "selectedCandidateId": %d,
+                  "latitude": 37.498095,
+                  "longitude": 127.027610,
+                  "radiusMeters": 1000,
+                  "address": "서울 강남구 테헤란로 123"
+                }
+                """.formatted(selectedCandidateId);
     }
 
     private String bearer(String accessToken) {


### PR DESCRIPTION
## 관련 노션 백로그 ID
MC-65

## 📝 작업 내용
- 개인 추천 후보 선택 및 그룹 추천 최종 확정 API가 클라이언트의 최종 위치 정보(`latitude`, `longitude`, `radiusMeters`, `address`)를 필수로 받도록 변경했습니다.
- 서버의 `MemberLocation`·`GroupLocation`을 조회하거나 갱신하지 않고, 클라이언트가 확정 시점에 전달한 위치만 `context_json`에 스냅샷으로 저장하도록 변경했습니다.
- 개인 선택과 그룹 최종 확정 service 호출에 command 객체를 도입해 과도한 원시 타입 매개변수를 제거했습니다.
- OpenAPI, API 상태표, API/데이터 모델 문서 및 통합 테스트를 갱신했습니다.

클라이언트가 주변 식당 탐색을 위해 단계적으로 확장한 최종 반경을 정확히 저장하고, 추천 확정 흐름의 service 경계를 명확하게 유지하기 위해 필요합니다.

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
  - 최종 확정 요청의 위치 4개 필수값 검증
  - `context_json`이 클라이언트 요청값만 저장하고 기존 위치 저장소를 갱신하지 않는지
  - `RecommendationMapper`·`GroupMapper`의 command 변환과 service 경계