### PR TITLE
[Refactor] 응답시 contextJson string 타입으로 통일 (MC-65)

### DIFF
--- a/src/main/java/matchuri/backend/api/recommendation/RecommendationMapper.java
+++ b/src/main/java/matchuri/backend/api/recommendation/RecommendationMapper.java
@@ -1,8 +1,6 @@
 package matchuri.backend.api.recommendation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Map;
@@ -99,7 +97,7 @@ public class RecommendationMapper {
                 result.id(),
                 result.status(),
                 result.closedAt(),
-                toContextMap(result.contextJson()),
+                result.contextJson(),
                 toCandidateResponses(result.candidates()),
                 result.selectedCandidateId()
         );
@@ -165,21 +163,4 @@ public class RecommendationMapper {
         );
     }
 
-    private Map<String, Object> toContextMap(String contextJson) {
-        if (contextJson == null || contextJson.isBlank()) {
-            return Map.of();
-        }
-
-        try {
-            JsonNode contextNode = objectMapper.readTree(contextJson);
-            while (contextNode.isTextual()) {
-                contextNode = objectMapper.readTree(contextNode.asText());
-            }
-
-            return objectMapper.convertValue(contextNode, new TypeReference<>() {
-            });
-        } catch (JsonProcessingException exception) {
-            throw new IllegalStateException("저장된 contextJson을 해석할 수 없습니다.", exception);
-        }
-    }
 }

--- a/src/main/java/matchuri/backend/api/recommendation/dto/docs/RecommendationApiExamples.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/docs/RecommendationApiExamples.java
@@ -211,11 +211,7 @@ public final class RecommendationApiExamples {
                 "id": 9001,
                 "status": "SELECTED",
                 "closedAt": "2026-05-06T12:15:00",
-                "contextJson": {
-                  "mealTime": "LUNCH",
-                  "budgetLevel": 2,
-                  "mood": "가볍지만 든든한 점심"
-                },
+                "contextJson": "{\\"latitude\\":37.498095,\\"longitude\\":127.027610,\\"radiusMeters\\":1000,\\"address\\":\\"서울 강남구 테헤란로 123\\"}",
                 "candidates": [
                   {
                     "id": 10001,

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationDetailResponse.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationDetailResponse.java
@@ -3,7 +3,6 @@ package matchuri.backend.api.recommendation.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 import matchuri.backend.domain.recommendation.entity.PersonalRecommendationStatus;
 
 public record PersonalRecommendationDetailResponse(
@@ -16,8 +15,12 @@ public record PersonalRecommendationDetailResponse(
         @Schema(description = "추천 종료 시각입니다. 아직 종료되지 않았다면 null입니다.", example = "2026-05-06T12:15:00")
         LocalDateTime closedAt,
 
-        @Schema(description = "요청 컨텍스트 JSON입니다.")
-        Map<String, Object> contextJson,
+        @Schema(
+                description = "추천 당시 위치 등 컨텍스트 JSON 문자열입니다. 클라이언트가 필요 시 파싱합니다.",
+                example = "{\"latitude\":37.498095,\"longitude\":127.027610,\"radiusMeters\":1000,\"address\":\"서울 강남구 테헤란로 123\"}",
+                nullable = true
+        )
+        String contextJson,
 
         @Schema(description = "추천 후보 목록입니다.")
         List<PersonalRecommendationCandidateResponse> candidates,

--- a/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationMocks.java
+++ b/src/main/java/matchuri/backend/api/recommendation/dto/response/PersonalRecommendationMocks.java
@@ -1,7 +1,6 @@
 package matchuri.backend.api.recommendation.dto.response;
 
 import java.util.List;
-import java.util.Map;
 
 final class PersonalRecommendationMocks {
 
@@ -16,11 +15,7 @@ final class PersonalRecommendationMocks {
         );
     }
 
-    static Map<String, Object> contextJson() {
-        return Map.of(
-                "mealTime", "LUNCH",
-                "budgetLevel", 2,
-                "mood", "가볍지만 든든한 점심"
-        );
+    static String contextJson() {
+        return "{\"latitude\":37.498095,\"longitude\":127.027610,\"radiusMeters\":1000,\"address\":\"서울 강남구 테헤란로 123\"}";
     }
 }

--- a/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
+++ b/src/test/java/matchuri/backend/api/recommendation/PersonalRecommendationIntegrationTest.java
@@ -199,7 +199,7 @@ class PersonalRecommendationIntegrationTest {
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.id").value(requestId))
-                .andExpect(jsonPath("$.data.contextJson").isMap())
+                .andExpect(jsonPath("$.data.contextJson").value(nullValue()))
                 .andExpect(jsonPath("$.data.closedAt").value(nullValue()))
                 .andExpect(jsonPath("$.data.candidates.length()").value(2))
                 .andExpect(jsonPath("$.data.selectedCandidateId").value(nullValue()));
@@ -245,6 +245,7 @@ class PersonalRecommendationIntegrationTest {
                         .header(HttpHeaders.AUTHORIZATION, bearer(accessToken)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.status").value(PersonalRecommendationStatus.SELECTED.name()))
+                .andExpect(jsonPath("$.data.contextJson").isString())
                 .andExpect(jsonPath("$.data.closedAt").exists());
     }
 


### PR DESCRIPTION
## 관련 노션 백로그 ID
MC-65

## 📝 작업 내용
- 개인 추천 상세 응답의 `contextJson`을 JSON 객체에서 JSON 문자열로 변경했습니다.
- `RecommendationApiExamples.PERSONAL_RECOMMENDATION_DETAIL_SUCCESS`와 Swagger DTO 설명을 현재 계약에 맞게 갱신했습니다.
- 개인 추천 상세 API 문서와 통합 테스트를 갱신했습니다.
- 개인 추천 생성·재요청 요청의 `contextJson` 입력 형식은 기존 JSON 객체를 유지했습니다.

개인 추천도 그룹 추천과 동일하게 컨텍스트 원문을 문자열로 전달하고, JSON 파싱 책임을 클라이언트에 두기 위해 필요합니다.

## 🚨 주요 변경사항
- [x] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
  - 개인 추천 상세 응답의 `contextJson`이 저장된 JSON 원문 문자열을 그대로 반환하는지
  - 선택 전 `contextJson=null`, 선택 후 JSON 문자열 반환 흐름이 맞는지
  - Swagger 예시와 실제 응답 타입이 일치하는지
- 알려진 제한 사항:
  - 프론트엔드 코드는 변경하지 않았습니다.
  - 프론트엔드에서 `contextJson` 타입을 `string | null`로 변경하고, 필요한 경우 `JSON.parse`로 처리해야 합니다.