### PR TITLE
[Chore] Actuator endpoint 비활성화 설정 (MC-73)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -191,5 +191,13 @@ springdoc:
 
 management:
   endpoints:
+    access:
+      default: none
     web:
+      exposure:
+        include: health
       base-path: /api/v1
+
+  endpoint:
+    health:
+      access: read-only


### PR DESCRIPTION
## 관련 노션 백로그 ID
XX

## 📝 작업 내용
- Spring Boot Actuator endpoint 접근 정책을 최신 권장 방식으로 변경했습니다.
  - 기본 endpoint 접근을 `none`으로 차단했습니다.
  - `health` endpoint만 `read-only`로 명시적으로 허용했습니다.
  - HTTP 노출 대상도 `health`로 제한했습니다.
  - 관리 endpoint 경로를 `/api/v1/health`로 유지했습니다.
- 운영 환경에서 필요한 health check는 제공하면서, `env`, `beans`, `loggers` 등 민감하거나 불필요한 Actuator endpoint가 노출되지 않도록 하기 위해 변경했습니다.

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요? (`./gradlew test`)
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
  - `management.endpoints.access.default: none` 및 `health.access: read-only` 조합이 운영 정책에 적절한지
  - `/api/v1/health` 공개 허용과 Spring Security 설정의 일관성
- 알려진 제한 사항:
  - 현재 health check는 공개 기본 상태 확인용입니다. DB·외부 연동 등의 상세 상태는 외부에 노출하지 않습니다.