### PR TITLE
[Chore] 백엔드 배포 워크플로우 하드코딩 개선 (MC-80)

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -35,28 +35,34 @@ jobs:
       REMOTE_DEPLOY_SCRIPT: ${{ vars.REMOTE_DEPLOY_SCRIPT }}
       REMOTE_ENV_FILE: ${{ vars.REMOTE_ENV_FILE }}
       REMOTE_SERVICE_NAME: ${{ vars.REMOTE_SERVICE_NAME }}
+      REMOTE_HEALTH_URL: ${{ vars.REMOTE_HEALTH_URL }}
+      REMOTE_HEALTH_ATTEMPTS: ${{ vars.REMOTE_HEALTH_ATTEMPTS }}
+      REMOTE_HEALTH_INTERVAL_SECONDS: ${{ vars.REMOTE_HEALTH_INTERVAL_SECONDS }}
+      REMOTE_RELEASE_OWNER: ${{ vars.REMOTE_RELEASE_OWNER }}
+      REMOTE_RELEASE_GROUP: ${{ vars.REMOTE_RELEASE_GROUP }}
+      REMOTE_TMP_ROOT: ${{ vars.REMOTE_TMP_ROOT }}
+      SSM_POLL_ATTEMPTS: ${{ vars.SSM_POLL_ATTEMPTS }}
+      SSM_POLL_INTERVAL_SECONDS: ${{ vars.SSM_POLL_INTERVAL_SECONDS }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
       - name: Validate required variables
-        run: |
-          set -euo pipefail
-          required_vars=(
-            INFISICAL_PROJECT_SLUG
-            INFISICAL_IDENTITY_ID
-            MATCHURI_SPRING_PROFILE
-            AWS_ROLE_TO_ASSUME
-            AWS_SSM_TARGET_INSTANCE_ID
-            DEPLOY_S3_BUCKET
-          )
-
-          for var_name in "${required_vars[@]}"; do
-            if [ -z "${!var_name:-}" ]; then
-              echo "Missing required workflow variable: ${var_name}" >&2
-              exit 1
-            fi
-          done
+        run: >-
+          bash scripts/deploy/validate-required-env.sh "workflow variable"
+          INFISICAL_PROJECT_SLUG
+          INFISICAL_IDENTITY_ID
+          MATCHURI_SPRING_PROFILE
+          AWS_REGION
+          AWS_ROLE_TO_ASSUME
+          AWS_SSM_TARGET_INSTANCE_ID
+          DEPLOY_S3_BUCKET
+          DEPLOY_S3_PREFIX
+          DEPLOY_RELEASE_PREFIX
+          REMOTE_RELEASES_DIR
+          REMOTE_DEPLOY_SCRIPT
+          REMOTE_ENV_FILE
+          REMOTE_SERVICE_NAME
 
       - name: Fetch secrets from Infisical via OIDC
         uses: Infisical/secrets-action@v1.0.16
@@ -68,24 +74,15 @@ jobs:
           domain: ${{ env.INFISICAL_API_URL }}
 
       - name: Validate required secret values
-        run: |
-          set -euo pipefail
-          required_secrets=(
-            MATCHURI_FRONTEND_ORIGIN
-            MATCHURI_DB_PW
-            MATCHURI_JWT_SECRET
-            MATCHURI_GOOGLE_CLIENT_ID
-            MATCHURI_GOOGLE_CLIENT_SECRET
-            MATCHURI_COOKIE_SECURE
-            MATCHURI_COOKIE_SAME_SITE
-          )
-
-          for secret_name in "${required_secrets[@]}"; do
-            if [ -z "${!secret_name:-}" ]; then
-              echo "Missing required secret from Infisical: ${secret_name}" >&2
-              exit 1
-            fi
-          done
+        run: >-
+          bash scripts/deploy/validate-required-env.sh "secret from Infisical"
+          MATCHURI_FRONTEND_ORIGIN
+          MATCHURI_DB_PW
+          MATCHURI_JWT_SECRET
+          MATCHURI_GOOGLE_CLIENT_ID
+          MATCHURI_GOOGLE_CLIENT_SECRET
+          MATCHURI_COOKIE_SECURE
+          MATCHURI_COOKIE_SAME_SITE
 
       - name: Setup JDK 21
         uses: actions/setup-java@v5
@@ -107,27 +104,10 @@ jobs:
         run: ./gradlew --no-daemon clean build
 
       - name: Resolve release metadata
-        run: |
-          set -euo pipefail
-          release_file="${DEPLOY_RELEASE_PREFIX}-${GITHUB_SHA}.jar"
-          echo "RELEASE_FILE=${release_file}" >> "$GITHUB_ENV"
-          echo "JAR_PATH=$(find build/libs -maxdepth 1 -type f -name '*.jar' ! -name '*-plain.jar' | head -n 1)" >> "$GITHUB_ENV"
-
-      - name: Validate build artifact
-        run: |
-          set -euo pipefail
-          if [ -z "${JAR_PATH:-}" ] || [ ! -f "${JAR_PATH}" ]; then
-            echo "Executable boot jar not found under build/libs" >&2
-            exit 1
-          fi
+        run: bash scripts/deploy/resolve-release-metadata.sh
 
       - name: Render backend.env
-        run: |
-          set -euo pipefail
-          {
-            echo "MATCHURI_SPRING_PROFILE=${MATCHURI_SPRING_PROFILE}"
-            printenv | grep '^MATCHURI_' | grep -v '^MATCHURI_SPRING_PROFILE=' | sort
-          } > backend.env
+        run: bash scripts/deploy/render-backend-env.sh backend.env
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -143,101 +123,13 @@ jobs:
           aws s3 cp backend.env "s3://${DEPLOY_S3_BUCKET}/${DEPLOY_S3_PREFIX}/backend.env"
 
       - name: Render SSM command payload
-        run: |
-          set -euo pipefail
-          python - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-          import shlex
-
-          bucket = os.environ["DEPLOY_S3_BUCKET"]
-          prefix = os.environ["DEPLOY_S3_PREFIX"].strip("/")
-          release = os.environ["RELEASE_FILE"]
-          remote_env_file = os.environ["REMOTE_ENV_FILE"]
-          remote_releases_dir = os.environ["REMOTE_RELEASES_DIR"]
-          remote_deploy_script = os.environ["REMOTE_DEPLOY_SCRIPT"]
-          remote_service_name = os.environ["REMOTE_SERVICE_NAME"]
-          tmp_root_ref = "${TMP_ROOT}"
-
-          script_lines = [
-              "set -euo pipefail",
-              'TMP_ROOT="/tmp/matchuri-deploy"',
-              f'RELEASE_FILE="{release}"',
-              'mkdir -p "${TMP_ROOT}"',
-              f'aws s3 cp "s3://{bucket}/{prefix}/{release}" "{tmp_root_ref}/{release}"',
-              f'aws s3 cp "s3://{bucket}/{prefix}/backend.env" "{tmp_root_ref}/backend.env"',
-              f'sudo install -m 600 "{tmp_root_ref}/backend.env" "{remote_env_file}"',
-              f'sudo mv "{tmp_root_ref}/{release}" "{remote_releases_dir}/{release}"',
-              f'sudo chown matchuri:matchuri "{remote_releases_dir}/{release}"',
-              f'sudo MATCHURI_RELEASE_FILE="{release}" "{remote_deploy_script}"',
-              f'sudo systemctl status "{remote_service_name}" --no-pager',
-              "success=0",
-              "for attempt in {1..12}; do",
-              '  if curl --fail --silent --show-error http://127.0.0.1:8080/api/v1/health; then',
-              '    success=1',
-              '    break',
-              '  fi',
-              '  sleep 5',
-              'done',
-              'if [ "${success}" -ne 1 ]; then',
-              '  echo "Matchuri health check failed after deployment." >&2',
-              '  exit 1',
-              'fi',
-          ]
-          script = "\n".join(script_lines)
-          commands = [f"bash -lc {shlex.quote(script)}"]
-
-          Path("ssm-parameters.json").write_text(
-              json.dumps({"commands": commands}),
-              encoding="utf-8",
-          )
-          PY
+        run: python scripts/deploy/render-ssm-parameters.py
 
       - name: Send deploy command
-        run: |
-          set -euo pipefail
-          command_id="$(
-            aws ssm send-command \
-              --instance-ids "${AWS_SSM_TARGET_INSTANCE_ID}" \
-              --document-name "AWS-RunShellScript" \
-              --comment "Matchuri backend deploy ${GITHUB_SHA}" \
-              --parameters file://ssm-parameters.json \
-              --query "Command.CommandId" \
-              --output text
-          )"
-          echo "SSM_COMMAND_ID=${command_id}" >> "$GITHUB_ENV"
+        run: bash scripts/deploy/send-ssm-command.sh
 
       - name: Poll deploy command result
-        run: |
-          set -euo pipefail
-          for attempt in {1..60}; do
-            status="$(
-              aws ssm get-command-invocation \
-                --command-id "${SSM_COMMAND_ID}" \
-                --instance-id "${AWS_SSM_TARGET_INSTANCE_ID}" \
-                --query "Status" \
-                --output text
-            )"
-            echo "Current SSM status: ${status}"
-            if [ "${status}" = "Success" ]; then
-              aws ssm get-command-invocation \
-                --command-id "${SSM_COMMAND_ID}" \
-                --instance-id "${AWS_SSM_TARGET_INSTANCE_ID}" \
-                --query "{Status:Status,StandardOutput:StandardOutputContent,StandardError:StandardErrorContent}"
-              exit 0
-            fi
-            if [ "${status}" = "Failed" ] || [ "${status}" = "Cancelled" ] || [ "${status}" = "TimedOut" ]; then
-              aws ssm get-command-invocation \
-                --command-id "${SSM_COMMAND_ID}" \
-                --instance-id "${AWS_SSM_TARGET_INSTANCE_ID}" \
-                --query "{Status:Status,StandardOutput:StandardOutputContent,StandardError:StandardErrorContent}"
-              exit 1
-            fi
-            sleep 5
-          done
-          echo "SSM command polling timed out." >&2
-          exit 1
+        run: bash scripts/deploy/wait-ssm-command.sh
 
       - name: Delete deploy assets from S3
         if: success()

--- a/scripts/deploy/remote-deploy.sh
+++ b/scripts/deploy/remote-deploy.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${DEPLOY_S3_BUCKET:?DEPLOY_S3_BUCKET is required}"
+: "${DEPLOY_S3_PREFIX:?DEPLOY_S3_PREFIX is required}"
+: "${RELEASE_FILE:?RELEASE_FILE is required}"
+: "${REMOTE_ENV_FILE:?REMOTE_ENV_FILE is required}"
+: "${REMOTE_RELEASES_DIR:?REMOTE_RELEASES_DIR is required}"
+: "${REMOTE_DEPLOY_SCRIPT:?REMOTE_DEPLOY_SCRIPT is required}"
+: "${REMOTE_SERVICE_NAME:?REMOTE_SERVICE_NAME is required}"
+: "${REMOTE_HEALTH_URL:?REMOTE_HEALTH_URL is required}"
+
+remote_health_attempts="${REMOTE_HEALTH_ATTEMPTS:-12}"
+remote_health_interval_seconds="${REMOTE_HEALTH_INTERVAL_SECONDS:-5}"
+remote_release_owner="${REMOTE_RELEASE_OWNER:-matchuri}"
+remote_release_group="${REMOTE_RELEASE_GROUP:-matchuri}"
+remote_tmp_root="${REMOTE_TMP_ROOT:-/tmp/matchuri-deploy}"
+
+if ! [[ "${remote_health_attempts}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "REMOTE_HEALTH_ATTEMPTS must be a positive integer." >&2
+  exit 1
+fi
+if ! [[ "${remote_health_interval_seconds}" =~ ^[0-9]+$ ]]; then
+  echo "REMOTE_HEALTH_INTERVAL_SECONDS must be a non-negative integer." >&2
+  exit 1
+fi
+
+temporary_release="${remote_tmp_root}/${RELEASE_FILE}"
+temporary_env="${remote_tmp_root}/backend.env"
+
+cleanup() {
+  rm -f "${temporary_release}" "${temporary_env}"
+}
+trap cleanup EXIT
+
+mkdir -p "${remote_tmp_root}"
+aws s3 cp \
+  "s3://${DEPLOY_S3_BUCKET}/${DEPLOY_S3_PREFIX}/${RELEASE_FILE}" \
+  "${temporary_release}"
+aws s3 cp \
+  "s3://${DEPLOY_S3_BUCKET}/${DEPLOY_S3_PREFIX}/backend.env" \
+  "${temporary_env}"
+
+sudo install -m 600 "${temporary_env}" "${REMOTE_ENV_FILE}"
+sudo mv "${temporary_release}" "${REMOTE_RELEASES_DIR}/${RELEASE_FILE}"
+sudo chown \
+  "${remote_release_owner}:${remote_release_group}" \
+  "${REMOTE_RELEASES_DIR}/${RELEASE_FILE}"
+sudo MATCHURI_RELEASE_FILE="${RELEASE_FILE}" "${REMOTE_DEPLOY_SCRIPT}"
+sudo systemctl status "${REMOTE_SERVICE_NAME}" --no-pager
+
+for ((attempt = 1; attempt <= remote_health_attempts; attempt++)); do
+  if curl --fail --silent --show-error "${REMOTE_HEALTH_URL}"; then
+    exit 0
+  fi
+
+  echo "Health check attempt ${attempt}/${remote_health_attempts} failed." >&2
+  if [ "${attempt}" -lt "${remote_health_attempts}" ]; then
+    sleep "${remote_health_interval_seconds}"
+  fi
+done
+
+echo "Matchuri health check failed after deployment." >&2
+sudo journalctl -u "${REMOTE_SERVICE_NAME}" -n 100 --no-pager >&2 || true
+exit 1

--- a/scripts/deploy/render-backend-env.sh
+++ b/scripts/deploy/render-backend-env.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${MATCHURI_SPRING_PROFILE:?MATCHURI_SPRING_PROFILE is required}"
+
+output_file="${1:-backend.env}"
+umask 077
+
+{
+  echo "MATCHURI_SPRING_PROFILE=${MATCHURI_SPRING_PROFILE}"
+  printenv |
+    grep '^MATCHURI_' |
+    grep -v '^MATCHURI_SPRING_PROFILE=' |
+    sort
+} > "${output_file}"

--- a/scripts/deploy/render-ssm-parameters.py
+++ b/scripts/deploy/render-ssm-parameters.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+import json
+import os
+from pathlib import Path
+import shlex
+
+
+def required_environment(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value
+
+
+remote_environment = {
+    name: required_environment(name)
+    for name in (
+        "DEPLOY_S3_BUCKET",
+        "DEPLOY_S3_PREFIX",
+        "RELEASE_FILE",
+        "REMOTE_ENV_FILE",
+        "REMOTE_RELEASES_DIR",
+        "REMOTE_DEPLOY_SCRIPT",
+        "REMOTE_SERVICE_NAME",
+    )
+}
+remote_environment["DEPLOY_S3_PREFIX"] = remote_environment[
+    "DEPLOY_S3_PREFIX"
+].strip("/")
+remote_environment.update(
+    {
+        "REMOTE_HEALTH_URL": os.environ.get("REMOTE_HEALTH_URL")
+        or "http://127.0.0.1:8080/api/v1/health",
+        "REMOTE_HEALTH_ATTEMPTS": os.environ.get("REMOTE_HEALTH_ATTEMPTS") or "12",
+        "REMOTE_HEALTH_INTERVAL_SECONDS": os.environ.get(
+            "REMOTE_HEALTH_INTERVAL_SECONDS"
+        )
+        or "5",
+        "REMOTE_RELEASE_OWNER": os.environ.get("REMOTE_RELEASE_OWNER") or "matchuri",
+        "REMOTE_RELEASE_GROUP": os.environ.get("REMOTE_RELEASE_GROUP") or "matchuri",
+        "REMOTE_TMP_ROOT": os.environ.get("REMOTE_TMP_ROOT")
+        or "/tmp/matchuri-deploy",
+    }
+)
+
+remote_script_path = Path(
+    os.environ.get(
+        "REMOTE_DEPLOY_PAYLOAD_SCRIPT",
+        "scripts/deploy/remote-deploy.sh",
+    )
+)
+if not remote_script_path.is_file():
+    raise SystemExit(f"Remote deploy payload script not found: {remote_script_path}")
+
+exports = "\n".join(
+    f"export {name}={shlex.quote(value)}"
+    for name, value in remote_environment.items()
+)
+remote_script = remote_script_path.read_text(encoding="utf-8")
+command_script = f"{exports}\n{remote_script}"
+commands = [f"bash -lc {shlex.quote(command_script)}"]
+
+output_path = Path(os.environ.get("SSM_PARAMETERS_FILE", "ssm-parameters.json"))
+output_path.write_text(
+    json.dumps({"commands": commands}),
+    encoding="utf-8",
+)

--- a/scripts/deploy/resolve-release-metadata.sh
+++ b/scripts/deploy/resolve-release-metadata.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${DEPLOY_RELEASE_PREFIX:?DEPLOY_RELEASE_PREFIX is required}"
+: "${GITHUB_SHA:?GITHUB_SHA is required}"
+: "${GITHUB_ENV:?GITHUB_ENV is required}"
+
+mapfile -d '' executable_jars < <(
+  find build/libs \
+    -maxdepth 1 \
+    -type f \
+    -name '*.jar' \
+    ! -name '*-plain.jar' \
+    -print0
+)
+
+if [ "${#executable_jars[@]}" -ne 1 ]; then
+  echo "Expected exactly one executable boot jar under build/libs, found ${#executable_jars[@]}." >&2
+  printf 'Candidate: %s\n' "${executable_jars[@]}" >&2
+  exit 1
+fi
+
+release_file="${DEPLOY_RELEASE_PREFIX}-${GITHUB_SHA}.jar"
+{
+  echo "RELEASE_FILE=${release_file}"
+  echo "JAR_PATH=${executable_jars[0]}"
+} >> "${GITHUB_ENV}"

--- a/scripts/deploy/send-ssm-command.sh
+++ b/scripts/deploy/send-ssm-command.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${AWS_SSM_TARGET_INSTANCE_ID:?AWS_SSM_TARGET_INSTANCE_ID is required}"
+: "${GITHUB_ENV:?GITHUB_ENV is required}"
+: "${GITHUB_SHA:?GITHUB_SHA is required}"
+
+ssm_parameters_file="${SSM_PARAMETERS_FILE:-ssm-parameters.json}"
+if [ ! -f "${ssm_parameters_file}" ]; then
+  echo "SSM parameters file not found: ${ssm_parameters_file}" >&2
+  exit 1
+fi
+
+command_id="$(
+  aws ssm send-command \
+    --instance-ids "${AWS_SSM_TARGET_INSTANCE_ID}" \
+    --document-name "AWS-RunShellScript" \
+    --comment "Matchuri backend deploy ${GITHUB_SHA}" \
+    --parameters "file://${ssm_parameters_file}" \
+    --query "Command.CommandId" \
+    --output text
+)"
+
+if [ -z "${command_id}" ] || [ "${command_id}" = "None" ]; then
+  echo "AWS SSM did not return a command ID." >&2
+  exit 1
+fi
+
+echo "SSM_COMMAND_ID=${command_id}" >> "${GITHUB_ENV}"

--- a/scripts/deploy/validate-required-env.sh
+++ b/scripts/deploy/validate-required-env.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "Usage: $0 <value-kind> <environment-variable>..." >&2
+  exit 2
+fi
+
+value_kind="$1"
+shift
+
+missing_variables=()
+for variable_name in "$@"; do
+  if [ -z "${!variable_name:-}" ]; then
+    missing_variables+=("${variable_name}")
+  fi
+done
+
+if [ "${#missing_variables[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+for variable_name in "${missing_variables[@]}"; do
+  echo "Missing required ${value_kind}: ${variable_name}" >&2
+done
+exit 1

--- a/scripts/deploy/wait-ssm-command.sh
+++ b/scripts/deploy/wait-ssm-command.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${SSM_COMMAND_ID:?SSM_COMMAND_ID is required}"
+: "${AWS_SSM_TARGET_INSTANCE_ID:?AWS_SSM_TARGET_INSTANCE_ID is required}"
+
+poll_attempts="${SSM_POLL_ATTEMPTS:-60}"
+poll_interval_seconds="${SSM_POLL_INTERVAL_SECONDS:-5}"
+
+if ! [[ "${poll_attempts}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "SSM_POLL_ATTEMPTS must be a positive integer." >&2
+  exit 1
+fi
+if ! [[ "${poll_interval_seconds}" =~ ^[0-9]+$ ]]; then
+  echo "SSM_POLL_INTERVAL_SECONDS must be a non-negative integer." >&2
+  exit 1
+fi
+
+print_command_result() {
+  aws ssm get-command-invocation \
+    --command-id "${SSM_COMMAND_ID}" \
+    --instance-id "${AWS_SSM_TARGET_INSTANCE_ID}" \
+    --query "{Status:Status,StandardOutput:StandardOutputContent,StandardError:StandardErrorContent}"
+}
+
+for ((attempt = 1; attempt <= poll_attempts; attempt++)); do
+  status="$(
+    aws ssm get-command-invocation \
+      --command-id "${SSM_COMMAND_ID}" \
+      --instance-id "${AWS_SSM_TARGET_INSTANCE_ID}" \
+      --query "Status" \
+      --output text
+  )"
+  echo "Current SSM status: ${status}"
+
+  case "${status}" in
+    Success)
+      print_command_result
+      exit 0
+      ;;
+    Failed | Cancelled | TimedOut)
+      print_command_result
+      exit 1
+      ;;
+  esac
+
+  if [ "${attempt}" -lt "${poll_attempts}" ]; then
+    sleep "${poll_interval_seconds}"
+  fi
+done
+
+echo "SSM command polling timed out." >&2
+print_command_result || true
+exit 1


### PR DESCRIPTION
## 관련 노션 백로그 ID
MC-80

## 📝 작업 내용

- `backend-cd.yml`에 인라인으로 작성되어 있던 배포 스크립트를 `scripts/deploy/` 아래의 Bash 및 Python 파일로 분리했습니다.
- GitHub Actions에는 빌드, AWS 인증, S3 업로드 등 짧고 선언적인 단계만 남겼습니다.
- 환경 변수 검증, 릴리스 메타데이터 생성, 환경 파일 렌더링, SSM payload 생성, 원격 배포, SSM 실행 및 polling 로직을 각각 분리했습니다.
- 배포 로직을 독립적으로 검증하고 변경 이력을 명확하게 관리하기 위해 리팩토링했습니다.
- health check 실패 시 `journalctl` 로그를 출력하도록 개선해 배포 실패 원인을 확인하기 쉽게 했습니다.

## 🚨 주요 변경사항

- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트

- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항

- 중점적으로 봐주었으면 하는 부분:
  - `backend-cd.yml`과 `scripts/deploy/` 사이의 책임 분리가 적절한지
  - SSM payload에 원격 배포 스크립트를 포함하는 방식과 shell quoting이 안전한지
  - health check 및 SSM polling 기본값과 환경 변수 설정 방식이 적절한지
  - 기존 서버의 `REMOTE_DEPLOY_SCRIPT`와 분리된 `remote-deploy.sh`의 책임 경계가 명확한지
- 알려진 제한 사항:
  - 실제 AWS SSM 및 EC2 staging 배포는 수행하지 않았습니다.
  - 배포 산출물 삭제가 여전히 `if: success()` 조건이어서 배포 실패 시 S3에 `backend.env`가 남을 수 있습니다.
  - DB, API 계약, rollback 방식에는 변경이 없습니다.
  - 로컬 `./gradlew test`, Bash 문법 검사, Python 컴파일 및 SSM payload 생성, YAML 파싱 검증은 통과했습니다.