### PR TITLE
[Chore] 로컬 Prometheus·Grafana 모니터링 환경 구성 (MC-79)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ out/
 ### env
 .env
 .infisical.json
+
+.pyc

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     runtimeOnly("com.mysql:mysql-connector-j")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.7")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.7")
+    runtimeOnly("io.micrometer:micrometer-registry-prometheus")
     developmentOnly("org.springframework.boot:spring-boot-docker-compose")
     testRuntimeOnly("com.h2database:h2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,5 +19,73 @@ services:
       - mysql_data:/var/lib/mysql
       - ./init/sql:/docker-entrypoint-initdb.d
 
+  prometheus:
+    image: prom/prometheus:v3.12.0
+    container_name: matchuri-local-prometheus
+    profiles:
+      - monitoring
+    restart: "no"
+    ports:
+      - "127.0.0.1:9090:9090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=15d"
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    depends_on:
+      - node-exporter
+      - blackbox-exporter
+
+  grafana:
+    image: grafana/grafana:13.1.0
+    container_name: matchuri-local-grafana
+    profiles:
+      - monitoring
+    restart: "no"
+    ports:
+      - "127.0.0.1:3001:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: ${MATCHURI_GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${MATCHURI_GRAFANA_ADMIN_PASSWORD:?MATCHURI_GRAFANA_ADMIN_PASSWORD is required}
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+    depends_on:
+      - prometheus
+
+  node-exporter:
+    image: quay.io/prometheus/node-exporter:v1.11.1
+    container_name: matchuri-local-node-exporter
+    profiles:
+      - monitoring
+    restart: "no"
+    ports:
+      - "127.0.0.1:9100:9100"
+    pid: host
+    command:
+      - "--path.rootfs=/host"
+      - "--collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+|var/lib/containers/storage/.+)($|/)"
+    volumes:
+      - "/:/host:ro"
+
+  blackbox-exporter:
+    image: quay.io/prometheus/blackbox-exporter:v0.28.0
+    container_name: matchuri-local-blackbox-exporter
+    profiles:
+      - monitoring
+    restart: "no"
+    ports:
+      - "127.0.0.1:9115:9115"
+    command:
+      - "--config.file=/etc/blackbox_exporter/config.yml"
+    volumes:
+      - ./monitoring/blackbox/blackbox.yml:/etc/blackbox_exporter/config.yml:ro
+
 volumes:
   mysql_data:
+  prometheus_data:
+  grafana_data:

--- a/monitoring/blackbox/blackbox.yml
+++ b/monitoring/blackbox/blackbox.yml
@@ -1,0 +1,11 @@
+modules:
+  http_matchuri_health:
+    prober: http
+    timeout: 5s
+    http:
+      method: GET
+      preferred_ip_protocol: ip4
+      valid_status_codes:
+        - 200
+      fail_if_body_not_matches_regexp:
+        - '"status"\s*:\s*"UP"'

--- a/monitoring/grafana/provisioning/datasources/prometheus.yaml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: matchuri-prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,44 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets:
+          - prometheus:9090
+
+  - job_name: matchuri-backend
+    metrics_path: /api/v1/prometheus
+    static_configs:
+      - targets:
+          - host.docker.internal:8080
+        labels:
+          environment: local
+
+  - job_name: node-exporter
+    static_configs:
+      - targets:
+          - node-exporter:9100
+        labels:
+          environment: local
+
+  - job_name: matchuri-health
+    metrics_path: /probe
+    params:
+      module:
+        - http_matchuri_health
+    static_configs:
+      - targets:
+          - http://host.docker.internal:8080/api/v1/health
+        labels:
+          environment: local
+    relabel_configs:
+      - source_labels:
+          - __address__
+        target_label: __param_target
+      - source_labels:
+          - __param_target
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter:9115

--- a/src/main/java/matchuri/backend/global/config/LocalMonitoringSecurityConfig.java
+++ b/src/main/java/matchuri/backend/global/config/LocalMonitoringSecurityConfig.java
@@ -1,0 +1,25 @@
+package matchuri.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Profile("local")
+@Configuration
+public class LocalMonitoringSecurityConfig {
+
+    @Bean
+    @Order(0)
+    SecurityFilterChain localMonitoringSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher("/api/v1/prometheus")
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll());
+
+        return http.build();
+    }
+}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -9,3 +9,16 @@ spring:
 logging:
   level:
     org.hibernate.SQL: debug
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus
+  endpoint:
+    prometheus:
+      access: read-only
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true

--- a/src/test/java/matchuri/backend/global/config/LocalMonitoringSecurityConfigTest.java
+++ b/src/test/java/matchuri/backend/global/config/LocalMonitoringSecurityConfigTest.java
@@ -1,0 +1,29 @@
+package matchuri.backend.global.config;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"test", "local"})
+class LocalMonitoringSecurityConfigTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void prometheusEndpointIsAccessibleWithoutAuthenticationInLocalProfile() throws Exception {
+        mockMvc.perform(get("/api/v1/prometheus"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("jvm_")));
+    }
+}


### PR DESCRIPTION
## 관련 노션 백로그 ID
MC-79

## 📝 작업 내용
- Docker Compose의 `monitoring` profile에 Prometheus, Grafana, node-exporter, blackbox-exporter를 추가했습니다.
- Spring Boot local profile에서만 `/api/v1/prometheus` endpoint를 노출하고, 전용 SecurityFilterChain으로 인증 없이 scrape할 수 있게 구성했습니다.
- Prometheus에 backend metrics, health probe, node-exporter 및 Prometheus 자체 scrape target을 설정했습니다.
- Grafana의 Prometheus datasource를 provisioning하고, 관리자 비밀번호가 누락되면 Compose 단계에서 즉시 실패하도록 구성했습니다.
- Windows Docker Desktop에서 node-exporter를 실행할 수 있도록 host root mount의 Linux 전용 `rslave` propagation을 사용하지 않았습니다.
- local profile의 Prometheus endpoint 접근을 검증하는 통합 테스트를 추가했습니다.

로컬에서 운영 모니터링의 수집 경로와 대시보드·알림 전략을 검증할 기반이 필요해 추가했습니다. 모니터링 서비스는 profile과 `restart: "no"`를 사용하므로 DB만 필요한 평상시 개발 흐름에는 자동으로 포함되지 않습니다.

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [x] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [x] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [x] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [x] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분: local profile에서만 Prometheus endpoint가 노출되는지와 monitoring profile이 기존 DB 실행 흐름과 분리됐는지 확인 부탁드립니다.
- 알려진 제한 사항: Docker Desktop의 node-exporter 지표는 Windows host가 아니라 Linux VM 기준입니다. 운영 EC2 배치, Slack contact point, dashboard와 alert rule provisioning은 이번 PR 범위에서 제외했습니다.

검증:
- `./gradlew.bat test`
- `./gradlew.bat test --tests matchuri.backend.global.config.LocalMonitoringSecurityConfigTest`
- `docker compose --profile monitoring config --quiet`
- `promtool check config /etc/prometheus/prometheus.yml`