### PR TITLE
[Chore] dev와 prod profile에서 health,prometheus를 expose (MC-81)

### DIFF
--- a/src/main/java/matchuri/backend/global/config/MonitoringSecurityConfig.java
+++ b/src/main/java/matchuri/backend/global/config/MonitoringSecurityConfig.java
@@ -8,13 +8,13 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 
-@Profile("local")
+@Profile({"local", "dev", "prod"})
 @Configuration
-public class LocalMonitoringSecurityConfig {
+public class MonitoringSecurityConfig {
 
     @Bean
     @Order(0)
-    SecurityFilterChain localMonitoringSecurityFilterChain(HttpSecurity http) throws Exception {
+    SecurityFilterChain monitoringSecurityFilterChain(HttpSecurity http) throws Exception {
         http
                 .securityMatcher("/api/v1/prometheus")
                 .csrf(AbstractHttpConfigurer::disable)

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -9,16 +9,3 @@ spring:
 logging:
   level:
     org.hibernate.SQL: debug
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health,prometheus
-  endpoint:
-    prometheus:
-      access: read-only
-  metrics:
-    distribution:
-      percentiles-histogram:
-        http.server.requests: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -195,9 +195,14 @@ management:
       default: none
     web:
       exposure:
-        include: health
+        include: health,prometheus
       base-path: /api/v1
-
   endpoint:
     health:
       access: read-only
+    prometheus:
+      access: read_only
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,4 +1,6 @@
 server:
+  address: 127.0.0.1
+  port: 8080
   forward-headers-strategy: framework
 
 spring:

--- a/src/test/java/matchuri/backend/global/config/DevMonitoringSecurityConfigTest.java
+++ b/src/test/java/matchuri/backend/global/config/DevMonitoringSecurityConfigTest.java
@@ -6,6 +6,6 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles({"test", "local"})
-class LocalMonitoringSecurityConfigTest extends MonitoringSecurityConfigTestSupport {
+@ActiveProfiles({"test", "dev"})
+class DevMonitoringSecurityConfigTest extends MonitoringSecurityConfigTestSupport {
 }

--- a/src/test/java/matchuri/backend/global/config/MonitoringSecurityConfigTestSupport.java
+++ b/src/test/java/matchuri/backend/global/config/MonitoringSecurityConfigTestSupport.java
@@ -1,0 +1,47 @@
+package matchuri.backend.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.test.web.servlet.MockMvc;
+
+abstract class MonitoringSecurityConfigTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private Environment environment;
+
+    @Test
+    void applicationServerBindsToLoopbackOnly() {
+        assertThat(environment.getProperty("server.address")).isEqualTo("127.0.0.1");
+        assertThat(environment.getProperty("server.port", Integer.class)).isEqualTo(8080);
+    }
+
+    @Test
+    void prometheusEndpointIsAccessibleWithoutAuthentication() throws Exception {
+        mockMvc.perform(get("/api/v1/prometheus"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("jvm_")));
+    }
+
+    @Test
+    void prometheusEndpointDoesNotAcceptWrites() throws Exception {
+        mockMvc.perform(post("/api/v1/prometheus"))
+                .andExpect(status().isMethodNotAllowed());
+    }
+
+    @Test
+    void monitoringSecurityChainDoesNotPermitChildPaths() throws Exception {
+        mockMvc.perform(get("/api/v1/prometheus/extra"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/matchuri/backend/global/config/ProdMonitoringSecurityConfigTest.java
+++ b/src/test/java/matchuri/backend/global/config/ProdMonitoringSecurityConfigTest.java
@@ -6,6 +6,6 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles({"test", "local"})
-class LocalMonitoringSecurityConfigTest extends MonitoringSecurityConfigTestSupport {
+@ActiveProfiles({"test", "prod"})
+class ProdMonitoringSecurityConfigTest extends MonitoringSecurityConfigTestSupport {
 }


### PR DESCRIPTION
## 관련 노션 백로그 ID
MC-81

## 📝 작업 내용

- dev와 prod profile에서 health,prometheus를 expose합니다.
- /api/v1/prometheus는 read-only입니다.
- http.server.requests histogram을 활성화합니다.
- dev와 prod에서 /api/v1/prometheus exact path만 처리하는 `@Order(0)` security chain을 둡니다.
- 이 chain은 Nginx monitoring listener가 외부 인증을 담당한다는 전제에서 endpoint 요청을 허용합니다.
- 공통 public-get-api-patterns에는 metrics path를 추가하지 않습니다.
- public Nginx 443에서는 metrics path를 404로 차단합니다.

## 🚨 주요 변경사항
- [ ] API의 요구사항이 변경됐어요
- [ ] DB 구조가 변경됐어요

## ✅ 필수 체크리스트
- [ ] 로컬 환경에서 정상적으로 빌드 및 테스트를 통과했나요?
- [ ] 불필요한 콘솔 출력(`System.out.println`)이나 디버깅용 주석은 제거했나요?
- [ ] 민감한 정보(비밀번호, API 키 등)가 코드에 하드코딩되어 있지 않은지 확인했나요?
- [ ] 코드 컨벤션(Formatting 등)을 준수했나요?

## 리뷰 참고 사항
- 중점적으로 봐주었으면 하는 부분:
- 알려진 제한 사항:
